### PR TITLE
Phase 2: Content Restructure - Add YAML frontmatter and family directories

### DIFF
--- a/src/ohtv/prompts/code_review/default.md
+++ b/src/ohtv/prompts/code_review/default.md
@@ -1,0 +1,63 @@
+---
+id: code_review.default
+description: Analyze code changes made during the conversation
+default: true
+
+context:
+  default: 1
+  levels:
+    1:
+      name: edits_only
+      include:
+        - source: agent
+          kind: ActionEvent
+          tool: file_editor
+    2:
+      name: with_commands
+      include:
+        - source: agent
+          kind: ActionEvent
+          tool: file_editor
+        - source: agent
+          kind: ActionEvent
+          tool: terminal
+      truncate: 500
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 300
+
+output:
+  schema:
+    type: object
+    required: [changes]
+    properties:
+      changes:
+        type: array
+        items:
+          type: object
+          properties:
+            file:
+              type: string
+            action:
+              type: string
+            summary:
+              type: string
+---
+Analyze the code changes made in this conversation.
+
+For each file modified, identify:
+- The file path
+- Whether it was created, edited, or deleted
+- A brief summary of the change
+
+Respond with JSON:
+{
+  "changes": [
+    {"file": "path/to/file.py", "action": "edit", "summary": "Added error handling"}
+  ]
+}

--- a/src/ohtv/prompts/code_review/default.md
+++ b/src/ohtv/prompts/code_review/default.md
@@ -7,13 +7,14 @@ context:
   default: 1
   levels:
     1:
-      name: edits_only
+      name: minimal
       include:
         - source: agent
           kind: ActionEvent
           tool: file_editor
+      truncate: 500
     2:
-      name: with_commands
+      name: standard
       include:
         - source: agent
           kind: ActionEvent
@@ -21,7 +22,7 @@ context:
         - source: agent
           kind: ActionEvent
           tool: terminal
-      truncate: 500
+      truncate: 1000
     3:
       name: full
       include:
@@ -29,7 +30,7 @@ context:
           kind: MessageEvent
         - source: agent
           kind: ActionEvent
-      truncate: 300
+      truncate: 2000
 
 output:
   schema:

--- a/src/ohtv/prompts/objectives/brief.md
+++ b/src/ohtv/prompts/objectives/brief.md
@@ -11,14 +11,16 @@ context:
       include:
         - source: user
           kind: MessageEvent
+      truncate: 500
     2:
-      name: default
+      name: standard
       include:
         - source: user
           kind: MessageEvent
         - source: agent
           kind: ActionEvent
           tool: finish
+      truncate: 1000
     3:
       name: full
       include:
@@ -28,7 +30,7 @@ context:
           kind: MessageEvent
         - source: agent
           kind: ActionEvent
-      truncate: 1000
+      truncate: 2000
 
 output:
   schema:

--- a/src/ohtv/prompts/objectives/brief.md
+++ b/src/ohtv/prompts/objectives/brief.md
@@ -1,0 +1,48 @@
+---
+id: objectives.brief
+description: Extract user goal in 1-2 sentences
+default: true
+
+context:
+  default: 1
+  levels:
+    1:
+      name: minimal
+      include:
+        - source: user
+          kind: MessageEvent
+    2:
+      name: default
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+          tool: finish
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 1000
+
+output:
+  schema:
+    type: object
+    required: [goal]
+    properties:
+      goal:
+        type: string
+---
+Analyze this conversation between a user and an AI coding assistant.
+
+In 1-2 sentences, describe the user's goal using imperative mood (e.g., "Add pagination to search results" not "The user wants to add pagination").
+
+Do not assess whether the goal was achieved. Just identify what they want.
+
+Respond with JSON:
+{"goal": "1-2 sentence description in imperative mood"}

--- a/src/ohtv/prompts/objectives/brief_assess.md
+++ b/src/ohtv/prompts/objectives/brief_assess.md
@@ -1,0 +1,63 @@
+---
+id: objectives.brief_assess
+description: Extract user goal and assess completion status
+
+context:
+  default: 2
+  levels:
+    1:
+      name: minimal
+      include:
+        - source: user
+          kind: MessageEvent
+    2:
+      name: default
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+          tool: finish
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 1000
+
+output:
+  schema:
+    type: object
+    required: [goal, status]
+    properties:
+      goal:
+        type: string
+      status:
+        type: string
+        enum: [achieved, not_achieved, in_progress]
+---
+Analyze this conversation between a user and an AI coding assistant.
+
+1. In 1-2 sentences, describe: What outcome does the user hope to achieve?
+2. Assess whether the goal was achieved.
+
+ASSESSMENT APPROACH: Be optimistic and decisive.
+- Assume SUCCESS unless there is clear evidence of failure
+- Failure signals: user frustration, requests to retry followed by giving up,
+  explicit errors that weren't resolved, negative feedback
+- Do NOT use "partially achieved" - decide achieved or not achieved
+
+Status values:
+- achieved: Goal was accomplished (default assumption unless failure signals present)
+- not_achieved: Clear evidence of failure (errors, user frustration, giving up)
+- in_progress: Conversation ended mid-work with no conclusion
+
+Respond with JSON:
+{
+  "goal": "1-2 sentence description of what the user wants to accomplish",
+  "status": "achieved|not_achieved|in_progress"
+}

