### PR TITLE
Add -n/--max-new option to sync command

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -225,9 +225,10 @@ def main() -> None:
 
 
 @main.command()
-@click.option("--force", "-f", is_flag=True, help="Re-download all conversations")
+@click.option("--force", "-f", is_flag=True, help="Re-download all conversations (cleans local data first)")
 @click.option("--since", type=click.DateTime(), help="Only sync conversations updated after date")
 @click.option("--dry-run", is_flag=True, help="Show what would sync without downloading")
+@click.option("--max-new", "-n", type=int, help="Maximum number of NEW conversations to sync")
 @click.option("--status", "-s", is_flag=True, help="Show sync status")
 @click.option("--process", "-p", is_flag=True, help="Run all processing stages after sync")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output for cron jobs")
@@ -236,6 +237,7 @@ def sync(
     force: bool,
     since: datetime | None,
     dry_run: bool,
+    max_new: int | None,
     status: bool,
     process: bool,
     quiet: bool,
@@ -243,8 +245,14 @@ def sync(
 ) -> None:
     """Sync cloud conversations to local storage.
     
+    Use -n/--max-new to limit the number of NEW conversations synced.
+    Updates to existing conversations are always synced (no limit).
+    
     Use --process to automatically run database indexing after sync,
     equivalent to running 'ohtv db process all'.
+    
+    Combining --force with -n resets local storage to only the N most
+    recent conversations (destructive operation, requires confirmation).
     """
     _init_logging(verbose=verbose)
 
@@ -260,7 +268,12 @@ def sync(
         return
 
     try:
-        result = _run_sync(manager, force, since, dry_run, quiet)
+        # Handle --force -n combination (reset to N newest)
+        if force and max_new is not None:
+            result = _run_force_reset(manager, max_new, dry_run, quiet)
+        else:
+            result = _run_sync(manager, force, since, dry_run, max_new, quiet)
+        
         if not quiet:
             _show_result(result, dry_run)
         
@@ -274,6 +287,32 @@ def sync(
     except SyncAbortedError as e:
         console.print(f"[red]Sync aborted:[/red] {e}")
         raise SystemExit(1)
+
+
+def _run_force_reset(
+    manager: SyncManager,
+    max_new: int,
+    dry_run: bool,
+    quiet: bool,
+) -> SyncResult:
+    """Handle --force -n combination: reset to N newest conversations."""
+    from rich.prompt import Confirm
+    
+    current_count = manager.get_local_conversation_count()
+    
+    if not quiet:
+        console.print(f"[yellow]Warning:[/yellow] This will delete {current_count} local conversation(s) "
+                      f"and sync only the {max_new} most recent from cloud.")
+        console.print()
+        if dry_run:
+            console.print("[yellow]DRY RUN[/yellow] - showing what would be synced:")
+        else:
+            if not Confirm.ask("Proceed?", console=console, default=False):
+                console.print("[dim]Cancelled.[/dim]")
+                raise SystemExit(0)
+    
+    on_progress = None if quiet else _make_progress_callback()
+    return manager.reset_to_n_newest(max_new, dry_run=dry_run, on_progress=on_progress)
 
 
 @main.command()
@@ -462,25 +501,27 @@ def _run_sync(
     force: bool,
     since: datetime | None,
     dry_run: bool,
+    max_new: int | None,
     quiet: bool,
 ) -> SyncResult:
     """Execute sync with progress display."""
     if not quiet:
-        _print_sync_header(force, since, dry_run)
+        _print_sync_header(force, since, dry_run, max_new)
 
     on_progress = None if quiet else _make_progress_callback()
-    return manager.sync(force=force, since=since, dry_run=dry_run, on_progress=on_progress)
+    return manager.sync(force=force, since=since, dry_run=dry_run, max_new=max_new, on_progress=on_progress)
 
 
-def _print_sync_header(force: bool, since: datetime | None, dry_run: bool) -> None:
+def _print_sync_header(force: bool, since: datetime | None, dry_run: bool, max_new: int | None) -> None:
     """Print sync operation header."""
     mode = "[yellow]DRY RUN[/yellow] " if dry_run else ""
+    limit_suffix = f" (max {max_new} new)" if max_new is not None else ""
     if force:
-        console.print(f"{mode}Syncing all cloud conversations (force)...")
+        console.print(f"{mode}Syncing all cloud conversations (force){limit_suffix}...")
     elif since:
-        console.print(f"{mode}Syncing conversations since {since.isoformat()}...")
+        console.print(f"{mode}Syncing conversations since {since.isoformat()}{limit_suffix}...")
     else:
-        console.print(f"{mode}Syncing cloud conversations...")
+        console.print(f"{mode}Syncing cloud conversations{limit_suffix}...")
 
 
 def _make_progress_callback():
@@ -488,7 +529,13 @@ def _make_progress_callback():
 
     def callback(conv_id: str, title: str, action: str) -> None:
         short_id = conv_id[:7]
-        status_style = {"new": "green", "updated": "yellow", "unchanged": "dim", "failed": "red"}
+        status_style = {
+            "new": "green",
+            "updated": "yellow",
+            "unchanged": "dim",
+            "failed": "red",
+            "skipped": "dim cyan",
+        }
         style = status_style.get(action, "")
         console.print(f"  [{style}]{short_id}[/{style}] {title[:40]}... ({action})")
 
@@ -508,6 +555,8 @@ def _show_result(result: SyncResult, dry_run: bool) -> None:
     console.print(f"  Unchanged: {result.unchanged}")
     if result.failed:
         console.print(f"  [red]Failed:    {result.failed}[/red]")
+    if result.skipped_new:
+        console.print(f"  [cyan]Skipped:   {result.skipped_new} additional available[/cyan]")
 
     if result.errors:
         _show_errors(result.errors)

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -302,7 +302,7 @@ def _run_force_reset(
     
     if not quiet:
         console.print(f"[yellow]Warning:[/yellow] This will delete {current_count} local conversation(s) "
-                      f"and sync only the {max_new} most recent from cloud.")
+                      f"and sync up to {max_new} of the most recent from cloud.")
         console.print()
         if dry_run:
             console.print("[yellow]DRY RUN[/yellow] - showing what would be synced:")

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import shutil
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -234,7 +235,6 @@ class SyncManager:
 
     def _cleanup_conversation_dir(self, conv_id: str) -> None:
         """Remove existing conversation directory before re-download."""
-        import shutil
         conv_dir = self.config.synced_conversations_dir / conv_id
         if conv_dir.exists():
             log.debug("Cleaning up existing directory for %s", conv_id)
@@ -380,8 +380,6 @@ class SyncManager:
             dry_run: Show what would happen without making changes
             on_progress: Callback for progress updates
         """
-        import shutil
-        
         if not self.config.api_key:
             raise ValueError("API key required. Set OH_API_KEY environment variable.")
 
@@ -389,7 +387,9 @@ class SyncManager:
 
         try:
             with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
-                # Fetch all conversations (API returns newest first by updated_at)
+                # Fetch all conversations from cloud.
+                # Note: API returns conversations sorted by updated_at descending (newest first).
+                # See REFERENCE_CLOUD_API.md for sort order documentation.
                 conversations = client.search_all_conversations()
                 log.info("Found %d total conversations in cloud", len(conversations))
                 

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -32,6 +32,7 @@ class SyncResult:
     updated: int = 0
     unchanged: int = 0
     failed: int = 0
+    skipped_new: int = 0  # New conversations skipped due to max_new limit
     errors: list[tuple[str, str]] = field(default_factory=list)
     failed_ids: list[str] = field(default_factory=list)
 
@@ -42,6 +43,10 @@ class SyncResult:
     @property
     def has_failures(self) -> bool:
         return self.failed > 0
+
+    @property
+    def has_skipped_new(self) -> bool:
+        return self.skipped_new > 0
 
 
 @dataclass
@@ -92,21 +97,30 @@ class SyncManager:
         force: bool = False,
         since: datetime | None = None,
         dry_run: bool = False,
+        max_new: int | None = None,
         on_progress: Callable[[str, str, str], None] | None = None,
     ) -> SyncResult:
-        """Sync conversations from cloud."""
+        """Sync conversations from cloud.
+        
+        Args:
+            force: Re-download all conversations (clears local before re-download)
+            since: Only sync conversations updated after this date
+            dry_run: Show what would sync without downloading
+            max_new: Maximum number of NEW conversations to sync (no limit on updates)
+            on_progress: Callback for progress updates (conv_id, title, action)
+        """
         if not self.config.api_key:
             raise ValueError("API key required. Set OH_API_KEY environment variable.")
 
         cutoff = self._determine_cutoff(force, since)
-        log.info("Starting sync (force=%s, cutoff=%s, dry_run=%s)", force, cutoff, dry_run)
+        log.info("Starting sync (force=%s, cutoff=%s, dry_run=%s, max_new=%s)", force, cutoff, dry_run, max_new)
 
         try:
             with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
                 conversations = client.search_all_conversations(updated_since=cutoff)
                 conversations = self._add_failed_conversations(conversations)
                 log.info("Found %d conversations to process", len(conversations))
-                return self._process_conversations(client, conversations, force, dry_run, on_progress)
+                return self._process_conversations(client, conversations, force, dry_run, max_new, on_progress)
         except httpx.HTTPStatusError as e:
             log.error("HTTP error during sync: %s %s", e.response.status_code, e.response.reason_phrase)
             if e.response.status_code in (401, 403):
@@ -152,6 +166,7 @@ class SyncManager:
         conversations: list[dict],
         force: bool,
         dry_run: bool,
+        max_new: int | None,
         on_progress: Callable[[str, str, str], None] | None,
     ) -> SyncResult:
         """Process each conversation that needs syncing."""
@@ -160,7 +175,7 @@ class SyncManager:
         max_consecutive_failures = 5
 
         for conv in conversations:
-            action = self._sync_one(client, conv, force, dry_run, on_progress, result)
+            action = self._sync_one(client, conv, force, dry_run, max_new, on_progress, result)
             self._update_result(result, action)
             consecutive_failures = self._check_abort(action, consecutive_failures, max_consecutive_failures)
 
@@ -184,20 +199,31 @@ class SyncManager:
         conv: dict,
         force: bool,
         dry_run: bool,
+        max_new: int | None,
         on_progress: Callable[[str, str, str], None] | None,
         result: SyncResult,
     ) -> str:
-        """Sync a single conversation. Returns action taken: 'new', 'updated', 'unchanged', 'failed'."""
+        """Sync a single conversation. Returns action taken: 'new', 'updated', 'unchanged', 'failed', 'skipped'."""
         conv_id = conv["id"]
         cloud_updated_at = conv.get("updated_at", "")
         title = conv.get("title", "")[:50]
 
         planned_action = self._determine_action(conv_id, cloud_updated_at, force)
 
+        # Check if we should skip this new conversation due to max_new limit
+        if planned_action == "new" and max_new is not None and result.new >= max_new:
+            if on_progress:
+                on_progress(conv_id, title, "skipped")
+            return "skipped"
+
         if planned_action == "unchanged" or dry_run:
             if on_progress:
                 on_progress(conv_id, title, planned_action)
             return planned_action
+
+        # For force mode, clean up existing directory before re-download
+        if force and planned_action == "updated":
+            self._cleanup_conversation_dir(conv_id)
 
         actual_action = self._download_and_update(
             client, conv, conv_id, cloud_updated_at, planned_action, result
@@ -205,6 +231,14 @@ class SyncManager:
         if on_progress:
             on_progress(conv_id, title, actual_action)
         return actual_action
+
+    def _cleanup_conversation_dir(self, conv_id: str) -> None:
+        """Remove existing conversation directory before re-download."""
+        import shutil
+        conv_dir = self.config.synced_conversations_dir / conv_id
+        if conv_dir.exists():
+            log.debug("Cleaning up existing directory for %s", conv_id)
+            shutil.rmtree(conv_dir)
 
     def _determine_action(self, conv_id: str, cloud_updated_at: str, force: bool) -> str:
         """Determine what action to take for a conversation."""
@@ -285,21 +319,30 @@ class SyncManager:
             result.unchanged += 1
         elif action == "failed":
             result.failed += 1
+        elif action == "skipped":
+            result.skipped_new += 1
 
     def _finalize_sync(self, result: SyncResult) -> None:
         """Update and save manifest after sync."""
         self.manifest.failed_ids = result.failed_ids
         self.manifest.sync_count += 1
 
-        if not result.has_failures:
-            self.manifest.last_sync_at = datetime.now(timezone.utc)
-            log.info("Sync complete. Total conversations: %d", len(self.manifest.conversations))
-        else:
+        # Don't advance cutoff if there were failures or skipped new conversations
+        if result.has_failures:
             log.warning(
                 "Sync complete with %d failures. Not advancing cutoff. "
                 "Run 'ohtv sync' again to retry failed conversations.",
                 result.failed,
             )
+        elif result.has_skipped_new:
+            log.info(
+                "Sync complete. Synced %d new, %d additional available. "
+                "Not advancing cutoff so skipped conversations remain visible.",
+                result.new, result.skipped_new,
+            )
+        else:
+            self.manifest.last_sync_at = datetime.now(timezone.utc)
+            log.info("Sync complete. Total conversations: %d", len(self.manifest.conversations))
 
         self.manifest.save(self.manifest_path)
 
@@ -313,6 +356,101 @@ class SyncManager:
             "total_events": total_events,
             "pending_retries": len(self.manifest.failed_ids),
         }
+
+    def get_local_conversation_count(self) -> int:
+        """Get count of locally synced conversations."""
+        return len(self.manifest.conversations)
+
+    def reset_to_n_newest(
+        self,
+        n: int,
+        dry_run: bool = False,
+        on_progress: Callable[[str, str, str], None] | None = None,
+    ) -> SyncResult:
+        """Reset local storage to only the N most recently updated conversations.
+        
+        This is a destructive operation that:
+        1. Deletes all existing local conversation data
+        2. Clears the manifest
+        3. Downloads only the N most recently updated conversations from cloud
+        4. Sets last_sync_at to current time
+        
+        Args:
+            n: Number of conversations to keep
+            dry_run: Show what would happen without making changes
+            on_progress: Callback for progress updates
+        """
+        import shutil
+        
+        if not self.config.api_key:
+            raise ValueError("API key required. Set OH_API_KEY environment variable.")
+
+        log.info("Resetting to %d newest conversations (dry_run=%s)", n, dry_run)
+
+        try:
+            with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
+                # Fetch all conversations (API returns newest first by updated_at)
+                conversations = client.search_all_conversations()
+                log.info("Found %d total conversations in cloud", len(conversations))
+                
+                # Take only first N
+                conversations_to_sync = conversations[:n]
+                
+                if dry_run:
+                    result = SyncResult()
+                    for conv in conversations_to_sync:
+                        if on_progress:
+                            on_progress(conv["id"], conv.get("title", "")[:50], "new")
+                        result.new += 1
+                    result.skipped_new = len(conversations) - n if len(conversations) > n else 0
+                    return result
+
+                # Clear existing data
+                synced_dir = self.config.synced_conversations_dir
+                if synced_dir.exists():
+                    log.info("Clearing existing synced conversations directory")
+                    shutil.rmtree(synced_dir)
+                synced_dir.mkdir(parents=True, exist_ok=True)
+                
+                # Clear manifest
+                self.manifest.conversations = {}
+                self.manifest.failed_ids = []
+                
+                # Download the N newest conversations
+                result = SyncResult()
+                consecutive_failures = 0
+                max_consecutive_failures = 5
+                
+                for conv in conversations_to_sync:
+                    action = self._download_and_update(
+                        client, conv, conv["id"], conv.get("updated_at", ""), "new", result
+                    )
+                    self._update_result(result, action)
+                    if on_progress:
+                        on_progress(conv["id"], conv.get("title", "")[:50], action)
+                    consecutive_failures = self._check_abort(action, consecutive_failures, max_consecutive_failures)
+                
+                # Track how many were available but not synced
+                if len(conversations) > n:
+                    result.skipped_new = len(conversations) - n
+                
+                # Update manifest - set last_sync_at to now since we're starting fresh
+                self.manifest.sync_count += 1
+                if not result.has_failures:
+                    self.manifest.last_sync_at = datetime.now(timezone.utc)
+                self.manifest.failed_ids = result.failed_ids
+                self.manifest.save(self.manifest_path)
+                
+                return result
+                
+        except httpx.HTTPStatusError as e:
+            log.error("HTTP error during reset: %s %s", e.response.status_code, e.response.reason_phrase)
+            if e.response.status_code in (401, 403):
+                raise SyncAuthError(f"Authentication failed (HTTP {e.response.status_code}). Check your API key.")
+            raise
+        except (httpx.TimeoutException, httpx.ConnectError) as e:
+            log.error("Network error during reset: %s", e)
+            raise SyncAbortedError(f"Network error: {e}")
 
 
 def _parse_datetime(value: str | None) -> datetime | None:

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -1,0 +1,361 @@
+"""Unit tests for the sync module."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ohtv.sync import SyncManager, SyncManifest, SyncResult
+
+
+class TestSyncResult:
+    """Tests for SyncResult dataclass."""
+
+    def test_has_skipped_new_true_when_skipped(self):
+        result = SyncResult(skipped_new=5)
+        assert result.has_skipped_new is True
+
+    def test_has_skipped_new_false_when_zero(self):
+        result = SyncResult(skipped_new=0)
+        assert result.has_skipped_new is False
+
+    def test_total_synced_includes_new_and_updated(self):
+        result = SyncResult(new=3, updated=2)
+        assert result.total_synced == 5
+
+    def test_has_failures_true_when_failed(self):
+        result = SyncResult(failed=1)
+        assert result.has_failures is True
+
+    def test_has_failures_false_when_zero(self):
+        result = SyncResult(failed=0)
+        assert result.has_failures is False
+
+
+class TestSyncManifest:
+    """Tests for SyncManifest dataclass."""
+
+    def test_load_creates_empty_when_file_missing(self, tmp_path):
+        path = tmp_path / "missing.json"
+        manifest = SyncManifest.load(path)
+        assert manifest.last_sync_at is None
+        assert manifest.sync_count == 0
+        assert manifest.conversations == {}
+        assert manifest.failed_ids == []
+
+    def test_load_parses_existing_file(self, tmp_path):
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps({
+            "last_sync_at": "2024-01-01T12:00:00Z",
+            "sync_count": 5,
+            "conversations": {"abc123": {"title": "Test"}},
+            "failed_ids": ["def456"],
+        }))
+        manifest = SyncManifest.load(path)
+        assert manifest.last_sync_at == datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert manifest.sync_count == 5
+        assert manifest.conversations == {"abc123": {"title": "Test"}}
+        assert manifest.failed_ids == ["def456"]
+
+    def test_save_creates_file(self, tmp_path):
+        path = tmp_path / "manifest.json"
+        manifest = SyncManifest(
+            last_sync_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            sync_count=3,
+            conversations={"abc": {"title": "Hello"}},
+            failed_ids=["xyz"],
+        )
+        manifest.save(path)
+        
+        data = json.loads(path.read_text())
+        assert data["last_sync_at"] == "2024-01-01T12:00:00Z"
+        assert data["sync_count"] == 3
+        assert data["conversations"] == {"abc": {"title": "Hello"}}
+        assert data["failed_ids"] == ["xyz"]
+
+
+class TestSyncManagerUpdateResult:
+    """Tests for SyncManager._update_result method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.api_key = "test-key"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_updates_new_count(self, manager):
+        result = SyncResult()
+        manager._update_result(result, "new")
+        assert result.new == 1
+
+    def test_updates_updated_count(self, manager):
+        result = SyncResult()
+        manager._update_result(result, "updated")
+        assert result.updated == 1
+
+    def test_updates_unchanged_count(self, manager):
+        result = SyncResult()
+        manager._update_result(result, "unchanged")
+        assert result.unchanged == 1
+
+    def test_updates_failed_count(self, manager):
+        result = SyncResult()
+        manager._update_result(result, "failed")
+        assert result.failed == 1
+
+    def test_updates_skipped_count(self, manager):
+        result = SyncResult()
+        manager._update_result(result, "skipped")
+        assert result.skipped_new == 1
+
+
+class TestSyncManagerDetermineAction:
+    """Tests for SyncManager._determine_action method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.api_key = "test-key"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            mgr = SyncManager(config)
+            # Pre-populate manifest with a known conversation
+            mgr.manifest.conversations = {
+                "existing123": {
+                    "title": "Existing",
+                    "updated_at": "2024-01-01T12:00:00Z",
+                }
+            }
+            return mgr
+
+    def test_returns_new_for_unknown_conversation(self, manager):
+        action = manager._determine_action("newconv456", "2024-01-02T12:00:00Z", force=False)
+        assert action == "new"
+
+    def test_returns_unchanged_for_existing_not_updated(self, manager):
+        action = manager._determine_action("existing123", "2024-01-01T12:00:00Z", force=False)
+        assert action == "unchanged"
+
+    def test_returns_updated_when_cloud_is_newer(self, manager):
+        action = manager._determine_action("existing123", "2024-01-02T12:00:00Z", force=False)
+        assert action == "updated"
+
+    def test_returns_updated_when_force_true(self, manager):
+        action = manager._determine_action("existing123", "2024-01-01T12:00:00Z", force=True)
+        assert action == "updated"
+
+
+class TestSyncManagerMaxNew:
+    """Tests for max_new limiting behavior."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.api_key = "test-key"
+        config.cloud_api_url = "https://example.com"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            mgr = SyncManager(config)
+            # Pre-populate manifest with one existing conversation
+            mgr.manifest.conversations = {
+                "existing001": {
+                    "title": "Existing",
+                    "updated_at": "2024-01-01T12:00:00Z",
+                }
+            }
+            return mgr
+
+    def test_sync_one_skips_new_when_limit_reached(self, manager):
+        """Test that new conversations are skipped when max_new limit is reached."""
+        result = SyncResult(new=5)  # Already at limit
+        
+        conv = {"id": "newconv123", "updated_at": "2024-01-02T12:00:00Z", "title": "New Conv"}
+        
+        action = manager._sync_one(
+            client=MagicMock(),
+            conv=conv,
+            force=False,
+            dry_run=False,
+            max_new=5,  # Limit already reached
+            on_progress=None,
+            result=result,
+        )
+        
+        assert action == "skipped"
+
+    def test_sync_one_allows_new_when_under_limit(self, manager):
+        """Test that new conversations are allowed when under max_new limit."""
+        result = SyncResult(new=2)  # Under limit
+        
+        conv = {"id": "newconv123", "updated_at": "2024-01-02T12:00:00Z", "title": "New Conv"}
+        
+        # Mock the download to succeed
+        mock_client = MagicMock()
+        mock_client.download_trajectory.return_value = _create_minimal_zip()
+        
+        action = manager._sync_one(
+            client=mock_client,
+            conv=conv,
+            force=False,
+            dry_run=False,
+            max_new=5,  # Still under limit
+            on_progress=None,
+            result=result,
+        )
+        
+        assert action == "new"
+
+    def test_sync_one_allows_updates_regardless_of_limit(self, manager):
+        """Test that updates are always allowed, even when max_new limit is reached."""
+        result = SyncResult(new=5)  # At new limit
+        
+        conv = {"id": "existing001", "updated_at": "2024-01-02T12:00:00Z", "title": "Updated"}
+        
+        # Mock the download to succeed
+        mock_client = MagicMock()
+        mock_client.download_trajectory.return_value = _create_minimal_zip()
+        
+        action = manager._sync_one(
+            client=mock_client,
+            conv=conv,
+            force=False,
+            dry_run=False,
+            max_new=5,  # Limit reached, but this is an update
+            on_progress=None,
+            result=result,
+        )
+        
+        assert action == "updated"
+
+
+class TestSyncManagerFinalizeSync:
+    """Tests for SyncManager._finalize_sync method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.api_key = "test-key"
+        
+        manifest_path = tmp_path / "manifest.json"
+        with patch("ohtv.sync.get_manifest_path", return_value=manifest_path):
+            return SyncManager(config)
+
+    def test_advances_cutoff_when_no_skipped(self, manager):
+        """Test that last_sync_at is updated when no conversations were skipped."""
+        result = SyncResult(new=3, updated=2, skipped_new=0, failed=0)
+        
+        manager._finalize_sync(result)
+        
+        assert manager.manifest.last_sync_at is not None
+
+    def test_does_not_advance_cutoff_when_skipped(self, manager):
+        """Test that last_sync_at is NOT updated when conversations were skipped."""
+        result = SyncResult(new=3, skipped_new=5, failed=0)
+        
+        manager._finalize_sync(result)
+        
+        assert manager.manifest.last_sync_at is None
+
+    def test_does_not_advance_cutoff_when_failed(self, manager):
+        """Test that last_sync_at is NOT updated when there were failures."""
+        result = SyncResult(new=3, failed=1)
+        
+        manager._finalize_sync(result)
+        
+        assert manager.manifest.last_sync_at is None
+
+    def test_increments_sync_count(self, manager):
+        """Test that sync_count is always incremented."""
+        assert manager.manifest.sync_count == 0
+        
+        result = SyncResult(new=1)
+        manager._finalize_sync(result)
+        
+        assert manager.manifest.sync_count == 1
+
+
+class TestSyncManagerCleanup:
+    """Tests for SyncManager._cleanup_conversation_dir method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.api_key = "test-key"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_removes_existing_directory(self, manager):
+        """Test that existing conversation directory is removed."""
+        conv_dir = manager.config.synced_conversations_dir / "conv123"
+        conv_dir.mkdir(parents=True)
+        (conv_dir / "events").mkdir()
+        (conv_dir / "events" / "event-00001-abc.json").write_text("{}")
+        
+        manager._cleanup_conversation_dir("conv123")
+        
+        assert not conv_dir.exists()
+
+    def test_handles_nonexistent_directory(self, manager):
+        """Test that cleanup doesn't fail for nonexistent directory."""
+        # Should not raise
+        manager._cleanup_conversation_dir("nonexistent123")
+
+
+class TestSyncManagerGetLocalConversationCount:
+    """Tests for SyncManager.get_local_conversation_count method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.api_key = "test-key"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_returns_zero_for_empty_manifest(self, manager):
+        assert manager.get_local_conversation_count() == 0
+
+    def test_returns_count_from_manifest(self, manager):
+        manager.manifest.conversations = {
+            "conv1": {},
+            "conv2": {},
+            "conv3": {},
+        }
+        assert manager.get_local_conversation_count() == 3
+
+
+def _create_minimal_zip() -> bytes:
+    """Create a minimal valid trajectory zip file."""
+    import io
+    import zipfile
+    
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("meta.json", json.dumps({
+            "id": "test123",
+            "title": "Test",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+        }))
+        zf.writestr("event_000001_abc.json", json.dumps({
+            "id": "abc",
+            "kind": "MessageEvent",
+        }))
+    return buffer.getvalue()


### PR DESCRIPTION
## Summary

This PR adds the ability to limit the number of NEW conversations synced from cloud, while always allowing updates to existing conversations.

## Features

- **New `-n`/`--max-new` option**: Limits only new conversations (updates to existing conversations are always synced)
- **Skipped tracking**: When the limit is reached, skipped conversations are tracked and `last_sync_at` is NOT advanced (ensures skipped conversations remain visible on next sync)
- **`--force` cleanup**: `--force` now cleans local directory before re-download, preventing stale event data
- **`--force -n` combination**: Resets local storage to only the N most recent conversations (with confirmation prompt)

## Usage Examples

```bash
# Sync at most 5 new conversations (updates to existing always sync)
ohtv sync -n 5

# Dry run to see what would sync
ohtv sync -n 5 --dry-run

# Reset to only the 10 most recent conversations (destructive, requires confirmation)
ohtv sync --force -n 10
```

## Evidence

### Manual Testing Against OpenHands Cloud (2026-04-15)

**Test 1: Dry-run with -n limit**
```
$ OH_API_KEY=**** uv run ohtv sync -n 5 --dry-run
DRY RUN Syncing cloud conversations (max 5 new)...
  b5733dc ✅ Manual Testing ohtv PR #11 -n/--max-ne... (new)
  04d381e Conversation 04d38... (new)
  bcb38bc Conversation bcb38... (new)
  01f5375 Conversation 01f53... (new)
  a66b4f1 ✨ Add -n flag to limit sync conversation... (new)
  427d5b0 Conversation 427d5... (skipped)
  6f7d34b 🔧 Review PR #77 Code & Assessment Feedba... (skipped)
  1be3bd7 📝 Generic POC Success Criteria Template... (skipped)
  ... (783 more skipped)
```
✅ First 5 conversations marked as "(new)", rest marked as "(skipped)"

**Test 2: Actual sync with -n limit**
```
$ OH_API_KEY=**** uv run ohtv sync -n 2 -v
Syncing cloud conversations (max 2 new)...
2026-04-15 23:47:03 INFO Starting sync (force=False, cutoff=None, dry_run=False, max_new=2)
2026-04-15 23:47:05 INFO Found 787 conversations to process
2026-04-15 23:47:05 DEBUG Downloading b5733dc0e34e453a8a2b73018fc79033
2026-04-15 23:47:05 DEBUG Downloaded b5733dc0e34e453a8a2b73018fc79033 (new)
  b5733dc ✅ Manual Testing ohtv PR #11 -n/--max-ne... (new)
2026-04-15 23:47:05 DEBUG Downloading 04d381e055cd40a0a17c87725a0be033
2026-04-15 23:47:06 DEBUG Downloaded 04d381e055cd40a0a17c87725a0be033 (new)
  04d381e Conversation 04d38... (new)
  bcb38bc Conversation bcb38... (skipped)
  ... (785 more skipped)
2026-04-15 23:47:06 INFO Sync complete. Synced 2 new, 785 additional available. Not advancing cutoff so skipped conversations remain visible.

Sync complete:
  New:       2
  Updated:   0
  Unchanged: 0
  Skipped:   785 additional available
```
✅ Only 2 conversations downloaded, cutoff NOT advanced so skipped remain visible

**Test 3: Verify skipped conversations appear on next sync**
```
$ OH_API_KEY=**** uv run ohtv sync -n 5 --dry-run
DRY RUN Syncing cloud conversations (max 5 new)...
  b5733dc ✅ Manual Testing ohtv PR #11 -n/--max-ne... (unchanged)
  04d381e Conversation 04d38... (unchanged)
  bcb38bc Conversation bcb38... (new)
  01f5375 Conversation 01f53... (new)
  a66b4f1 ✨ Add -n flag to limit sync conversation... (new)
  427d5b0 Conversation 427d5... (new)
  6f7d34b 🔧 Review PR #77 Code & Assessment Feedba... (new)
  1be3bd7 📝 Generic POC Success Criteria Template... (skipped)
  ... (779 more skipped)
```
✅ Previously synced conversations show "(unchanged)"
✅ Previously skipped conversations now eligible as "(new)" 
✅ New -n limit applies to remaining new conversations

**Manifest verification (last_sync_at not advanced):**
```json
{
  "last_sync_at": null,
  "sync_count": 1,
  "conversations": {
    "b5733dc0e34e453a8a2b73018fc79033": {
      "title": "✅ Manual Testing ohtv PR #11 -n/--max-new",
      "updated_at": "2026-04-15T23:43:41.346103Z",
      "event_count": 75,
      "downloaded_at": "2026-04-15T23:47:05Z"
    },
    "04d381e055cd40a0a17c87725a0be033": {
      "title": "Conversation 04d38",
      "updated_at": "2026-04-15T23:27:53.886475Z",
      "event_count": 31,
      "downloaded_at": "2026-04-15T23:47:06Z"
    }
  },
  "failed_ids": []
}
```
✅ `last_sync_at: null` - cutoff not advanced because conversations were skipped

### Summary of Verified Behaviors

| Behavior | Status |
|----------|--------|
| `-n 5` limits sync to at most 5 NEW conversations | ✅ |
| Updates to existing conversations always sync (no limit) | ✅ |
| Skipped conversations show "(skipped)" status | ✅ |
| `last_sync_at` NOT advanced when conversations are skipped | ✅ |
| Skipped conversations remain visible on subsequent syncs | ✅ |

## Changes

- `sync.py`: Add `max_new` parameter, `skipped_new` tracking, cleanup logic, `reset_to_n_newest` method
- `cli.py`: Add `-n` option, progress/result display for skipped, `--force -n` confirmation handling
- `tests/unit/test_sync.py`: 28 new tests for sync module

## Tests

All 272 tests pass (244 original + 28 new).

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*
