### PR TITLE
Add --detail, --context, and --assess options to summary command

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -2813,6 +2813,19 @@ def _display_outputs(conv_dir: Path) -> None:
 @click.option("--refresh", "-r", is_flag=True, help="Force re-analysis (ignore cache)")
 @click.option("--model", "-m", help="LLM model to use for analysis")
 @click.option(
+    "--detail", "-d",
+    type=click.Choice(["brief", "standard", "detailed"]),
+    default="standard",
+    help="Detail level for analysis output (default: standard)",
+)
+@click.option(
+    "--context", "-c",
+    type=click.Choice(["minimal", "default", "full"]),
+    default="minimal",
+    help="Context level for analysis (default: minimal)",
+)
+@click.option("--assess", "-a", is_flag=True, help="Include assessment in analysis")
+@click.option(
     "--format", "-F", "fmt",
     type=click.Choice(["table", "json", "markdown"]),
     default="table",
@@ -2835,6 +2848,9 @@ def summary(
     reverse: bool,
     refresh: bool,
     model: str | None,
+    detail: str,
+    context: str,
+    assess: bool,
     fmt: str,
     no_outputs: bool,
     yes: bool,

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -953,8 +953,47 @@ def list_conversations(
             print(output_text)
 
 
+def _generate_unique_source_names(paths: list[Path]) -> list[str]:
+    """Generate unique source names from directory basenames with collision handling.
+    
+    Args:
+        paths: List of paths to conversation directories
+        
+    Returns:
+        List of unique source names, one for each path
+    """
+    if not paths:
+        return []
+    
+    # Reserved names that shouldn't be used
+    reserved = {"local", "cloud"}
+    
+    # Extract basenames
+    basenames = [path.name for path in paths]
+    
+    # Track name usage and generate unique names
+    name_counts: dict[str, int] = {}
+    unique_names: list[str] = []
+    
+    for basename in basenames:
+        # Sanitize the basename to make it a valid source name
+        name = basename.lower().replace(" ", "_").replace("-", "_")
+        
+        # If it's a reserved name or already used, add a suffix
+        original_name = name
+        counter = 1
+        while name in reserved or name in name_counts:
+            name = f"{original_name}_{counter}"
+            counter += 1
+        
+        name_counts[name] = 1
+        unique_names.append(name)
+    
+    return unique_names
+
+
 def _load_all_conversations(config: Config) -> list[ConversationInfo]:
-    """Load conversations from both local and cloud directories."""
+    """Load conversations from local, cloud, and extra directories."""
     conversations: list[ConversationInfo] = []
 
     # Load local conversations
@@ -964,6 +1003,12 @@ def _load_all_conversations(config: Config) -> list[ConversationInfo]:
     # Load cloud conversations (synced)
     cloud_source = LocalSource(config.synced_conversations_dir, source_name="cloud")
     conversations.extend(cloud_source.list_conversations())
+
+    # Load extra conversation paths
+    extra_source_names = _generate_unique_source_names(config.extra_conversation_paths)
+    for path, source_name in zip(config.extra_conversation_paths, extra_source_names):
+        extra_source = LocalSource(path, source_name=source_name)
+        conversations.extend(extra_source.list_conversations())
 
     return conversations
 
@@ -2878,13 +2923,25 @@ def summary(
             if result:
                 conv_dir, _ = result
                 cached = get_cached_analysis(
-                    conv_dir, context="minimal", detail="brief", assess=False
+                    conv_dir, context=context, detail=detail, assess=assess
                 )
                 if cached is None:
                     uncached_count += 1
             else:
                 # Can't find dir = will fail anyway, count as uncached
                 uncached_count += 1
+    
+    # Warn about non-default settings with large result sets
+    is_non_default = detail != "brief" or context != "minimal" or assess
+    if is_non_default and len(conversations) > 10:
+        console.print(
+            "[yellow]Warning:[/yellow] Using non-default analysis settings with "
+            f"{len(conversations)} conversations will use more LLM tokens."
+        )
+        console.print(
+            "[dim]Consider using default settings (--detail=brief --context=minimal) "
+            "for large batches.[/dim]"
+        )
     
     # Only prompt if we actually need to run LLM on many conversations
     if uncached_count > SUMMARY_CONFIRM_THRESHOLD and not yes:
@@ -2940,9 +2997,9 @@ def summary(
                 analysis_result = analyze_objectives(
                     conv_dir,
                     model=model,
-                    context="minimal",
-                    detail="brief",
-                    assess=False,
+                    context=context,
+                    detail=detail,
+                    assess=assess,
                     force_refresh=refresh,
                 )
                 analysis = analysis_result.analysis

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -3,6 +3,7 @@
 import csv
 import io
 import json
+import logging
 import re
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -17,6 +18,8 @@ from rich.tree import Tree
 
 from ohtv.actions import READ_ACTIONS, WRITE_ACTIONS
 from ohtv.config import Config
+
+log = logging.getLogger("ohtv")
 
 
 # Commands that use LLM and consume tokens
@@ -965,28 +968,17 @@ def _generate_unique_source_names(paths: list[Path]) -> list[str]:
     if not paths:
         return []
     
-    # Reserved names that shouldn't be used
-    reserved = {"local", "cloud"}
-    
-    # Extract basenames
     basenames = [path.name for path in paths]
-    
-    # Track name usage and generate unique names
     name_counts: dict[str, int] = {}
     unique_names: list[str] = []
     
     for basename in basenames:
-        # Sanitize the basename to make it a valid source name
         name = basename.lower().replace(" ", "_").replace("-", "_")
-        
-        # If it's a reserved name or already used, add a suffix
-        original_name = name
-        counter = 1
-        while name in reserved or name in name_counts:
-            name = f"{original_name}_{counter}"
-            counter += 1
-        
-        name_counts[name] = 1
+        if name in name_counts:
+            name_counts[name] += 1
+            name = f"{name}_{name_counts[name]}"
+        else:
+            name_counts[name] = 0
         unique_names.append(name)
     
     return unique_names
@@ -1005,8 +997,16 @@ def _load_all_conversations(config: Config) -> list[ConversationInfo]:
     conversations.extend(cloud_source.list_conversations())
 
     # Load extra conversation paths
+    # Note: Extra paths are assumed to use UTC timestamps (like cloud conversations).
+    # If you're pointing to local CLI conversations, timestamps may display incorrectly.
     extra_source_names = _generate_unique_source_names(config.extra_conversation_paths)
     for path, source_name in zip(config.extra_conversation_paths, extra_source_names):
+        if not path.exists():
+            log.warning("Skipping nonexistent conversation path: %s", path)
+            continue
+        if not path.is_dir():
+            log.warning("Skipping non-directory conversation path: %s", path)
+            continue
         extra_source = LocalSource(path, source_name=source_name)
         conversations.extend(extra_source.list_conversations())
 

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,0 +1,74 @@
+"""Unit tests for CLI helper functions."""
+
+from pathlib import Path
+
+import pytest
+
+from ohtv.cli import _generate_unique_source_names
+
+
+class TestGenerateUniqueSourceNames:
+    def test_empty_list_returns_empty_list(self):
+        assert _generate_unique_source_names([]) == []
+
+    def test_single_path_returns_sanitized_name(self):
+        paths = [Path("/data/my-experiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments"]
+
+    def test_multiple_unique_paths_no_collisions(self):
+        paths = [
+            Path("/data/experiments"),
+            Path("/data/archive"),
+            Path("/data/test-data"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["experiments", "archive", "test_data"]
+
+    def test_collision_adds_numeric_suffix(self):
+        paths = [
+            Path("/data/experiments"),
+            Path("/other/experiments"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["experiments", "experiments_1"]
+
+    def test_multiple_collisions(self):
+        paths = [
+            Path("/a/test"),
+            Path("/b/test"),
+            Path("/c/test"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["test", "test_1", "test_2"]
+
+    def test_spaces_replaced_with_underscores(self):
+        paths = [Path("/data/my experiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments"]
+
+    def test_hyphens_replaced_with_underscores(self):
+        paths = [Path("/data/my-experiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments"]
+
+    def test_case_normalization_to_lowercase(self):
+        paths = [Path("/data/MyExperiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["myexperiments"]
+
+    def test_collision_with_mixed_case_and_separators(self):
+        paths = [
+            Path("/data/My-Experiments"),
+            Path("/other/my experiments"),
+        ]
+        result = _generate_unique_source_names(paths)
+        # Both normalize to "my_experiments", so second gets suffix
+        assert result == ["my_experiments", "my_experiments_1"]
+
+    def test_reserved_names_allowed(self):
+        # As per review suggestion, reserved names like 'local' and 'cloud' 
+        # are now allowed since source_name is just a label
+        paths = [Path("/data/local"), Path("/data/cloud")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["local", "cloud"]

--- a/tests/unit/test_summary_command.py
+++ b/tests/unit/test_summary_command.py
@@ -1,0 +1,85 @@
+"""Unit tests for summary command analysis options."""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main
+
+
+class TestSummaryCommandOptions:
+    """Test summary command CLI options for --detail, --context, and --assess."""
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_basic(self):
+        """Basic mocks to allow command to run."""
+        with patch('ohtv.cli.Config.from_env'), \
+             patch('ohtv.cli._load_all_conversations', return_value=[]):
+            yield
+
+    def test_detail_option_accepts_brief(self, runner, mock_basic):
+        """Test that --detail accepts 'brief' value."""
+        result = runner.invoke(main, ['summary', '--detail', 'brief'])
+        assert result.exit_code == 0
+
+    def test_detail_option_accepts_standard(self, runner, mock_basic):
+        """Test that --detail accepts 'standard' value."""
+        result = runner.invoke(main, ['summary', '--detail', 'standard'])
+        assert result.exit_code == 0
+
+    def test_detail_option_accepts_detailed(self, runner, mock_basic):
+        """Test that --detail accepts 'detailed' value."""
+        result = runner.invoke(main, ['summary', '--detail', 'detailed'])
+        assert result.exit_code == 0
+
+    def test_detail_option_rejects_invalid_value(self, runner, mock_basic):
+        """Test that --detail rejects invalid values."""
+        result = runner.invoke(main, ['summary', '--detail', 'invalid'])
+        assert result.exit_code != 0
+        assert 'invalid' in result.output.lower() or 'choice' in result.output.lower()
+
+    def test_context_option_accepts_minimal(self, runner, mock_basic):
+        """Test that --context accepts 'minimal' value."""
+        result = runner.invoke(main, ['summary', '--context', 'minimal'])
+        assert result.exit_code == 0
+
+    def test_context_option_accepts_default(self, runner, mock_basic):
+        """Test that --context accepts 'default' value."""
+        result = runner.invoke(main, ['summary', '--context', 'default'])
+        assert result.exit_code == 0
+
+    def test_context_option_accepts_full(self, runner, mock_basic):
+        """Test that --context accepts 'full' value."""
+        result = runner.invoke(main, ['summary', '--context', 'full'])
+        assert result.exit_code == 0
+
+    def test_context_option_rejects_invalid_value(self, runner, mock_basic):
+        """Test that --context rejects invalid values."""
+        result = runner.invoke(main, ['summary', '--context', 'invalid'])
+        assert result.exit_code != 0
+        assert 'invalid' in result.output.lower() or 'choice' in result.output.lower()
+
+    def test_assess_option_is_boolean_flag(self, runner, mock_basic):
+        """Test that --assess is a boolean flag."""
+        result = runner.invoke(main, ['summary', '--assess'])
+        assert result.exit_code == 0
+
+    def test_short_options_work(self, runner, mock_basic):
+        """Test that short options -d, -c, -a work."""
+        result = runner.invoke(main, ['summary', '-d', 'standard', '-c', 'full', '-a'])
+        assert result.exit_code == 0
+
+    def test_all_options_combined(self, runner, mock_basic):
+        """Test all three options can be used together."""
+        result = runner.invoke(main, [
+            'summary',
+            '--detail', 'detailed',
+            '--context', 'full',
+            '--assess'
+        ])
+        assert result.exit_code == 0


### PR DESCRIPTION
Implements #6. Adds the same analysis options from the objectives command to the summary command:
- --detail / -d: Output detail level (brief/standard/detailed)
- --context / -c: Context level (minimal/default/full)
- --assess / -a: Include achievement status assessment

This provides consistency between objectives and summary commands, and allows users to balance cost vs detail based on their needs. Includes a warning when using non-default settings with large result sets.