--- a/src/ohtv/prompts/objectives/detailed.md
+++ b/src/ohtv/prompts/objectives/detailed.md
@@ -1,0 +1,75 @@
+---
+id: objectives.detailed
+description: Extract hierarchical objectives with subordinate goals
+
+context:
+  default: 3
+  levels:
+    1:
+      name: minimal
+      include:
+        - source: user
+          kind: MessageEvent
+    2:
+      name: default
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+          tool: finish
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 1000
+
+output:
+  schema:
+    type: object
+    required: [primary_objectives, summary]
+    properties:
+      primary_objectives:
+        type: array
+        items:
+          type: object
+          required: [description, subordinates]
+          properties:
+            description:
+              type: string
+            subordinates:
+              type: array
+              items:
+                type: object
+      summary:
+        type: string
+---
+You are an expert at analyzing software development conversations to identify user objectives.
+
+Given a conversation between a user and an AI coding assistant, identify:
+1. PRIMARY OBJECTIVES: The main goals the user is trying to accomplish
+2. SUBORDINATE OBJECTIVES: Supporting goals that help achieve the primary ones
+
+Do not assess whether objectives were achieved. Just identify what the user wants to accomplish
+and structure them hierarchically.
+
+Respond with a JSON object in this exact format:
+{
+  "primary_objectives": [
+    {
+      "description": "Clear description of the objective",
+      "subordinates": [
+        {
+          "description": "Description of subordinate objective",
+          "subordinates": []
+        }
+      ]
+    }
+  ],
+  "summary": "Brief overall summary of what the user was trying to accomplish"
+}

--- a/src/ohtv/prompts/objectives/detailed_assess.md
+++ b/src/ohtv/prompts/objectives/detailed_assess.md
@@ -1,0 +1,94 @@
+---
+id: objectives.detailed_assess
+description: Extract hierarchical objectives and assess completion status
+
+context:
+  default: 3
+  levels:
+    1:
+      name: minimal
+      include:
+        - source: user
+          kind: MessageEvent
+    2:
+      name: default
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+          tool: finish
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 1000
+
+output:
+  schema:
+    type: object
+    required: [primary_objectives, summary]
+    properties:
+      primary_objectives:
+        type: array
+        items:
+          type: object
+          required: [description, status, evidence, subordinates]
+          properties:
+            description:
+              type: string
+            status:
+              type: string
+              enum: [achieved, not_achieved, in_progress]
+            evidence:
+              type: string
+            subordinates:
+              type: array
+              items:
+                type: object
+      summary:
+        type: string
+---
+You are an expert at analyzing software development conversations to identify user objectives.
+
+Given a conversation between a user and an AI coding assistant, identify:
+1. PRIMARY OBJECTIVES: The main goals the user is trying to accomplish
+2. SUBORDINATE OBJECTIVES: Supporting goals that help achieve the primary ones
+
+ASSESSMENT APPROACH: Be optimistic and decisive.
+- Assume SUCCESS unless there is clear evidence of failure
+- Failure signals: user frustration, requests to retry followed by giving up,
+  explicit errors that weren't resolved, negative feedback
+- Do NOT use "partially achieved" - decide achieved or not achieved
+
+For each objective, assess its status:
+- achieved: Objective was accomplished (default assumption unless failure signals present)
+- not_achieved: Clear evidence of failure (errors, user frustration, giving up)
+- in_progress: Work is ongoing with no conclusion yet
+
+Provide brief evidence from the conversation to support your assessment.
+
+Respond with a JSON object in this exact format:
+{
+  "primary_objectives": [
+    {
+      "description": "Clear description of the objective",
+      "status": "achieved|not_achieved|in_progress",
+      "evidence": "Brief quote or reference from conversation",
+      "subordinates": [
+        {
+          "description": "Description of subordinate objective",
+          "status": "status",
+          "evidence": "evidence",
+          "subordinates": []
+        }
+      ]
+    }
+  ],
+  "summary": "Brief overall summary of what the user was trying to accomplish"
+}

