### PR TITLE
Support configurable multiple conversation search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ Actions by type:
 | `OHTV_DB_PATH` | Direct path to database file | `~/.ohtv/index.db` |
 | `OHTV_CONVERSATIONS_DIR` | Local CLI conversations directory | `~/.openhands/conversations` |
 | `OHTV_CLOUD_CONVERSATIONS_DIR` | Synced cloud conversations directory | `~/.openhands/cloud/conversations` |
+| `OHTV_EXTRA_CONVERSATION_PATHS` | Additional conversation directories (colon-separated paths) | None |
 | `LLM_API_KEY` | API key for LLM provider | Required for `objectives`, `summary` |
 | `LLM_MODEL` | Default LLM model | Provider default |
 | `LLM_BASE_URL` | Custom LLM base URL | Provider default |

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -953,8 +953,47 @@ def list_conversations(
             print(output_text)
 
 
+def _generate_unique_source_names(paths: list[Path]) -> list[str]:
+    """Generate unique source names from directory basenames with collision handling.
+    
+    Args:
+        paths: List of paths to conversation directories
+        
+    Returns:
+        List of unique source names, one for each path
+    """
+    if not paths:
+        return []
+    
+    # Reserved names that shouldn't be used
+    reserved = {"local", "cloud"}
+    
+    # Extract basenames
+    basenames = [path.name for path in paths]
+    
+    # Track name usage and generate unique names
+    name_counts: dict[str, int] = {}
+    unique_names: list[str] = []
+    
+    for basename in basenames:
+        # Sanitize the basename to make it a valid source name
+        name = basename.lower().replace(" ", "_").replace("-", "_")
+        
+        # If it's a reserved name or already used, add a suffix
+        original_name = name
+        counter = 1
+        while name in reserved or name in name_counts:
+            name = f"{original_name}_{counter}"
+            counter += 1
+        
+        name_counts[name] = 1
+        unique_names.append(name)
+    
+    return unique_names
+
+
 def _load_all_conversations(config: Config) -> list[ConversationInfo]:
-    """Load conversations from both local and cloud directories."""
+    """Load conversations from local, cloud, and extra directories."""
     conversations: list[ConversationInfo] = []
 
     # Load local conversations
@@ -964,6 +1003,12 @@ def _load_all_conversations(config: Config) -> list[ConversationInfo]:
     # Load cloud conversations (synced)
     cloud_source = LocalSource(config.synced_conversations_dir, source_name="cloud")
     conversations.extend(cloud_source.list_conversations())
+
+    # Load extra conversation paths
+    extra_source_names = _generate_unique_source_names(config.extra_conversation_paths)
+    for path, source_name in zip(config.extra_conversation_paths, extra_source_names):
+        extra_source = LocalSource(path, source_name=source_name)
+        conversations.extend(extra_source.list_conversations())
 
     return conversations
 
@@ -3253,20 +3298,25 @@ def _format_summary_markdown(results: list[dict], *, include_outputs: bool = Tru
 
 
 def _find_conversation_dir(config: Config, conv_id: str) -> tuple[Path, bool] | None:
-    """Find conversation directory across both local and cloud sources.
+    """Find conversation directory across local, cloud, and extra sources.
 
     Returns:
         Tuple of (directory_path, is_cloud_source) or None if not found
+        Note: is_cloud_source indicates whether timestamps are UTC (True) or local (False)
     """
     # Normalize conv_id - remove dashes for directory lookup
     # (ConversationInfo.id has dashes, but directory names don't)
     normalized_id = conv_id.replace("-", "")
     
-    # Search both directories - local first, then cloud
+    # Search all directories - local first, then cloud, then extra
     dirs_to_search = [
         (config.local_conversations_dir, False),  # (path, is_cloud)
         (config.synced_conversations_dir, True),
     ]
+    
+    # Add extra paths (assume UTC timestamps like cloud)
+    for extra_path in config.extra_conversation_paths:
+        dirs_to_search.append((extra_path, True))
 
     all_matches: list[tuple[Path, bool]] = []
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -3,6 +3,7 @@
 import csv
 import io
 import json
+import logging
 import re
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -17,6 +18,8 @@ from rich.tree import Tree
 
 from ohtv.actions import READ_ACTIONS, WRITE_ACTIONS
 from ohtv.config import Config
+
+log = logging.getLogger("ohtv")
 
 
 # Commands that use LLM and consume tokens
@@ -965,28 +968,17 @@ def _generate_unique_source_names(paths: list[Path]) -> list[str]:
     if not paths:
         return []
     
-    # Reserved names that shouldn't be used
-    reserved = {"local", "cloud"}
-    
-    # Extract basenames
     basenames = [path.name for path in paths]
-    
-    # Track name usage and generate unique names
     name_counts: dict[str, int] = {}
     unique_names: list[str] = []
     
     for basename in basenames:
-        # Sanitize the basename to make it a valid source name
         name = basename.lower().replace(" ", "_").replace("-", "_")
-        
-        # If it's a reserved name or already used, add a suffix
-        original_name = name
-        counter = 1
-        while name in reserved or name in name_counts:
-            name = f"{original_name}_{counter}"
-            counter += 1
-        
-        name_counts[name] = 1
+        if name in name_counts:
+            name_counts[name] += 1
+            name = f"{name}_{name_counts[name]}"
+        else:
+            name_counts[name] = 0
         unique_names.append(name)
     
     return unique_names
@@ -1005,8 +997,16 @@ def _load_all_conversations(config: Config) -> list[ConversationInfo]:
     conversations.extend(cloud_source.list_conversations())
 
     # Load extra conversation paths
+    # Note: Extra paths are assumed to use UTC timestamps (like cloud conversations).
+    # If you're pointing to local CLI conversations, timestamps may display incorrectly.
     extra_source_names = _generate_unique_source_names(config.extra_conversation_paths)
     for path, source_name in zip(config.extra_conversation_paths, extra_source_names):
+        if not path.exists():
+            log.warning("Skipping nonexistent conversation path: %s", path)
+            continue
+        if not path.is_dir():
+            log.warning("Skipping non-directory conversation path: %s", path)
+            continue
         extra_source = LocalSource(path, source_name=source_name)
         conversations.extend(extra_source.list_conversations())
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -296,10 +296,11 @@ def config(action: str | None, key: str | None, value: str | None) -> None:
     
     \b
     Configurable keys:
-      local_conversations_dir   Path to local CLI conversations
+      local_conversations_dir    Path to local CLI conversations
       synced_conversations_dir   Path to synced cloud conversations
-      cloud_api_url            OpenHands Cloud API URL
-      source                    Default source: 'local' or 'cloud'
+      cloud_api_url              OpenHands Cloud API URL
+      source                     Default source: 'local' or 'cloud'
+      extra_conversation_paths   Additional conversation directories (colon-separated)
     
     \b
     Configuration priority (highest first):
@@ -366,6 +367,11 @@ def _show_config() -> None:
         "source",
         str(cfg.source.value),
         _source_style(cfg.source.source),
+    )
+    table.add_row(
+        "extra_conversation_paths",
+        str(cfg.extra_conversation_paths.value) if cfg.extra_conversation_paths.value else "[dim]None[/dim]",
+        _source_style(cfg.extra_conversation_paths.source),
     )
     
     console.print()

--- a/src/ohtv/config.py
+++ b/src/ohtv/config.py
@@ -22,6 +22,7 @@ CONFIGURABLE_KEYS = {
     "synced_conversations_dir": "Path to synced cloud conversations", 
     "cloud_api_url": "OpenHands Cloud API URL",
     "source": "Default source: 'local' or 'cloud'",
+    "extra_conversation_paths": "Additional conversation directories (colon-separated)",
 }
 
 
@@ -47,6 +48,7 @@ class ConfigWithSources:
     cloud_api_url: ConfigValue
     api_key: ConfigValue
     source: ConfigValue
+    extra_conversation_paths: ConfigValue
     ohtv_dir: ConfigValue
     manifest_path: Path
     config_file_path: Path
@@ -61,6 +63,7 @@ class Config:
     cloud_api_url: str
     api_key: str | None
     source: str  # "local" or "cloud"
+    extra_conversation_paths: list[Path]
     _sources: dict[str, str] = field(default_factory=dict, repr=False)
 
     @classmethod
@@ -74,11 +77,13 @@ class Config:
         cloud_dir, cloud_src = _get_synced_conversations_dir(home, file_config)
         cloud_url, url_src = _get_cloud_api_url(file_config)
         source_val, source_src = _get_source(file_config)
+        extra_paths, extra_src = _get_extra_conversation_paths(file_config)
         
         sources["local_conversations_dir"] = local_src
         sources["synced_conversations_dir"] = cloud_src
         sources["cloud_api_url"] = url_src
         sources["source"] = source_src
+        sources["extra_conversation_paths"] = extra_src
         
         return cls(
             local_conversations_dir=local_dir,
@@ -86,6 +91,7 @@ class Config:
             cloud_api_url=cloud_url,
             api_key=_get_api_key(home),
             source=source_val,
+            extra_conversation_paths=extra_paths,
             _sources=sources,
         )
     
@@ -98,12 +104,16 @@ class Config:
         ohtv_dir = get_ohtv_dir()
         ohtv_source = "env" if os.environ.get("OHTV_DIR") else "default"
         
+        # Format extra paths for display
+        extra_paths_str = ":".join(str(p) for p in self.extra_conversation_paths) if self.extra_conversation_paths else None
+        
         return ConfigWithSources(
             local_conversations_dir=ConfigValue(self.local_conversations_dir, self._sources.get("local_conversations_dir", "default")),
             synced_conversations_dir=ConfigValue(self.synced_conversations_dir, self._sources.get("synced_conversations_dir", "default")),
             cloud_api_url=ConfigValue(self.cloud_api_url, self._sources.get("cloud_api_url", "default")),
             api_key=ConfigValue("****" if api_key else None, api_source),
             source=ConfigValue(self.source, self._sources.get("source", "default")),
+            extra_conversation_paths=ConfigValue(extra_paths_str, self._sources.get("extra_conversation_paths", "default")),
             ohtv_dir=ConfigValue(ohtv_dir, ohtv_source),
             manifest_path=get_manifest_path(),
             config_file_path=get_config_file_path(),
@@ -161,6 +171,24 @@ def _get_source(file_config: dict) -> tuple[str, str]:
     if file_source:
         return file_source, "file"
     return "local", "default"
+
+
+def _get_extra_conversation_paths(file_config: dict) -> tuple[list[Path], str]:
+    """Get extra conversation paths with source tracking."""
+    env_paths = os.environ.get("OHTV_EXTRA_CONVERSATION_PATHS")
+    if env_paths:
+        paths = [Path(p.strip()).expanduser() for p in env_paths.split(":") if p.strip()]
+        return paths, "env"
+    file_paths = file_config.get("extra_conversation_paths")
+    if file_paths:
+        if isinstance(file_paths, str):
+            paths = [Path(p.strip()).expanduser() for p in file_paths.split(":") if p.strip()]
+        elif isinstance(file_paths, list):
+            paths = [Path(p).expanduser() for p in file_paths]
+        else:
+            paths = []
+        return paths, "file"
+    return [], "default"
 
 
 def _get_api_key(home: Path) -> str | None:

--- a/tests/integration/test_extra_paths.py
+++ b/tests/integration/test_extra_paths.py
@@ -1,0 +1,431 @@
+"""Integration tests for extra conversation paths feature.
+
+These tests validate end-to-end CLI behavior when configuring additional
+conversation search paths via environment variable.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main
+
+
+def create_mock_conversation(
+    conv_dir: Path,
+    conv_id: str,
+    title: str = "Test conversation",
+    event_count: int = 2,
+) -> None:
+    """Create a minimal mock conversation directory structure.
+
+    Args:
+        conv_dir: Parent directory for conversations
+        conv_id: Conversation ID (directory name, no dashes)
+        title: Title for the conversation
+        event_count: Number of mock events to create
+    """
+    conv_path = conv_dir / conv_id
+    conv_path.mkdir(parents=True, exist_ok=True)
+
+    # Create base_state.json
+    base_state = {
+        "id": conv_id,
+        "title": title,
+        "selected_repository": "test/repo",
+        "selected_branch": "main",
+        "created_at": "2026-04-01T10:00:00.000000Z",
+        "updated_at": "2026-04-01T10:30:00.000000Z",
+        "agent": {
+            "llm": {"model": "test-model"},
+            "tools": [],
+        },
+    }
+    (conv_path / "base_state.json").write_text(json.dumps(base_state))
+
+    # Create events directory with mock events
+    events_dir = conv_path / "events"
+    events_dir.mkdir(exist_ok=True)
+
+    for i in range(event_count):
+        event = {
+            "id": f"event_{i}",
+            "timestamp": f"2026-04-01T10:{i:02d}:00.000000",
+            "source": "user" if i % 2 == 0 else "agent",
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": [{"type": "text", "text": f"Message {i}"}],
+            },
+        }
+        event_file = events_dir / f"event-{i:05d}-{chr(97 + i)}.json"
+        event_file.write_text(json.dumps(event))
+
+
+class TestListWithExtraPaths:
+    """Tests for `list` command with extra conversation paths."""
+
+    def test_list_shows_conversations_from_extra_path(self, tmp_path):
+        """Conversations from extra paths appear in list output."""
+        # Create a mock conversation in an extra path
+        extra_path = tmp_path / "my_experiments"
+        extra_path.mkdir()
+        create_mock_conversation(extra_path, "abc123def456", title="Extra path test")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                # Ensure default paths don't interfere
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A"])
+
+        assert result.exit_code == 0
+        # Verify the conversation appears
+        assert "abc123" in result.output or "abc123d" in result.output
+        assert "Extra path test" in result.output
+
+    def test_list_shows_correct_source_name(self, tmp_path):
+        """Source name is derived from directory basename, not 'local' or 'cloud'."""
+        extra_path = tmp_path / "my_experiments"
+        extra_path.mkdir()
+        create_mock_conversation(extra_path, "aaa111bbb222", title="Source name test")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            # Use JSON format for precise verification of source name
+            result = runner.invoke(main, ["list", "-A", "-F", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        # Source should be 'my_experiments'
+        assert data[0]["source"] == "my_experiments"
+        # Should NOT be 'local' or 'cloud'
+        assert data[0]["source"] not in ("local", "cloud")
+
+    def test_list_with_multiple_extra_paths(self, tmp_path):
+        """Multiple extra paths are all searched."""
+        # Create two extra paths with conversations
+        path1 = tmp_path / "experiments"
+        path1.mkdir()
+        create_mock_conversation(path1, "exp111222333", title="Experiment 1")
+
+        path2 = tmp_path / "archive"
+        path2.mkdir()
+        create_mock_conversation(path2, "arc444555666", title="Archive conv")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": f"{path1}:{path2}",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A"])
+
+        assert result.exit_code == 0
+        # Both conversations should appear
+        assert "Experiment 1" in result.output
+        assert "Archive conv" in result.output
+
+    def test_list_json_format_includes_extra_path_source(self, tmp_path):
+        """JSON output includes correct source name for extra path conversations."""
+        extra_path = tmp_path / "test_data"
+        extra_path.mkdir()
+        create_mock_conversation(extra_path, "json111222333", title="JSON test")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A", "-F", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # JSON output is a list of conversations directly
+        assert isinstance(data, list)
+
+        # Find our conversation
+        conv = next(
+            (c for c in data if "json111" in c.get("id", "")),
+            None,
+        )
+        assert conv is not None
+        assert conv["source"] == "test_data"
+
+
+class TestShowWithExtraPaths:
+    """Tests for `show` command with extra conversation paths."""
+
+    def test_show_finds_conversation_in_extra_path(self, tmp_path):
+        """Show command can find and display a conversation from an extra path."""
+        extra_path = tmp_path / "experiments"
+        extra_path.mkdir()
+        create_mock_conversation(
+            extra_path,
+            "show111222333",
+            title="Show test conversation",
+            event_count=3,
+        )
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            # Use stats-only mode for simpler verification
+            result = runner.invoke(main, ["show", "show111222333", "-S"])
+
+        assert result.exit_code == 0
+        assert "Show test conversation" in result.output or "show111" in result.output
+
+    def test_show_with_dashed_id(self, tmp_path):
+        """Show command finds conversation using ID with dashes."""
+        extra_path = tmp_path / "experiments"
+        extra_path.mkdir()
+        # Directory name without dashes
+        create_mock_conversation(extra_path, "abcd1234efgh5678", title="Dashed ID test")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            # Use dashed ID format (like what's displayed in list)
+            result = runner.invoke(main, ["show", "abcd1234-efgh-5678", "-S"])
+
+        assert result.exit_code == 0
+
+    def test_show_displays_events_from_extra_path(self, tmp_path):
+        """Show command displays event content from extra path conversations."""
+        extra_path = tmp_path / "experiments"
+        extra_path.mkdir()
+        create_mock_conversation(
+            extra_path,
+            "events11223344",
+            title="Events test",
+            event_count=4,
+        )
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            # Show with user messages
+            result = runner.invoke(main, ["show", "events11223344", "-u"])
+
+        assert result.exit_code == 0
+        # Should show message content
+        assert "Message" in result.output
+
+    def test_show_not_found_error(self, tmp_path):
+        """Show command returns error for non-existent conversation."""
+        extra_path = tmp_path / "experiments"
+        extra_path.mkdir()
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": str(extra_path),
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["show", "nonexistent123456"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+
+class TestSourceNameCollisions:
+    """Tests for source name collision handling in actual CLI output."""
+
+    def test_collision_handling_in_list_output(self, tmp_path):
+        """Source names with collisions get numeric suffixes in CLI output."""
+        # Create two paths with the same basename
+        path1 = tmp_path / "dir1" / "experiments"
+        path1.mkdir(parents=True)
+        create_mock_conversation(path1, "coll111222333", title="First experiments")
+
+        path2 = tmp_path / "dir2" / "experiments"
+        path2.mkdir(parents=True)
+        create_mock_conversation(path2, "coll444555666", title="Second experiments")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": f"{path1}:{path2}",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            # Use JSON for precise verification
+            result = runner.invoke(main, ["list", "-A", "-F", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # Both conversations should appear
+        assert len(data) == 2
+        sources = {c["source"] for c in data}
+        # Source names should show collision handling
+        # First path: 'experiments', second path: 'experiments_1'
+        assert "experiments" in sources
+        assert "experiments_1" in sources
+
+    def test_collision_handling_in_json_output(self, tmp_path):
+        """JSON output shows unique source names for colliding paths."""
+        path1 = tmp_path / "a" / "data"
+        path1.mkdir(parents=True)
+        create_mock_conversation(path1, "json111aaaaaa", title="Data 1")
+
+        path2 = tmp_path / "b" / "data"
+        path2.mkdir(parents=True)
+        create_mock_conversation(path2, "json222bbbbbb", title="Data 2")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": f"{path1}:{path2}",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A", "-F", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # JSON output is a list of conversations directly
+        assert isinstance(data, list)
+
+        sources = {c["source"] for c in data}
+        # Should have 'data' and 'data_1' (or similar unique names)
+        assert len(sources) == 2
+        assert "data" in sources
+        assert "data_1" in sources
+
+    def test_mixed_case_and_separator_normalization(self, tmp_path):
+        """Source names are normalized (lowercase, underscores) for collision detection."""
+        path1 = tmp_path / "dir1" / "My-Data"
+        path1.mkdir(parents=True)
+        create_mock_conversation(path1, "norm111222333", title="Conv 1")
+
+        path2 = tmp_path / "dir2" / "my data"
+        path2.mkdir(parents=True)
+        create_mock_conversation(path2, "norm444555666", title="Conv 2")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": f"{path1}:{path2}",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A", "-F", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # JSON output is a list of conversations directly
+        assert isinstance(data, list)
+
+        sources = {c["source"] for c in data}
+        # Both normalize to 'my_data', so second should be 'my_data_1'
+        assert "my_data" in sources
+        assert "my_data_1" in sources
+
+
+class TestExtraPathEdgeCases:
+    """Tests for edge cases with extra conversation paths."""
+
+    def test_nonexistent_path_is_skipped(self, tmp_path):
+        """Non-existent paths are skipped without error."""
+        # Create one valid path
+        valid_path = tmp_path / "valid"
+        valid_path.mkdir()
+        create_mock_conversation(valid_path, "valid1112223", title="Valid conv")
+
+        # Reference a non-existent path
+        nonexistent = tmp_path / "does_not_exist"
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": f"{valid_path}:{nonexistent}",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A"])
+
+        # Should succeed despite non-existent path
+        assert result.exit_code == 0
+        assert "Valid conv" in result.output
+
+    def test_empty_extra_path_list(self, tmp_path):
+        """Empty extra paths configuration works correctly."""
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": "",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A"])
+
+        # Should succeed with empty extra paths
+        assert result.exit_code == 0
+
+    def test_path_is_file_not_directory(self, tmp_path):
+        """File paths (not directories) are skipped."""
+        # Create a file instead of directory
+        fake_file = tmp_path / "not_a_dir"
+        fake_file.write_text("not a directory")
+
+        # Create a valid path too
+        valid_path = tmp_path / "valid"
+        valid_path.mkdir()
+        create_mock_conversation(valid_path, "validfile123", title="Valid conv")
+
+        runner = CliRunner()
+        with patch.dict(
+            os.environ,
+            {
+                "OHTV_EXTRA_CONVERSATION_PATHS": f"{fake_file}:{valid_path}",
+                "HOME": str(tmp_path / "fake_home"),
+            },
+        ):
+            result = runner.invoke(main, ["list", "-A"])
+
+        # Should succeed with file path skipped
+        assert result.exit_code == 0
+        assert "Valid conv" in result.output

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,0 +1,71 @@
+"""Unit tests for CLI helper functions."""
+
+from pathlib import Path
+
+import pytest
+
+from ohtv.cli import _generate_unique_source_names
+
+
+class TestGenerateUniqueSourceNames:
+    def test_empty_list_returns_empty_list(self):
+        assert _generate_unique_source_names([]) == []
+
+    def test_single_path_returns_sanitized_name(self):
+        paths = [Path("/data/my-experiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments"]
+
+    def test_multiple_unique_paths_no_collisions(self):
+        paths = [
+            Path("/data/experiments"),
+            Path("/data/archive"),
+            Path("/data/test-data"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["experiments", "archive", "test_data"]
+
+    def test_collision_adds_numeric_suffix(self):
+        paths = [
+            Path("/data/experiments"),
+            Path("/other/experiments"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["experiments", "experiments_1"]
+
+    def test_multiple_collisions(self):
+        paths = [
+            Path("/a/test"),
+            Path("/b/test"),
+            Path("/c/test"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["test", "test_1", "test_2"]
+
+    def test_spaces_replaced_with_underscores(self):
+        paths = [Path("/data/my experiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments"]
+
+    def test_hyphens_replaced_with_underscores(self):
+        paths = [Path("/data/my-experiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments"]
+
+    def test_case_normalization_to_lowercase(self):
+        paths = [Path("/data/MyExperiments")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["myexperiments"]
+
+    def test_collision_with_mixed_case_and_separators(self):
+        paths = [
+            Path("/data/My-Experiments"),
+            Path("/other/my experiments"),
+        ]
+        result = _generate_unique_source_names(paths)
+        assert result == ["my_experiments", "my_experiments_1"]
+
+    def test_reserved_names_allowed(self):
+        paths = [Path("/data/local"), Path("/data/cloud")]
+        result = _generate_unique_source_names(paths)
+        assert result == ["local", "cloud"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,87 @@
+"""Unit tests for config module."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ohtv.config import _get_extra_conversation_paths
+
+
+class TestGetExtraConversationPaths:
+    def test_empty_config_returns_empty_list(self):
+        paths, source = _get_extra_conversation_paths({})
+        assert paths == []
+        assert source == "default"
+
+    def test_env_var_colon_separated(self):
+        with patch.dict(os.environ, {"OHTV_EXTRA_CONVERSATION_PATHS": "/path1:/path2:/path3"}):
+            paths, source = _get_extra_conversation_paths({})
+            assert len(paths) == 3
+            assert paths[0] == Path("/path1")
+            assert paths[1] == Path("/path2")
+            assert paths[2] == Path("/path3")
+            assert source == "env"
+
+    def test_env_var_with_spaces_stripped(self):
+        with patch.dict(os.environ, {"OHTV_EXTRA_CONVERSATION_PATHS": " /path1 : /path2 "}):
+            paths, source = _get_extra_conversation_paths({})
+            assert len(paths) == 2
+            assert paths[0] == Path("/path1")
+            assert paths[1] == Path("/path2")
+            assert source == "env"
+
+    def test_env_var_with_empty_entries_skipped(self):
+        with patch.dict(os.environ, {"OHTV_EXTRA_CONVERSATION_PATHS": "/path1::/path2"}):
+            paths, source = _get_extra_conversation_paths({})
+            assert len(paths) == 2
+            assert paths[0] == Path("/path1")
+            assert paths[1] == Path("/path2")
+
+    def test_env_var_with_tilde_expansion(self):
+        with patch.dict(os.environ, {"OHTV_EXTRA_CONVERSATION_PATHS": "~/experiments"}):
+            paths, source = _get_extra_conversation_paths({})
+            assert len(paths) == 1
+            assert paths[0] == Path.home() / "experiments"
+            assert source == "env"
+
+    def test_file_config_string_format(self):
+        file_config = {"extra_conversation_paths": "/path1:/path2"}
+        paths, source = _get_extra_conversation_paths(file_config)
+        assert len(paths) == 2
+        assert paths[0] == Path("/path1")
+        assert paths[1] == Path("/path2")
+        assert source == "file"
+
+    def test_file_config_list_format(self):
+        file_config = {"extra_conversation_paths": ["/path1", "/path2", "/path3"]}
+        paths, source = _get_extra_conversation_paths(file_config)
+        assert len(paths) == 3
+        assert paths[0] == Path("/path1")
+        assert paths[1] == Path("/path2")
+        assert paths[2] == Path("/path3")
+        assert source == "file"
+
+    def test_file_config_list_with_tilde_expansion(self):
+        file_config = {"extra_conversation_paths": ["~/experiments", "~/archive"]}
+        paths, source = _get_extra_conversation_paths(file_config)
+        assert len(paths) == 2
+        assert paths[0] == Path.home() / "experiments"
+        assert paths[1] == Path.home() / "archive"
+        assert source == "file"
+
+    def test_env_var_takes_precedence_over_file(self):
+        with patch.dict(os.environ, {"OHTV_EXTRA_CONVERSATION_PATHS": "/env/path"}):
+            file_config = {"extra_conversation_paths": "/file/path"}
+            paths, source = _get_extra_conversation_paths(file_config)
+            assert len(paths) == 1
+            assert paths[0] == Path("/env/path")
+            assert source == "env"
+
+    def test_file_config_invalid_type_returns_empty(self):
+        # Test graceful handling of unexpected config types
+        file_config = {"extra_conversation_paths": 123}
+        paths, source = _get_extra_conversation_paths(file_config)
+        assert paths == []
+        assert source == "file"


### PR DESCRIPTION
Implements #5. Adds support for additional conversation search paths via:
- OHTV_EXTRA_CONVERSATION_PATHS environment variable (colon-separated)
- Config file section for persistent setup

This allows users to include conversations from multiple sources (lxa, custom experiments) in OHTV.