### PR TITLE
Phase 3: Prompt Discovery & Loading

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5446,15 +5446,19 @@ def prompts(action: str | None, name: str | None, force: bool) -> None:
     """
     from ohtv.prompts import (
         PROMPT_NAMES,
+        discover_prompts,
         get_default_prompts_dir,
         get_prompt,
         get_user_prompts_dir,
         init_user_prompts,
+        list_families,
         list_prompts,
+        list_variants,
+        resolve_prompt,
     )
     
     if action is None or action == "list":
-        _show_prompts_status(list_prompts(), get_user_prompts_dir())
+        _show_prompts_family_structure()
         return
     
     if action == "init":
@@ -5529,8 +5533,45 @@ def prompts(action: str | None, name: str | None, force: bool) -> None:
         return
 
 
+def _show_prompts_family_structure() -> None:
+    """Display prompts organized by family and variant."""
+    from ohtv.prompts import list_families, list_variants, resolve_prompt, get_user_prompts_dir
+    
+    console.print("[bold]Prompt Families:[/bold]")
+    console.print()
+    
+    families = list_families()
+    if not families:
+        console.print("[dim]No prompts found.[/dim]")
+        return
+    
+    for family in families:
+        console.print(f"  [cyan]{family}/[/cyan]")
+        
+        variants = list_variants(family)
+        for variant in variants:
+            try:
+                meta = resolve_prompt(family, variant)
+                default_marker = " [green](default)[/green]" if meta.default else ""
+                description = meta.description or ""
+                
+                # Truncate description if too long
+                if len(description) > 60:
+                    description = description[:57] + "..."
+                
+                console.print(f"    {variant:<20} {default_marker:<18} {description}")
+            except Exception as e:
+                console.print(f"    {variant:<20} [red]error: {e}[/red]")
+        
+        console.print()
+    
+    user_dir = get_user_prompts_dir()
+    console.print(f"[dim]User prompts directory: {user_dir}[/dim]")
+    console.print("[dim]Run 'ohtv prompts init' to copy prompts for customization.[/dim]")
+
+
 def _show_prompts_status(prompts_list: list[dict], user_dir) -> None:
-    """Display prompt status in a table."""
+    """Display prompt status in a table (legacy)."""
     table = Table(title="LLM Analysis Prompts")
     table.add_column("Prompt", style="cyan")
     table.add_column("Status")

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5561,6 +5561,7 @@ def _show_prompts_family_structure() -> None:
                 
                 console.print(f"    {variant:<20} {default_marker:<18} {description}")
             except Exception as e:
+                log.exception("Failed to resolve prompt %s/%s", family, variant)
                 console.print(f"    {variant:<20} [red]error: {e}[/red]")
         
         console.print()

--- a/src/ohtv/prompts/__init__.py
+++ b/src/ohtv/prompts/__init__.py
@@ -1,184 +1,78 @@
 """Prompt management for ohtv.
 
-Prompts are stored as markdown files and can be customized by users.
-The system checks for user prompts in ~/.ohtv/prompts/ first, then
-falls back to the default prompts bundled with the package.
+This module provides both the legacy prompt management functions and the new
+discovery-based prompt system with family/variant organization.
 
-Usage:
+Legacy usage (backward compatible):
     from ohtv.prompts import get_prompt, get_prompt_hash
     
     prompt = get_prompt("brief")  # Gets the brief analysis prompt
-    prompt = get_prompt("brief_assess")  # Gets the brief analysis prompt with assessment
     hash = get_prompt_hash("brief")  # Gets hash for cache invalidation
