### PR TITLE
Phase 1: Frontmatter Infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "click>=8.0",
     "httpx>=0.27",
     "openhands-sdk>=1.16.1",
+    "pyyaml>=6.0",
     "rich>=13.0",
 ]
 

--- a/src/ohtv/prompts/metadata.py
+++ b/src/ohtv/prompts/metadata.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+@dataclass
+class EventFilter:
+    """Filter for matching events in context level definitions."""
+    source: Literal["user", "agent", "*"] = "*"
+    kind: Literal["MessageEvent", "ActionEvent", "ErrorEvent", "*"] = "*"
+    tool: str | None = None
+
+    def matches(self, event: dict) -> bool:
+        """Check if this filter matches an event.
+        
+        Args:
+            event: Event dict with 'source', 'kind', and optionally 'tool' fields
+            
+        Returns:
+            True if event matches this filter, False otherwise
+        """
+        if self.source != "*" and event.get("source") != self.source:
+            return False
+        
+        if self.kind != "*" and event.get("kind") != self.kind:
+            return False
+        
+        if self.tool is not None:
+            if event.get("kind") != "ActionEvent":
+                return False
+            if event.get("tool") != self.tool:
+                return False
+        
+        return True
+
+
+@dataclass
+class ContextLevel:
+    """A context level definition from prompt frontmatter."""
+    number: int
+    name: str
+    include: list[EventFilter]
+    exclude: list[EventFilter] = field(default_factory=list)
+    truncate: int = 0
+
+    def matches(self, event: dict) -> bool:
+        """Check if event should be included at this context level.
+        
+        Match if ANY include filter matches AND NO exclude filter matches.
+        
+        Args:
+            event: Event dict to match against
+            
+        Returns:
+            True if event should be included at this level, False otherwise
+        """
+        if not any(f.matches(event) for f in self.include):
+            return False
+        
+        if any(f.matches(event) for f in self.exclude):
+            return False
+        
+        return True
+
+
+@dataclass
+class PromptMetadata:
+    """Metadata parsed from prompt file frontmatter."""
+    id: str
+    family: str
+    variant: str
+    description: str = ""
+    default: bool = False
+    context_levels: dict[int, ContextLevel] = field(default_factory=dict)
+    default_context: int = 1
+    output_schema: dict | None = None
+    handler: str | None = None
+    tags: list[str] = field(default_factory=list)
+    path: Path | None = None
+    content: str = ""
+    content_hash: str = ""
+
+    def get_context_level(self, level: int | str) -> ContextLevel:
+        """Get context level by number or name.
+        
+        Args:
+            level: Context level number or name
+            
+        Returns:
+            ContextLevel matching the given number or name
+            
+        Raises:
+            ValueError: If level not found
+        """
+        if isinstance(level, int):
+            if level not in self.context_levels:
+                raise ValueError(f"Unknown context level: {level}")
+            return self.context_levels[level]
+        
+        for ctx in self.context_levels.values():
+            if ctx.name == level:
+                return ctx
+        
+        raise ValueError(f"Unknown context level: {level}")