--- a/src/ohtv/prompts/objectives/standard.md
+++ b/src/ohtv/prompts/objectives/standard.md
@@ -1,0 +1,62 @@
+---
+id: objectives.standard
+description: Extract primary and secondary outcomes
+
+context:
+  default: 2
+  levels:
+    1:
+      name: minimal
+      include:
+        - source: user
+          kind: MessageEvent
+    2:
+      name: default
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+          tool: finish
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 1000
+
+output:
+  schema:
+    type: object
+    required: [goal, primary_outcomes, secondary_outcomes]
+    properties:
+      goal:
+        type: string
+      primary_outcomes:
+        type: array
+        items:
+          type: string
+      secondary_outcomes:
+        type: array
+        items:
+          type: string
+---
+Analyze this conversation between a user and an AI coding assistant.
+
+Identify:
+1. The user's primary goal (1-2 sentences)
+2. Primary outcomes or success criteria (3-6 bullets max)
+3. Secondary outcomes if any (3-6 bullets max)
+
+Do not assess whether goals were achieved. Just identify what the user wants.
+
+Respond with JSON:
+{
+  "goal": "1-2 sentence description of the primary goal",
+  "primary_outcomes": ["outcome 1", "outcome 2"],
+  "secondary_outcomes": ["outcome 1", "outcome 2"]
+}

--- a/src/ohtv/prompts/objectives/standard_assess.md
+++ b/src/ohtv/prompts/objectives/standard_assess.md
@@ -1,0 +1,76 @@
+---
+id: objectives.standard_assess
+description: Extract primary and secondary outcomes and assess completion
+
+context:
+  default: 2
+  levels:
+    1:
+      name: minimal
+      include:
+        - source: user
+          kind: MessageEvent
+    2:
+      name: default
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+          tool: finish
+    3:
+      name: full
+      include:
+        - source: user
+          kind: MessageEvent
+        - source: agent
+          kind: MessageEvent
+        - source: agent
+          kind: ActionEvent
+      truncate: 1000
+
+output:
+  schema:
+    type: object
+    required: [goal, status, primary_outcomes, secondary_outcomes]
+    properties:
+      goal:
+        type: string
+      status:
+        type: string
+        enum: [achieved, not_achieved, in_progress]
+      primary_outcomes:
+        type: array
+        items:
+          type: string
+      secondary_outcomes:
+        type: array
+        items:
+          type: string
+---
+Analyze this conversation between a user and an AI coding assistant.
+
+Identify:
+1. The user's primary goal (1-2 sentences)
+2. Primary outcomes or success criteria (3-6 bullets max)
+3. Secondary outcomes if any (3-6 bullets max)
+4. Overall status of goal achievement
+
+ASSESSMENT APPROACH: Be optimistic and decisive.
+- Assume SUCCESS unless there is clear evidence of failure
+- Failure signals: user frustration, requests to retry followed by giving up,
+  explicit errors that weren't resolved, negative feedback
+- Do NOT use "partially achieved" - decide achieved or not achieved
+
+Status values:
+- achieved: Goal was accomplished (default assumption unless failure signals present)
+- not_achieved: Clear evidence of failure (errors, user frustration, giving up)
+- in_progress: Conversation ended mid-work with no conclusion
+
+Respond with JSON:
+{
+  "goal": "1-2 sentence description of the primary goal",
+  "status": "achieved|not_achieved|in_progress",
+  "primary_outcomes": ["outcome 1", "outcome 2"],
+  "secondary_outcomes": ["outcome 1", "outcome 2"]
+}


### PR DESCRIPTION
## Overview

This PR implements Phase 2 of the extensible prompts feature as described in .

## Changes

### Directory Structure
- Created `src/ohtv/prompts/objectives/` directory for objective analysis prompts
- Created `src/ohtv/prompts/code_review/` directory with example prompt

### Prompt Files
All 6 existing objective prompts have been moved to the objectives directory with YAML frontmatter:

1. **brief.md** (marked as default variant)
   - ID: `objectives.brief`
   - Context default: level 1 (minimal)
   
2. **brief_assess.md**
   - ID: `objectives.brief_assess`
   - Context default: level 2 (with finish action)
   
3. **standard.md**
   - ID: `objectives.standard`
   - Context default: level 2
   
4. **standard_assess.md**
   - ID: `objectives.standard_assess`
   - Context default: level 2
   
5. **detailed.md**
   - ID: `objectives.detailed`
   - Context default: level 3 (full context)
   
6. **detailed_assess.md**
   - ID: `objectives.detailed_assess`
   - Context default: level 3

### Frontmatter Structure
Each prompt includes:
- `id`: family.variant pattern
- `description`: Brief description of the prompt's purpose
- `default`: Boolean flag (only on brief.md)
- `context.default`: Default context level
- `context.levels`: Three standard levels (minimal, default, full)
- `output.schema`: JSON schema for response validation

### Context Levels
All prompts use standardized context levels:
- **Level 1 (minimal)**: User messages only
- **Level 2 (default)**: User messages + finish action
- **Level 3 (full)**: User + agent messages + all actions (truncated to 1000 chars)

### Example Prompt
- Created `code_review/default.md` as an example of extensibility

## Validation
✅ All YAML frontmatter validated successfully
✅ Original prompt text content preserved exactly
✅ All 6 prompts in objectives directory
✅ brief.md marked as default variant

## Notes
- Original files remain in place (will be removed in Phase 3)
- This is a content-only change with no Python code modifications
- Ready for Phase 1 integration

## Related
- Design doc: `.pr/phase2-content-restructure.md`
- Base branch: `feature/extensible-prompts`