+
+New discovery-based usage:
+    from ohtv.prompts import discover_prompts, resolve_prompt, resolve_context
+    
+    # Discover all prompts organized by family/variant
+    prompts = discover_prompts()
+    
+    # Resolve a specific prompt (with optional variant)
+    meta = resolve_prompt("objectives", "brief")
+    meta = resolve_prompt("objectives")  # Uses default variant
+    
+    # Resolve a context level
+    ctx = resolve_context(meta, 1)  # By number
+    ctx = resolve_context(meta, "minimal")  # By name
 """
 
-import hashlib
-import logging
-from pathlib import Path
+# Legacy functions - for backward compatibility
+from ohtv.prompts._legacy import (
+    PROMPT_NAMES,
+    get_default_prompts_dir,
+    get_prompt,
+    get_prompt_hash,
+    get_user_prompts_dir,
+    init_user_prompts,
+    list_prompts,
+)
 
-from ohtv.config import get_ohtv_dir
+# New discovery-based functions
+from ohtv.prompts.discovery import (
+    clear_prompt_cache,
+    discover_prompts,
+    get_prompts_dirs,
+    list_families,
+    list_variants,
+    resolve_context,
+    resolve_prompt,
+)
 
-log = logging.getLogger("ohtv")
+# Metadata types
+from ohtv.prompts.metadata import ContextLevel, EventFilter, PromptMetadata
 
-# Available prompt names (without .md extension)
-PROMPT_NAMES = [
-    "brief",
-    "brief_assess",
-    "standard",
-    "standard_assess",
-    "detailed",
-    "detailed_assess",
+# Parser functions (for advanced usage)
+from ohtv.prompts.parser import parse_prompt_file
+
+__all__ = [
+    # Legacy API
+    "PROMPT_NAMES",
+    "get_default_prompts_dir",
+    "get_prompt",
+    "get_prompt_hash",
+    "get_user_prompts_dir",
+    "init_user_prompts",
+    "list_prompts",
+    # Discovery API
+    "clear_prompt_cache",
+    "discover_prompts",
+    "get_prompts_dirs",
+    "list_families",
+    "list_variants",
+    "resolve_context",
+    "resolve_prompt",
+    # Metadata types
+    "ContextLevel",
+    "EventFilter",
+    "PromptMetadata",
+    # Parser
+    "parse_prompt_file",
 ]
-
-
-def get_default_prompts_dir() -> Path:
-    """Get the path to the default prompts directory bundled with the package."""
-    return Path(__file__).parent
-
-
-def get_user_prompts_dir() -> Path:
-    """Get the path to user-customizable prompts directory (~/.ohtv/prompts/)."""
-    return get_ohtv_dir() / "prompts"
-
-
-def _get_prompt_path(name: str) -> Path:
-    """Get the path to a prompt file, checking user directory first.
-    
-    Args:
-        name: Prompt name without .md extension
-        
-    Returns:
-        Path to the prompt file
-        
-    Raises:
-        ValueError: If the prompt name is unknown
-        FileNotFoundError: If the prompt file cannot be found
-    """
-    if name not in PROMPT_NAMES:
-        raise ValueError(f"Unknown prompt: {name}. Valid prompts: {', '.join(PROMPT_NAMES)}")
-    
-    filename = f"{name}.md"
-    
-    # Check user directory first
-    user_path = get_user_prompts_dir() / filename
-    if user_path.exists():
-        return user_path
-    
-    # Fall back to default
-    default_path = get_default_prompts_dir() / filename
-    if default_path.exists():
-        return default_path
-    
-    raise FileNotFoundError(f"Prompt file not found: {filename}")
-
-
-def get_prompt(name: str) -> str:
-    """Load a prompt by name, checking user directory first, then defaults.
-    
-    Args:
-        name: Prompt name without .md extension (e.g., "brief", "standard_assess")
-        
-    Returns:
-        The prompt text content
-        
-    Raises:
-        ValueError: If the prompt name is unknown
-        FileNotFoundError: If the prompt file cannot be found
-    """
-    path = _get_prompt_path(name)
-    log.debug("Loading prompt from %s", path)
-    return path.read_text()
-
-
-def get_prompt_hash(name: str) -> str:
-    """Get a hash of the prompt content for cache invalidation.
-    
-    This allows the analysis cache to detect when a prompt has been
-    modified and invalidate cached results that used the old prompt.
-    
-    Args:
-        name: Prompt name without .md extension (e.g., "brief", "standard_assess")
-        
-    Returns:
-        16-character hex hash of the prompt content
-        
-    Raises:
-        ValueError: If the prompt name is unknown
-        FileNotFoundError: If the prompt file cannot be found
-    """
-    content = get_prompt(name)
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
-
-
-def init_user_prompts(force: bool = False) -> list[str]:
-    """Copy default prompts to user directory for customization.
-    
-    Args:
-        force: If True, overwrite existing user prompts
-        
-    Returns:
-        List of prompt names that were copied
-    """
-    user_dir = get_user_prompts_dir()
-    user_dir.mkdir(parents=True, exist_ok=True)
-    
-    default_dir = get_default_prompts_dir()
-    copied = []
-    
-    for name in PROMPT_NAMES:
-        filename = f"{name}.md"
-        user_path = user_dir / filename
-        default_path = default_dir / filename
-        
-        if not default_path.exists():
-            log.warning("Default prompt missing: %s", filename)
-            continue
-            
-        if user_path.exists() and not force:
-            log.debug("Skipping existing user prompt: %s", filename)
-            continue
-        
-        user_path.write_text(default_path.read_text())
-        copied.append(name)
-        log.debug("Copied prompt: %s", filename)
-    
-    return copied
-
-
-def list_prompts() -> list[dict]:
-    """List all prompts with their status (default, customized, or missing).
-    
-    Returns:
-        List of dicts with keys: name, status, user_path, default_path
-    """
-    user_dir = get_user_prompts_dir()
-    default_dir = get_default_prompts_dir()
-    
-    result = []
-    for name in PROMPT_NAMES:
-        filename = f"{name}.md"
-        user_path = user_dir / filename
-        default_path = default_dir / filename
-        
-        has_user = user_path.exists()
-        has_default = default_path.exists()
-        
-        if has_user:
-            # Check if customized (different from default)
-            if has_default and user_path.read_text() != default_path.read_text():
-                status = "customized"
-            else:
-                status = "copied"
-        elif has_default:
-            status = "default"
-        else:
-            status = "missing"
-        
-        result.append({
-            "name": name,
-            "status": status,
-            "user_path": user_path if has_user else None,
-            "default_path": default_path if has_default else None,
-        })
-    
-    return result

--- a/src/ohtv/prompts/_legacy.py
+++ b/src/ohtv/prompts/_legacy.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 
 from ohtv.config import get_ohtv_dir
+from ohtv.prompts.discovery import clear_prompt_cache
 
 log = logging.getLogger("ohtv")
 
@@ -134,6 +135,10 @@ def init_user_prompts(force: bool = False) -> list[str]:
         user_path.write_text(default_path.read_text())
         copied.append(name)
         log.debug("Copied prompt: %s", filename)
+
+    # Clear discovery cache so new user prompts are found
+    from ohtv.prompts.discovery import clear_prompt_cache
+    clear_prompt_cache()
     
     return copied
 

--- a/src/ohtv/prompts/_legacy.py
+++ b/src/ohtv/prompts/_legacy.py
@@ -1,0 +1,177 @@
+"""Legacy prompt management functions for backward compatibility.
+
+This module contains the original prompt management functions that work
+with the old flat prompt structure. These are kept for backward compatibility
+while the new discovery-based system is integrated.
+"""
+
+import hashlib
+import logging
+from pathlib import Path
+
+from ohtv.config import get_ohtv_dir
+
+log = logging.getLogger("ohtv")
+
+# Available prompt names (without .md extension)
+PROMPT_NAMES = [
+    "brief",
+    "brief_assess",
+    "standard",
+    "standard_assess",
+    "detailed",
+    "detailed_assess",
+]
+
+
+def get_default_prompts_dir() -> Path:
+    """Get the path to the default prompts directory bundled with the package."""
+    return Path(__file__).parent
+
+
+def get_user_prompts_dir() -> Path:
+    """Get the path to user-customizable prompts directory (~/.ohtv/prompts/)."""
+    return get_ohtv_dir() / "prompts"
+
+
+def _get_prompt_path(name: str) -> Path:
+    """Get the path to a prompt file, checking user directory first.
+    
+    Args:
+        name: Prompt name without .md extension
+        
+    Returns:
+        Path to the prompt file
+        
+    Raises:
+        ValueError: If the prompt name is unknown
+        FileNotFoundError: If the prompt file cannot be found
+    """
+    if name not in PROMPT_NAMES:
+        raise ValueError(f"Unknown prompt: {name}. Valid prompts: {', '.join(PROMPT_NAMES)}")
+    
+    filename = f"{name}.md"
+    
+    # Check user directory first
+    user_path = get_user_prompts_dir() / filename
+    if user_path.exists():
+        return user_path
+    
+    # Fall back to default
+    default_path = get_default_prompts_dir() / filename
+    if default_path.exists():
+        return default_path
+    
+    raise FileNotFoundError(f"Prompt file not found: {filename}")
+
+
+def get_prompt(name: str) -> str:
+    """Load a prompt by name, checking user directory first, then defaults.
+    
+    Args:
+        name: Prompt name without .md extension (e.g., "brief", "standard_assess")
+        
+    Returns:
+        The prompt text content
+        
+    Raises:
+        ValueError: If the prompt name is unknown
+        FileNotFoundError: If the prompt file cannot be found
+    """
+    path = _get_prompt_path(name)
+    log.debug("Loading prompt from %s", path)
+    return path.read_text()
+
+
+def get_prompt_hash(name: str) -> str:
+    """Get a hash of the prompt content for cache invalidation.
+    
+    This allows the analysis cache to detect when a prompt has been
+    modified and invalidate cached results that used the old prompt.
+    
+    Args:
+        name: Prompt name without .md extension (e.g., "brief", "standard_assess")
+        
+    Returns:
+        16-character hex hash of the prompt content
+        
+    Raises:
+        ValueError: If the prompt name is unknown
+        FileNotFoundError: If the prompt file cannot be found
+    """
+    content = get_prompt(name)
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+def init_user_prompts(force: bool = False) -> list[str]:
+    """Copy default prompts to user directory for customization.
+    
+    Args:
+        force: If True, overwrite existing user prompts
+        
+    Returns:
+        List of prompt names that were copied
+    """
+    user_dir = get_user_prompts_dir()
+    user_dir.mkdir(parents=True, exist_ok=True)
+    
+    default_dir = get_default_prompts_dir()
+    copied = []
+    
+    for name in PROMPT_NAMES:
+        filename = f"{name}.md"
+        user_path = user_dir / filename
+        default_path = default_dir / filename
+        
+        if not default_path.exists():
+            log.warning("Default prompt missing: %s", filename)
+            continue
+            
+        if user_path.exists() and not force:
+            log.debug("Skipping existing user prompt: %s", filename)
+            continue
+        
+        user_path.write_text(default_path.read_text())
+        copied.append(name)
+        log.debug("Copied prompt: %s", filename)
+    
+    return copied
+
+
+def list_prompts() -> list[dict]:
+    """List all prompts with their status (default, customized, or missing).
+    
+    Returns:
+        List of dicts with keys: name, status, user_path, default_path
+    """
+    user_dir = get_user_prompts_dir()
+    default_dir = get_default_prompts_dir()
+    
+    result = []
+    for name in PROMPT_NAMES:
+        filename = f"{name}.md"
+        user_path = user_dir / filename
+        default_path = default_dir / filename
+        
+        has_user = user_path.exists()
+        has_default = default_path.exists()
+        
+        if has_user:
+            # Check if customized (different from default)
+            if has_default and user_path.read_text() != default_path.read_text():
+                status = "customized"
+            else:
+                status = "copied"
+        elif has_default:
+            status = "default"
+        else:
+            status = "missing"
+        
+        result.append({
+            "name": name,
+            "status": status,
+            "user_path": user_path if has_user else None,
+            "default_path": default_path if has_default else None,
+        })
+    
+    return result

--- a/src/ohtv/prompts/discovery.py
+++ b/src/ohtv/prompts/discovery.py
@@ -54,6 +54,7 @@ def discover_prompts() -> dict[str, dict[str, PromptMetadata]]:
         for prompt_file in prompts_dir.rglob("*.md"):
             # Skip files directly in prompts directory (old structure)
             if prompt_file.parent == prompts_dir:
+                log.debug("Skipping old-structure prompt: %s", prompt_file)
                 continue
             
             try:
@@ -140,8 +141,12 @@ def resolve_prompt(family: str, variant: str | None = None) -> PromptMetadata:
             raise ValueError(f"No default variant for family '{family}'. "
                            f"Available variants: {', '.join(family_prompts.keys())}")
         if len(defaults) > 1:
-            log.warning("Multiple default variants for family '%s': %s. Using first.", 
-                       family, defaults)
+            log.warning(
+                "Multiple default variants for family '%s': %s. "
+                "Using '%s' (first in discovery order). "
+                "Mark only one variant as default: true.",
+                family, defaults, defaults[0]
+            )
         variant = defaults[0]
     
     if variant not in family_prompts:

--- a/src/ohtv/prompts/discovery.py
+++ b/src/ohtv/prompts/discovery.py
@@ -1,0 +1,170 @@
+"""Prompt discovery and resolution.
+
+This module discovers prompts from the filesystem and provides functions
+to resolve prompts by family and variant.
+"""
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+
+from ohtv.config import get_ohtv_dir
+from ohtv.prompts.metadata import ContextLevel, PromptMetadata
+from ohtv.prompts.parser import parse_prompt_file
+
+log = logging.getLogger("ohtv")
+
+
+def get_prompts_dirs() -> list[Path]:
+    """Get prompt directories to search (user first, then default).
+    
+    Returns:
+        List of Path objects, with user directory first, then default directory.
+        User directory: ~/.ohtv/prompts/
+        Default directory: src/ohtv/prompts/ (bundled with package)
+    """
+    user_dir = get_ohtv_dir() / "prompts"
+    default_dir = Path(__file__).parent
+    return [user_dir, default_dir]
+
+
+@lru_cache(maxsize=1)
+def discover_prompts() -> dict[str, dict[str, PromptMetadata]]:
+    """Discover all prompts organized by family and variant.
+    
+    Returns:
+        Dict mapping family -> variant -> PromptMetadata
+        e.g., {"objectives": {"brief": PromptMetadata(...), "detailed": ...}}
+    
+    Scans both user and default directories.
+    User prompts override defaults with the same family/variant.
+    
+    Results are cached to avoid repeated filesystem scans.
+    Call clear_prompt_cache() to invalidate the cache.
+    """
+    prompts: dict[str, dict[str, PromptMetadata]] = {}
+    
+    # Search directories in reverse order (default first, user last)
+    # so user prompts override defaults
+    for prompts_dir in reversed(get_prompts_dirs()):
+        if not prompts_dir.exists():
+            continue
+        
+        # Find all .md files in subdirectories (family directories)
+        for prompt_file in prompts_dir.rglob("*.md"):
+            # Skip files directly in prompts directory (old structure)
+            if prompt_file.parent == prompts_dir:
+                continue
+            
+            try:
+                meta = parse_prompt_file(prompt_file)
+                
+                # Organize by family and variant
+                if meta.family not in prompts:
+                    prompts[meta.family] = {}
+                
+                prompts[meta.family][meta.variant] = meta
+                log.debug("Discovered prompt: %s.%s from %s", 
+                         meta.family, meta.variant, prompt_file)
+                
+            except Exception as e:
+                log.warning("Failed to parse prompt %s: %s", prompt_file, e)
+    
+    return prompts
+
+
+def clear_prompt_cache():
+    """Clear the cached discovered prompts.
+    
+    Call this to force a re-scan of the filesystem.
+    """
+    discover_prompts.cache_clear()
+
+
+def list_families() -> list[str]:
+    """List all available prompt families.
+    
+    Returns:
+        Sorted list of family names
+    """
+    prompts = discover_prompts()
+    return sorted(prompts.keys())
+
+
+def list_variants(family: str) -> list[str]:
+    """List all variants for a family.
+    
+    Args:
+        family: Prompt family name
+        
+    Returns:
+        Sorted list of variant names for the family
+        
+    Raises:
+        ValueError: If family not found
+    """
+    prompts = discover_prompts()
+    if family not in prompts:
+        raise ValueError(f"Unknown prompt family: {family}. "
+                        f"Available families: {', '.join(list_families())}")
+    
+    return sorted(prompts[family].keys())
+
+
+def resolve_prompt(family: str, variant: str | None = None) -> PromptMetadata:
+    """Resolve a prompt by family and optional variant.
+    
+    Args:
+        family: Prompt family (e.g., "objectives")
+        variant: Variant name (e.g., "brief"). If None, uses default variant
+                (marked with default: true in frontmatter).
+        
+    Returns:
+        PromptMetadata for the resolved prompt
+        
+    Raises:
+        ValueError: If family not found, variant not found, or no default variant
+    """
+    prompts = discover_prompts()
+    
+    if family not in prompts:
+        raise ValueError(f"Unknown prompt family: {family}. "
+                        f"Available families: {', '.join(list_families())}")
+    
+    family_prompts = prompts[family]
+    
+    # If no variant specified, find the default
+    if variant is None:
+        defaults = [v for v, meta in family_prompts.items() if meta.default]
+        if not defaults:
+            raise ValueError(f"No default variant for family '{family}'. "
+                           f"Available variants: {', '.join(family_prompts.keys())}")
+        if len(defaults) > 1:
+            log.warning("Multiple default variants for family '%s': %s. Using first.", 
+                       family, defaults)
+        variant = defaults[0]
+    
+    if variant not in family_prompts:
+        raise ValueError(f"Unknown variant '{variant}' for family '{family}'. "
+                        f"Available variants: {', '.join(family_prompts.keys())}")
+    
+    return family_prompts[variant]
+
+
+def resolve_context(prompt: PromptMetadata, context: int | str | None = None) -> ContextLevel:
+    """Resolve a context level for a prompt.
+    
+    Args:
+        prompt: The prompt metadata
+        context: Context level number or name. If None, uses prompt's default.
+        
+    Returns:
+        ContextLevel for the resolved context
+        
+    Raises:
+        ValueError: If context level not found
+    """
+    if context is None:
+        context = prompt.default_context
+    
+    return prompt.get_context_level(context)

--- a/src/ohtv/prompts/parser.py
+++ b/src/ohtv/prompts/parser.py
@@ -108,9 +108,8 @@ def parse_prompt_file(path: Path) -> PromptMetadata:
         
         if "levels" in context_data:
             for number, level_data in context_data["levels"].items():
-                level_dict = dict(level_data)
-                level_dict["number"] = int(number)
-                context_levels[int(number)] = parse_context_level(level_dict)
+                level_data_with_number = {**level_data, "number": int(number)}
+                context_levels[int(number)] = parse_context_level(level_data_with_number)
     
     # Compute content hash
     content_hash = hashlib.sha256(prompt_content.encode()).hexdigest()[:16]

--- a/src/ohtv/prompts/parser.py
+++ b/src/ohtv/prompts/parser.py
@@ -91,16 +91,34 @@ def parse_prompt_file(path: Path) -> PromptMetadata:
     variant = frontmatter.get("variant", stem)
     prompt_id = frontmatter.get("id", f"{family}.{variant}")
     
-    # Parse context levels
+    # Parse context levels - handle both formats
     context_levels = {}
+    default_context = 1
+    
     if "context_levels" in frontmatter:
+        # Old format: context_levels as list
         for level_data in frontmatter["context_levels"]:
             number = level_data.get("number")
             if number is not None:
                 context_levels[number] = parse_context_level(level_data)
+    elif "context" in frontmatter:
+        # New format: nested context with default and levels
+        context_data = frontmatter["context"]
+        default_context = context_data.get("default", 1)
+        
+        if "levels" in context_data:
+            for number, level_data in context_data["levels"].items():
+                level_dict = dict(level_data)
+                level_dict["number"] = int(number)
+                context_levels[int(number)] = parse_context_level(level_dict)
     
     # Compute content hash
     content_hash = hashlib.sha256(prompt_content.encode()).hexdigest()[:16]
+    
+    # Handle output schema (may be nested under "output")
+    output_schema = frontmatter.get("output_schema")
+    if output_schema is None and "output" in frontmatter:
+        output_schema = frontmatter["output"].get("schema")
     
     return PromptMetadata(
         id=prompt_id,
@@ -109,8 +127,8 @@ def parse_prompt_file(path: Path) -> PromptMetadata:
         description=frontmatter.get("description", ""),
         default=frontmatter.get("default", False),
         context_levels=context_levels,
-        default_context=frontmatter.get("default_context", 1),
-        output_schema=frontmatter.get("output_schema"),
+        default_context=frontmatter.get("default_context", default_context),
+        output_schema=output_schema,
         handler=frontmatter.get("handler"),
         tags=frontmatter.get("tags", []),
         path=path,

--- a/tests/unit/prompts/test_discovery.py
+++ b/tests/unit/prompts/test_discovery.py
@@ -1,0 +1,372 @@
+"""Tests for prompt discovery and resolution."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ohtv.prompts.discovery import (
+    clear_prompt_cache,
+    discover_prompts,
+    get_prompts_dirs,
+    list_families,
+    list_variants,
+    resolve_context,
+    resolve_prompt,
+)
+from ohtv.prompts.metadata import PromptMetadata
+
+
+class TestGetPromptsDirs:
+    """Tests for get_prompts_dirs()"""
+    
+    def test_returns_two_directories(self):
+        """Test that get_prompts_dirs returns user and default directories"""
+        dirs = get_prompts_dirs()
+        assert len(dirs) == 2
+        assert all(isinstance(d, Path) for d in dirs)
+    
+    def test_user_dir_first(self):
+        """Test that user directory comes before default directory"""
+        dirs = get_prompts_dirs()
+        user_dir, default_dir = dirs
+        assert "prompts" in str(user_dir)
+        assert ".ohtv" in str(user_dir) or "ohtv" in str(user_dir)
+        assert "prompts" in str(default_dir)
+
+
+class TestDiscoverPrompts:
+    """Tests for discover_prompts()"""
+    
+    def setup_method(self):
+        """Clear cache before each test"""
+        clear_prompt_cache()
+    
+    def test_discovers_default_prompts(self):
+        """Test that discover_prompts finds prompts in default directory"""
+        prompts = discover_prompts()
+        
+        assert isinstance(prompts, dict)
+        assert len(prompts) > 0
+        
+        # Check that objectives family exists
+        assert "objectives" in prompts
+        assert "brief" in prompts["objectives"]
+        
+        # Check that metadata is correct type
+        brief = prompts["objectives"]["brief"]
+        assert isinstance(brief, PromptMetadata)
+        assert brief.family == "objectives"
+        assert brief.variant == "brief"
+    
+    def test_organizes_by_family_and_variant(self):
+        """Test that prompts are organized by family then variant"""
+        prompts = discover_prompts()
+        
+        for family, variants in prompts.items():
+            assert isinstance(family, str)
+            assert isinstance(variants, dict)
+            
+            for variant, meta in variants.items():
+                assert isinstance(variant, str)
+                assert isinstance(meta, PromptMetadata)
+                assert meta.family == family
+                assert meta.variant == variant
+    
+    def test_caches_results(self):
+        """Test that discover_prompts caches results"""
+        result1 = discover_prompts()
+        result2 = discover_prompts()
+        
+        # Should be the same object (cached)
+        assert result1 is result2
+    
+    def test_clear_cache(self):
+        """Test that clear_prompt_cache invalidates cache"""
+        result1 = discover_prompts()
+        clear_prompt_cache()
+        result2 = discover_prompts()
+        
+        # Should be different objects (cache cleared)
+        assert result1 is not result2
+
+
+class TestUserOverride:
+    """Tests for user prompt override functionality"""
+    
+    def setup_method(self):
+        """Set up temporary directories for testing"""
+        clear_prompt_cache()
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.user_dir = self.temp_dir / "user" / "prompts"
+        self.default_dir = self.temp_dir / "default" / "prompts"
+        
+        self.user_dir.mkdir(parents=True)
+        self.default_dir.mkdir(parents=True)
+    
+    def teardown_method(self):
+        """Clean up temporary directories"""
+        clear_prompt_cache()
+        shutil.rmtree(self.temp_dir)
+    
+    def test_user_prompts_override_defaults(self, monkeypatch):
+        """Test that user prompts override default prompts"""
+        # Create default prompt
+        family_dir = self.default_dir / "test_family"
+        family_dir.mkdir()
+        default_prompt = family_dir / "variant1.md"
+        default_prompt.write_text("""---
+id: test_family.variant1
+family: test_family
+variant: variant1
+description: Default version
+---
+Default content""")
+        
+        # Create user override
+        user_family_dir = self.user_dir / "test_family"
+        user_family_dir.mkdir()
+        user_prompt = user_family_dir / "variant1.md"
+        user_prompt.write_text("""---
+id: test_family.variant1
+family: test_family
+variant: variant1
+description: User version
+---
+User content""")
+        
+        # Mock get_prompts_dirs to use our temp directories
+        def mock_get_prompts_dirs():
+            return [self.user_dir, self.default_dir]
+        
+        monkeypatch.setattr("ohtv.prompts.discovery.get_prompts_dirs", mock_get_prompts_dirs)
+        clear_prompt_cache()
+        
+        prompts = discover_prompts()
+        
+        # Should have user version
+        assert "test_family" in prompts
+        assert "variant1" in prompts["test_family"]
+        meta = prompts["test_family"]["variant1"]
+        assert meta.description == "User version"
+        assert meta.content == "User content"
+
+
+class TestListFamilies:
+    """Tests for list_families()"""
+    
+    def setup_method(self):
+        clear_prompt_cache()
+    
+    def test_returns_sorted_list(self):
+        """Test that list_families returns sorted list of family names"""
+        families = list_families()
+        
+        assert isinstance(families, list)
+        assert len(families) > 0
+        assert all(isinstance(f, str) for f in families)
+        
+        # Should be sorted
+        assert families == sorted(families)
+    
+    def test_includes_known_families(self):
+        """Test that known families are included"""
+        families = list_families()
+        assert "objectives" in families
+
+
+class TestListVariants:
+    """Tests for list_variants()"""
+    
+    def setup_method(self):
+        clear_prompt_cache()
+    
+    def test_returns_sorted_list(self):
+        """Test that list_variants returns sorted list of variant names"""
+        variants = list_variants("objectives")
+        
+        assert isinstance(variants, list)
+        assert len(variants) > 0
+        assert all(isinstance(v, str) for v in variants)
+        
+        # Should be sorted
+        assert variants == sorted(variants)
+    
+    def test_includes_known_variants(self):
+        """Test that known variants are included"""
+        variants = list_variants("objectives")
+        assert "brief" in variants
+        assert "detailed" in variants
+    
+    def test_unknown_family_raises_error(self):
+        """Test that unknown family raises ValueError"""
+        with pytest.raises(ValueError, match="Unknown prompt family"):
+            list_variants("nonexistent_family")
+
+
+class TestResolvePrompt:
+    """Tests for resolve_prompt()"""
+    
+    def setup_method(self):
+        clear_prompt_cache()
+    
+    def test_resolve_with_explicit_variant(self):
+        """Test resolving prompt with explicit variant"""
+        meta = resolve_prompt("objectives", "brief")
+        
+        assert isinstance(meta, PromptMetadata)
+        assert meta.family == "objectives"
+        assert meta.variant == "brief"
+        assert len(meta.content) > 0
+    
+    def test_resolve_with_default_variant(self):
+        """Test resolving prompt with default variant (None)"""
+        meta = resolve_prompt("objectives")
+        
+        assert isinstance(meta, PromptMetadata)
+        assert meta.family == "objectives"
+        assert meta.default is True  # Should be the default variant
+    
+    def test_resolve_unknown_family_raises_error(self):
+        """Test that unknown family raises ValueError"""
+        with pytest.raises(ValueError, match="Unknown prompt family"):
+            resolve_prompt("nonexistent_family")
+    
+    def test_resolve_unknown_variant_raises_error(self):
+        """Test that unknown variant raises ValueError"""
+        with pytest.raises(ValueError, match="Unknown variant"):
+            resolve_prompt("objectives", "nonexistent_variant")
+    
+    def test_resolve_without_default_raises_error(self, monkeypatch):
+        """Test that family without default variant raises error"""
+        # Create temp family without default
+        temp_dir = Path(tempfile.mkdtemp())
+        try:
+            family_dir = temp_dir / "prompts" / "no_default"
+            family_dir.mkdir(parents=True)
+            
+            prompt_file = family_dir / "variant1.md"
+            prompt_file.write_text("""---
+id: no_default.variant1
+family: no_default
+variant: variant1
+default: false
+---
+Content""")
+            
+            def mock_get_prompts_dirs():
+                return [temp_dir / "prompts"]
+            
+            monkeypatch.setattr("ohtv.prompts.discovery.get_prompts_dirs", mock_get_prompts_dirs)
+            clear_prompt_cache()
+            
+            with pytest.raises(ValueError, match="No default variant"):
+                resolve_prompt("no_default")
+        finally:
+            shutil.rmtree(temp_dir)
+            clear_prompt_cache()
+
+
+class TestResolveContext:
+    """Tests for resolve_context()"""
+    
+    def setup_method(self):
+        clear_prompt_cache()
+    
+    def test_resolve_by_number(self):
+        """Test resolving context level by number"""
+        meta = resolve_prompt("objectives", "brief")
+        ctx = resolve_context(meta, 1)
+        
+        assert ctx.number == 1
+        assert ctx.name == "minimal"
+    
+    def test_resolve_by_name(self):
+        """Test resolving context level by name"""
+        meta = resolve_prompt("objectives", "brief")
+        ctx = resolve_context(meta, "minimal")
+        
+        assert ctx.number == 1
+        assert ctx.name == "minimal"
+    
+    def test_resolve_with_none_uses_default(self):
+        """Test that None uses prompt's default context"""
+        meta = resolve_prompt("objectives", "brief")
+        ctx = resolve_context(meta, None)
+        
+        # Should use default_context from prompt
+        assert ctx.number == meta.default_context
+    
+    def test_resolve_unknown_number_raises_error(self):
+        """Test that unknown context number raises ValueError"""
+        meta = resolve_prompt("objectives", "brief")
+        
+        with pytest.raises(ValueError, match="Unknown context level"):
+            resolve_context(meta, 999)
+    
+    def test_resolve_unknown_name_raises_error(self):
+        """Test that unknown context name raises ValueError"""
+        meta = resolve_prompt("objectives", "brief")
+        
+        with pytest.raises(ValueError, match="Unknown context level"):
+            resolve_context(meta, "nonexistent_level")
+    
+    def test_all_context_levels_accessible(self):
+        """Test that all context levels can be accessed"""
+        meta = resolve_prompt("objectives", "brief")
+        
+        # Test all defined context levels
+        for number in meta.context_levels.keys():
+            ctx = resolve_context(meta, number)
+            assert ctx.number == number
+            assert len(ctx.include) > 0  # Should have filters
+
+
+class TestIntegration:
+    """Integration tests for discovery system"""
+    
+    def setup_method(self):
+        clear_prompt_cache()
+    
+    def test_full_workflow(self):
+        """Test complete workflow of discovering and resolving prompts"""
+        # Discover all prompts
+        prompts = discover_prompts()
+        assert len(prompts) > 0
+        
+        # List families
+        families = list_families()
+        assert "objectives" in families
+        
+        # List variants for a family
+        variants = list_variants("objectives")
+        assert "brief" in variants
+        
+        # Resolve default prompt
+        meta = resolve_prompt("objectives")
+        assert meta.default is True
+        
+        # Resolve specific variant
+        brief_meta = resolve_prompt("objectives", "brief")
+        assert brief_meta.variant == "brief"
+        
+        # Resolve context
+        ctx = resolve_context(brief_meta, 1)
+        assert ctx.number == 1
+    
+    def test_prompt_metadata_completeness(self):
+        """Test that discovered prompts have complete metadata"""
+        meta = resolve_prompt("objectives", "brief")
+        
+        # Check all important fields are populated
+        assert meta.id
+        assert meta.family == "objectives"
+        assert meta.variant == "brief"
+        assert meta.description
+        assert meta.content
+        assert meta.content_hash
+        assert meta.path
+        assert meta.path.exists()
+        assert len(meta.context_levels) > 0
+        assert meta.default_context >= 1