--- a/src/ohtv/prompts/parser.py
+++ b/src/ohtv/prompts/parser.py
@@ -1,0 +1,120 @@
+import hashlib
+import yaml
+from pathlib import Path
+from ohtv.prompts.metadata import EventFilter, ContextLevel, PromptMetadata
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Split content into YAML frontmatter dict and remaining content.
+    
+    Args:
+        content: Full file content
+        
+    Returns:
+        Tuple of (frontmatter dict, remaining content)
+        Returns ({}, content) if no frontmatter present
+    """
+    if not content.startswith("---\n"):
+        return {}, content
+    
+    parts = content.split("---\n", 2)
+    if len(parts) < 3:
+        return {}, content
+    
+    try:
+        frontmatter = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return {}, content
+    
+    return frontmatter, parts[2]
+
+
+def parse_event_filter(data: dict) -> EventFilter:
+    """Parse an event filter from frontmatter data.
+    
+    Args:
+        data: Dict with optional 'source', 'kind', and 'tool' keys
+        
+    Returns:
+        EventFilter instance
+    """
+    return EventFilter(
+        source=data.get("source", "*"),
+        kind=data.get("kind", "*"),
+        tool=data.get("tool")
+    )
+
+
+def parse_context_level(number: int, data: dict) -> ContextLevel:
+    """Parse a context level definition from frontmatter data.
+    
+    Args:
+        number: Context level number
+        data: Dict with 'name', 'include', and optional 'exclude' and 'truncate' keys
+        
+    Returns:
+        ContextLevel instance
+    """
+    include = [parse_event_filter(f) for f in data.get("include", [])]
+    exclude = [parse_event_filter(f) for f in data.get("exclude", [])]
+    
+    return ContextLevel(
+        number=number,
+        name=data.get("name", ""),
+        include=include,
+        exclude=exclude,
+        truncate=data.get("truncate", 0)
+    )
+
+
+def parse_prompt_file(path: Path) -> PromptMetadata:
+    """Parse a prompt file and extract metadata from YAML frontmatter.
+    
+    Args:
+        path: Path to the prompt .md file
+        
+    Returns:
+        PromptMetadata with parsed frontmatter and content
+        
+    The frontmatter should be YAML between --- delimiters at the start of the file.
+    If no frontmatter, returns metadata with defaults inferred from path.
+    """
+    content = path.read_text()
+    frontmatter, prompt_content = parse_frontmatter(content)
+    
+    # Infer family/variant from path if not in frontmatter
+    # e.g., prompts/objectives/brief.md -> family="objectives", variant="brief"
+    # or prompts/brief.md -> family="default", variant="brief"
+    stem = path.stem
+    parent = path.parent.name if path.parent.name != "prompts" else "default"
+    
+    family = frontmatter.get("family", parent)
+    variant = frontmatter.get("variant", stem)
+    prompt_id = frontmatter.get("id", f"{family}.{variant}")
+    
+    # Parse context levels
+    context_levels = {}
+    if "context_levels" in frontmatter:
+        for level_data in frontmatter["context_levels"]:
+            number = level_data.get("number")
+            if number is not None:
+                context_levels[number] = parse_context_level(number, level_data)
+    
+    # Compute content hash
+    content_hash = hashlib.sha256(prompt_content.encode()).hexdigest()[:16]
+    
+    return PromptMetadata(
+        id=prompt_id,
+        family=family,
+        variant=variant,
+        description=frontmatter.get("description", ""),
+        default=frontmatter.get("default", False),
+        context_levels=context_levels,
+        default_context=frontmatter.get("default_context", 1),
+        output_schema=frontmatter.get("output_schema"),
+        handler=frontmatter.get("handler"),
+        tags=frontmatter.get("tags", []),
+        path=path,
+        content=prompt_content,
+        content_hash=content_hash
+    )

--- a/tests/unit/prompts/test_metadata.py
+++ b/tests/unit/prompts/test_metadata.py
@@ -1,0 +1,169 @@
+import pytest
+from ohtv.prompts.metadata import EventFilter, ContextLevel, PromptMetadata
+
+
+class TestEventFilter:
+    """Tests for EventFilter.matches()"""
+    
+    def test_wildcard_matches_everything(self):
+        """Test that default wildcard filter matches any event"""
+        f = EventFilter()
+        assert f.matches({"source": "user", "kind": "MessageEvent"})
+        assert f.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+        assert f.matches({"source": "user", "kind": "ErrorEvent"})
+    
+    def test_source_filter(self):
+        """Test filtering by source"""
+        f = EventFilter(source="user")
+        assert f.matches({"source": "user", "kind": "MessageEvent"})
+        assert not f.matches({"source": "agent", "kind": "MessageEvent"})
+    
+    def test_kind_filter(self):
+        """Test filtering by kind"""
+        f = EventFilter(kind="MessageEvent")
+        assert f.matches({"source": "user", "kind": "MessageEvent"})
+        assert not f.matches({"source": "user", "kind": "ActionEvent", "tool": "terminal"})
+    
+    def test_tool_filter_requires_action_event(self):
+        """Test that tool filter only matches ActionEvent"""
+        f = EventFilter(tool="finish")
+        assert not f.matches({"source": "agent", "kind": "MessageEvent", "tool": "finish"})
+        assert f.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+    
+    def test_tool_filter_with_specific_tool(self):
+        """Test that tool filter matches specific tool name"""
+        f = EventFilter(tool="terminal")
+        assert f.matches({"source": "agent", "kind": "ActionEvent", "tool": "terminal"})
+        assert not f.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+    
+    def test_combined_filters(self):
+        """Test combining multiple filter criteria"""
+        f = EventFilter(source="agent", kind="ActionEvent", tool="terminal")
+        assert f.matches({"source": "agent", "kind": "ActionEvent", "tool": "terminal"})
+        assert not f.matches({"source": "user", "kind": "ActionEvent", "tool": "terminal"})
+        assert not f.matches({"source": "agent", "kind": "MessageEvent", "tool": "terminal"})
+        assert not f.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+    
+    def test_wildcard_source_with_specific_kind(self):
+        """Test wildcard source with specific kind"""
+        f = EventFilter(source="*", kind="MessageEvent")
+        assert f.matches({"source": "user", "kind": "MessageEvent"})
+        assert f.matches({"source": "agent", "kind": "MessageEvent"})
+        assert not f.matches({"source": "user", "kind": "ActionEvent", "tool": "finish"})
+
+
+class TestContextLevel:
+    """Tests for ContextLevel.matches()"""
+    
+    def test_include_any_matches(self):
+        """Test that ANY include filter matching causes inclusion"""
+        ctx = ContextLevel(
+            number=1,
+            name="test",
+            include=[
+                EventFilter(kind="MessageEvent"),
+                EventFilter(kind="ErrorEvent")
+            ]
+        )
+        assert ctx.matches({"source": "user", "kind": "MessageEvent"})
+        assert ctx.matches({"source": "agent", "kind": "ErrorEvent"})
+        assert not ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+    
+    def test_exclude_overrides_include(self):
+        """Test that exclude filters override include filters"""
+        ctx = ContextLevel(
+            number=1,
+            name="test",
+            include=[EventFilter()],  # Match everything
+            exclude=[EventFilter(kind="ActionEvent")]
+        )
+        assert ctx.matches({"source": "user", "kind": "MessageEvent"})
+        assert not ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+    
+    def test_no_include_matches_means_no_match(self):
+        """Test that if no include filter matches, event is excluded"""
+        ctx = ContextLevel(
+            number=1,
+            name="test",
+            include=[EventFilter(kind="MessageEvent")]
+        )
+        assert not ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+    
+    def test_specific_tool_inclusion(self):
+        """Test including only specific tool actions"""
+        ctx = ContextLevel(
+            number=1,
+            name="test",
+            include=[EventFilter(kind="ActionEvent", tool="finish")]
+        )
+        assert ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+        assert not ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "terminal"})
+    
+    def test_complex_include_exclude(self):
+        """Test complex include/exclude combination"""
+        ctx = ContextLevel(
+            number=2,
+            name="selective",
+            include=[
+                EventFilter(kind="MessageEvent"),
+                EventFilter(kind="ActionEvent")
+            ],
+            exclude=[
+                EventFilter(kind="ActionEvent", tool="terminal")
+            ]
+        )
+        assert ctx.matches({"source": "user", "kind": "MessageEvent"})
+        assert ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "finish"})
+        assert not ctx.matches({"source": "agent", "kind": "ActionEvent", "tool": "terminal"})
+
+
+class TestPromptMetadata:
+    """Tests for PromptMetadata.get_context_level()"""
+    
+    def test_get_context_level_by_number(self):
+        """Test getting context level by number"""
+        ctx1 = ContextLevel(1, "minimal", [EventFilter()])
+        ctx2 = ContextLevel(2, "full", [EventFilter()])
+        meta = PromptMetadata(
+            id="test.brief",
+            family="test",
+            variant="brief",
+            context_levels={1: ctx1, 2: ctx2}
+        )
+        assert meta.get_context_level(1) == ctx1
+        assert meta.get_context_level(2) == ctx2
+    
+    def test_get_context_level_by_name(self):
+        """Test getting context level by name"""
+        ctx1 = ContextLevel(1, "minimal", [EventFilter()])
+        ctx2 = ContextLevel(2, "full", [EventFilter()])
+        meta = PromptMetadata(
+            id="test.brief",
+            family="test",
+            variant="brief",
+            context_levels={1: ctx1, 2: ctx2}
+        )
+        assert meta.get_context_level("minimal") == ctx1
+        assert meta.get_context_level("full") == ctx2
+    
+    def test_get_context_level_unknown_number(self):
+        """Test that unknown number raises ValueError"""
+        meta = PromptMetadata(
+            id="test.brief",
+            family="test",
+            variant="brief",
+            context_levels={}
+        )
+        with pytest.raises(ValueError, match="Unknown context level: 1"):
+            meta.get_context_level(1)
+    
+    def test_get_context_level_unknown_name(self):
+        """Test that unknown name raises ValueError"""
+        meta = PromptMetadata(
+            id="test.brief",
+            family="test",
+            variant="brief",
+            context_levels={}
+        )
+        with pytest.raises(ValueError, match="Unknown context level: minimal"):
+            meta.get_context_level("minimal")

--- a/tests/unit/prompts/test_parser.py
+++ b/tests/unit/prompts/test_parser.py
@@ -1,0 +1,326 @@
+import pytest
+from pathlib import Path
+from ohtv.prompts.parser import (
+    parse_frontmatter,
+    parse_event_filter,
+    parse_context_level,
+    parse_prompt_file
+)
+from ohtv.prompts.metadata import EventFilter, ContextLevel
+
+
+class TestParseFrontmatter:
+    """Tests for parse_frontmatter()"""
+    
+    def test_valid_frontmatter(self):
+        """Test parsing valid YAML frontmatter"""
+        content = """---
+id: test.prompt
+family: test
+variant: prompt
+---
+This is the prompt content.
+"""
+        frontmatter, prompt = parse_frontmatter(content)
+        assert frontmatter == {
+            "id": "test.prompt",
+            "family": "test",
+            "variant": "prompt"
+        }
+        assert prompt == "This is the prompt content.\n"
+    
+    def test_no_frontmatter(self):
+        """Test content without frontmatter"""
+        content = "This is just prompt content."
+        frontmatter, prompt = parse_frontmatter(content)
+        assert frontmatter == {}
+        assert prompt == content
+    
+    def test_empty_frontmatter(self):
+        """Test empty frontmatter section"""
+        content = """---
+---
+Prompt content here.
+"""
+        frontmatter, prompt = parse_frontmatter(content)
+        assert frontmatter == {}
+        assert prompt == "Prompt content here.\n"
+    
+    def test_incomplete_frontmatter(self):
+        """Test content with only opening delimiter"""
+        content = """---
+This is not valid frontmatter.
+"""
+        frontmatter, prompt = parse_frontmatter(content)
+        assert frontmatter == {}
+        assert prompt == content
+    
+    def test_invalid_yaml(self):
+        """Test that invalid YAML returns empty frontmatter"""
+        content = """---
+this: is: invalid: yaml:
+---
+Prompt content.
+"""
+        frontmatter, prompt = parse_frontmatter(content)
+        assert frontmatter == {}
+        assert prompt == content
+    
+    def test_frontmatter_with_lists_and_dicts(self):
+        """Test parsing complex frontmatter structures"""
+        content = """---
+tags:
+  - analysis
+  - objectives
+context_levels:
+  - number: 1
+    name: minimal
+---
+Content here.
+"""
+        frontmatter, prompt = parse_frontmatter(content)
+        assert "tags" in frontmatter
+        assert frontmatter["tags"] == ["analysis", "objectives"]
+        assert "context_levels" in frontmatter
+        assert prompt == "Content here.\n"
+
+
+class TestParseEventFilter:
+    """Tests for parse_event_filter()"""
+    
+    def test_empty_dict(self):
+        """Test parsing empty dict returns defaults"""
+        f = parse_event_filter({})
+        assert f.source == "*"
+        assert f.kind == "*"
+        assert f.tool is None
+    
+    def test_with_source(self):
+        """Test parsing filter with source"""
+        f = parse_event_filter({"source": "user"})
+        assert f.source == "user"
+        assert f.kind == "*"
+        assert f.tool is None
+    
+    def test_with_kind(self):
+        """Test parsing filter with kind"""
+        f = parse_event_filter({"kind": "MessageEvent"})
+        assert f.source == "*"
+        assert f.kind == "MessageEvent"
+        assert f.tool is None
+    
+    def test_with_tool(self):
+        """Test parsing filter with tool"""
+        f = parse_event_filter({"tool": "finish"})
+        assert f.source == "*"
+        assert f.kind == "*"
+        assert f.tool == "finish"
+    
+    def test_all_fields(self):
+        """Test parsing filter with all fields"""
+        f = parse_event_filter({
+            "source": "agent",
+            "kind": "ActionEvent",
+            "tool": "terminal"
+        })
+        assert f.source == "agent"
+        assert f.kind == "ActionEvent"
+        assert f.tool == "terminal"
+
+
+class TestParseContextLevel:
+    """Tests for parse_context_level()"""
+    
+    def test_minimal_context_level(self):
+        """Test parsing minimal context level"""
+        ctx = parse_context_level(1, {
+            "name": "minimal",
+            "include": [{"kind": "MessageEvent"}]
+        })
+        assert ctx.number == 1
+        assert ctx.name == "minimal"
+        assert len(ctx.include) == 1
+        assert ctx.include[0].kind == "MessageEvent"
+        assert len(ctx.exclude) == 0
+        assert ctx.truncate == 0
+    
+    def test_with_exclude(self):
+        """Test parsing context level with exclude"""
+        ctx = parse_context_level(2, {
+            "name": "full",
+            "include": [{}],
+            "exclude": [{"kind": "ActionEvent", "tool": "terminal"}]
+        })
+        assert ctx.number == 2
+        assert len(ctx.exclude) == 1
+        assert ctx.exclude[0].tool == "terminal"
+    
+    def test_with_truncate(self):
+        """Test parsing context level with truncate"""
+        ctx = parse_context_level(1, {
+            "name": "truncated",
+            "include": [{}],
+            "truncate": 1000
+        })
+        assert ctx.truncate == 1000
+    
+    def test_multiple_include_filters(self):
+        """Test parsing context level with multiple include filters"""
+        ctx = parse_context_level(3, {
+            "name": "multi",
+            "include": [
+                {"kind": "MessageEvent"},
+                {"kind": "ErrorEvent"},
+                {"kind": "ActionEvent", "tool": "finish"}
+            ]
+        })
+        assert len(ctx.include) == 3
+        assert ctx.include[0].kind == "MessageEvent"
+        assert ctx.include[1].kind == "ErrorEvent"
+        assert ctx.include[2].tool == "finish"
+
+
+class TestParsePromptFile:
+    """Tests for parse_prompt_file()"""
+    
+    def test_file_without_frontmatter(self, tmp_path):
+        """Test parsing file without frontmatter (backward compat)"""
+        prompt_dir = tmp_path / "prompts"
+        prompt_dir.mkdir()
+        prompt_file = prompt_dir / "brief.md"
+        prompt_file.write_text("This is a simple prompt.")
+        
+        meta = parse_prompt_file(prompt_file)
+        assert meta.id == "default.brief"
+        assert meta.family == "default"
+        assert meta.variant == "brief"
+        assert meta.content == "This is a simple prompt."
+        assert meta.path == prompt_file
+        assert len(meta.content_hash) == 16
+    
+    def test_file_in_subdirectory(self, tmp_path):
+        """Test path inference for files in subdirectories"""
+        prompt_dir = tmp_path / "objectives"
+        prompt_dir.mkdir()
+        prompt_file = prompt_dir / "detailed.md"
+        prompt_file.write_text("Objective extraction prompt.")
+        
+        meta = parse_prompt_file(prompt_file)
+        assert meta.family == "objectives"
+        assert meta.variant == "detailed"
+        assert meta.id == "objectives.detailed"
+    
+    def test_file_with_frontmatter(self, tmp_path):
+        """Test parsing file with complete frontmatter"""
+        prompt_file = tmp_path / "test.md"
+        content = """---
+id: custom.id
+family: custom
+variant: test
+description: A test prompt
+default: true
+default_context: 2
+tags:
+  - test
+  - analysis
+context_levels:
+  - number: 1
+    name: minimal
+    include:
+      - kind: MessageEvent
+  - number: 2
+    name: full
+    include:
+      - source: "*"
+    truncate: 500
+---
+This is the prompt content.
+Multiple lines here.
+"""
+        prompt_file.write_text(content)
+        
+        meta = parse_prompt_file(prompt_file)
+        assert meta.id == "custom.id"
+        assert meta.family == "custom"
+        assert meta.variant == "test"
+        assert meta.description == "A test prompt"
+        assert meta.default is True
+        assert meta.default_context == 2
+        assert meta.tags == ["test", "analysis"]
+        assert len(meta.context_levels) == 2
+        assert 1 in meta.context_levels
+        assert 2 in meta.context_levels
+        assert meta.context_levels[1].name == "minimal"
+        assert meta.context_levels[2].truncate == 500
+        assert meta.content == "This is the prompt content.\nMultiple lines here.\n"
+    
+    def test_content_hash_uniqueness(self, tmp_path):
+        """Test that different content produces different hashes"""
+        file1 = tmp_path / "prompt1.md"
+        file2 = tmp_path / "prompt2.md"
+        file1.write_text("Content A")
+        file2.write_text("Content B")
+        
+        meta1 = parse_prompt_file(file1)
+        meta2 = parse_prompt_file(file2)
+        assert meta1.content_hash != meta2.content_hash
+    
+    def test_content_hash_same_for_same_content(self, tmp_path):
+        """Test that same content produces same hash"""
+        file1 = tmp_path / "prompt1.md"
+        file2 = tmp_path / "prompt2.md"
+        file1.write_text("Same content")
+        file2.write_text("Same content")
+        
+        meta1 = parse_prompt_file(file1)
+        meta2 = parse_prompt_file(file2)
+        assert meta1.content_hash == meta2.content_hash
+    
+    def test_content_hash_excludes_frontmatter(self, tmp_path):
+        """Test that content hash only includes prompt content, not frontmatter"""
+        file1 = tmp_path / "with_fm.md"
+        file2 = tmp_path / "without_fm.md"
+        
+        file1.write_text("""---
+id: test.one
+---
+Prompt content here.""")
+        file2.write_text("Prompt content here.")
+        
+        meta1 = parse_prompt_file(file1)
+        meta2 = parse_prompt_file(file2)
+        assert meta1.content_hash == meta2.content_hash
+    
+    def test_optional_fields(self, tmp_path):
+        """Test that optional fields have correct defaults"""
+        prompt_file = tmp_path / "minimal.md"
+        prompt_file.write_text("Minimal prompt")
+        
+        meta = parse_prompt_file(prompt_file)
+        assert meta.description == ""
+        assert meta.default is False
+        assert meta.context_levels == {}
+        assert meta.default_context == 1
+        assert meta.output_schema is None
+        assert meta.handler is None
+        assert meta.tags == []
+    
+    def test_with_output_schema_and_handler(self, tmp_path):
+        """Test parsing prompt with output_schema and handler"""
+        prompt_file = tmp_path / "schema.md"
+        content = """---
+id: test.schema
+output_schema:
+  type: object
+  properties:
+    result: string
+handler: ohtv.analysis.test:TestHandler
+---
+Prompt with schema.
+"""
+        prompt_file.write_text(content)
+        
+        meta = parse_prompt_file(prompt_file)
+        assert meta.output_schema is not None
+        assert meta.output_schema["type"] == "object"
+        assert meta.handler == "ohtv.analysis.test:TestHandler"

--- a/uv.lock
+++ b/uv.lock
@@ -1551,6 +1551,7 @@ dependencies = [
     { name = "click" },
     { name = "httpx" },
     { name = "openhands-sdk" },
+    { name = "pyyaml" },
     { name = "rich" },
 ]
 
@@ -1566,6 +1567,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "openhands-sdk", specifier = ">=1.16.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
 ]
 


### PR DESCRIPTION
## Overview

This PR implements Phase 1 of the extensible prompts feature, creating the foundation for YAML frontmatter support in prompt files.

## Changes

### Dependencies
- Added  to project dependencies

### New Modules

#### 
- **EventFilter**: Filter for matching events with support for:
  - Source filtering (user, agent, or wildcard)
  - Kind filtering (MessageEvent, ActionEvent, ErrorEvent, or wildcard)
  - Tool filtering for ActionEvent types
- **ContextLevel**: Context level definition with:
  - Include/exclude event filtering (OR logic for includes, overriding excludes)
  - Truncation support
- **PromptMetadata**: Complete prompt metadata with:
  - Family/variant identification
  - Context level management
  - Content hashing for cache invalidation
  - Support for output schemas and handlers

#### 
- **parse_frontmatter()**: Extract YAML frontmatter from markdown files
- **parse_event_filter()**: Parse event filter definitions
- **parse_context_level()**: Parse context level configurations
- **parse_prompt_file()**: Complete prompt file parsing with:
  - Frontmatter extraction
  - Path-based family/variant inference
  - Backward compatibility for files without frontmatter

### Tests
- **test_metadata.py**: 16 tests covering EventFilter and ContextLevel matching logic
- **test_parser.py**: 23 tests covering all parsing scenarios and edge cases
- All 39 tests passing ✅

## Backward Compatibility

✅ Files without frontmatter continue to work
✅ Family/variant inferred from file path when not specified
✅ All optional fields have sensible defaults

## Next Steps

This infrastructure enables:
- Phase 2: Content restructure with family-based organization
- Phase 3: Discovery service for finding prompts by criteria
- Phase 4: Transcript integration
- Phase 5: CLI enhancements

## Testing

```bash
uv run python -m pytest tests/unit/prompts/ -v
```

All tests pass successfully.