### PR DESCRIPTION
## Overview

This PR implements Phase 3 of the extensible prompts feature, adding prompt discovery and resolution with family/variant organization.

## What's New

### Core Features
- **Prompt Discovery System**: Automatically discovers and organizes prompts by family and variant
- **User Override Support**: User prompts in `~/.ohtv/prompts/` now correctly override defaults
- **Default Variant Selection**: Prompts can be marked as default within their family
- **Context Resolution**: Resolve context levels by number or name
- **Caching**: Discovered prompts are cached to avoid repeated filesystem scans

### New Functions (`discovery.py`)
- `discover_prompts()`: Scan directories and organize by family/variant
- `list_families()`: List all available prompt families
- `list_variants(family)`: List variants for a family
- `resolve_prompt(family, variant)`: Get prompt metadata with default support
- `resolve_context(prompt, context)`: Get context level by number or name
- `get_prompts_dirs()`: Get user and default prompt directories
- `clear_prompt_cache()`: Clear cached discoveries

### Parser Enhancements
- Updated `parser.py` to handle nested context format from Phase 2
- Supports both `context_levels` (list) and `context` (nested dict) formats
- Handles nested `output.schema` in frontmatter
- Maintains backward compatibility with existing tests

### Backward Compatibility
- Moved existing code to `_legacy.py`
- All original functions preserved and working
- Updated `__init__.py` to export both old and new APIs
- Existing code continues to work without changes

### CLI Updates
- `ohtv prompts` now displays family/variant structure
- Shows which variants are marked as default
- Displays prompt descriptions
- Maintains compatibility for init/show/reset actions

## Testing

- **25 new tests** in `test_discovery.py` covering:
  - Discovery from multiple directories
  - User override of defaults
  - Default variant selection
  - Context resolution by number and name
  - Error cases and edge conditions
  - Integration workflows

- **All 59 prompt module tests pass**
- **All 16 legacy prompt tests pass**
- **Full backward compatibility maintained**

## Example Usage

```python
from ohtv.prompts import discover_prompts, resolve_prompt, resolve_context

# Discover all prompts
prompts = discover_prompts()

# Resolve a prompt (uses default variant)
meta = resolve_prompt('objectives')

# Resolve specific variant
meta = resolve_prompt('objectives', 'brief')

# Resolve context level
ctx = resolve_context(meta, 1)  # By number
ctx = resolve_context(meta, 'minimal')  # By name
```

## Dependencies
- Requires Phase 1 (metadata.py, parser.py)
- Requires Phase 2 (restructured prompt files with frontmatter)

## Next Steps
After merging to `feature/extensible-prompts`, Phase 4 will integrate this discovery system with the transcript module.