### PR TITLE
Add display schema to prompt frontmatter for variant-aware table rendering

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -9,6 +9,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from click import Context, HelpFormatter
@@ -19,6 +20,9 @@ from rich.tree import Tree
 from ohtv.actions import READ_ACTIONS, WRITE_ACTIONS
 from ohtv.config import Config
 from ohtv.db.utils import generate_unique_source_names
+
+if TYPE_CHECKING:
+    from ohtv.prompts import DisplaySchema
 
 log = logging.getLogger("ohtv")
 
@@ -5267,8 +5271,9 @@ def _run_batch_objectives_analysis(
     try:
         prompt_meta = resolve_prompt("objs", effective_variant)
         display_schema = prompt_meta.display
-    except ValueError:
-        pass  # Unknown variant - will use default display
+    except ValueError as e:
+        # Unknown variant or malformed prompt - fall back to default display
+        log.debug("Could not load display schema for variant '%s': %s", effective_variant, e)
 
     # Safety threshold for LLM analysis - require confirmation for large batches
     SUMMARY_CONFIRM_THRESHOLD = 20

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -3266,15 +3266,6 @@ def _print_summary_table(
     # Use TableRenderer for schema-based rendering
     renderer = TableRenderer(schema, console=console)
     
-    # Pre-process results to combine goal + refs for default schema's Summary column
-    if not display_schema or not display_schema.columns:
-        # Using default schema - need to combine goal and refs into "goal" field
-        for r in results:
-            summary_parts = [r.get("goal", "")]
-            if include_outputs and r.get("refs_display"):
-                summary_parts.append(r["refs_display"])
-            r["goal"] = "\n".join(summary_parts)
-    
     renderer.render(
         results,
         variant=variant,

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -3237,48 +3237,51 @@ def _print_summary_table(
     error_count: int,
     *,
     include_outputs: bool = True,
+    display_schema: "DisplaySchema | None" = None,
+    variant: str | None = None,
 ) -> None:
-    """Print summary results as a table."""
-    table = Table(show_header=True, header_style="bold", show_lines=True)
-    table.add_column("ID", style="cyan", width=7, no_wrap=True)
-    table.add_column("Date", width=10, no_wrap=True)
-    table.add_column("Summary", no_wrap=False)
-
-    for r in results:
-        date_str = ""
-        if r["created_at"]:
-            local_time = r["created_at"].astimezone()
-            date_str = local_time.strftime("%Y-%m-%d")
-
-        # Build the summary cell content
-        summary_parts = [r["goal"]]
-
-        # Add refs/outputs if present
-        if include_outputs and r.get("outputs"):
-            ref_lines = _format_refs_for_summary(r["outputs"])
-            summary_parts.extend(ref_lines)
-
-        summary_cell = "\n".join(summary_parts)
-
-        table.add_row(
-            r["short_id"],
-            date_str,
-            summary_cell,
-        )
-
-    console.print(table)
-
-    # Summary line: "Showing 5 of 100 (3/5 cached)"
-    showing = len(results)
-    cached = sum(1 for r in results if r.get("cached", False))
-
-    summary_parts = [f"Showing {showing} of {total_count}"]
-    if showing > 0:
-        summary_parts.append(f"({cached}/{showing} cached)")
-    if error_count > 0:
-        summary_parts.append(f"{error_count} failed")
-
-    console.print(f"[dim]{' '.join(summary_parts)}[/dim]")
+    """Print summary results as a table.
+    
+    Args:
+        results: List of result dictionaries from analysis
+        total_count: Total number of conversations (for summary)
+        error_count: Number of errors
+        include_outputs: Whether to include refs/outputs in output
+        display_schema: Optional display schema from prompt for variant-aware rendering
+        variant: Current prompt variant name (for show_when filtering)
+    """
+    from ohtv.prompts import TableRenderer, get_default_display_schema, DisplaySchema
+    
+    # Use display schema if provided, otherwise fall back to default
+    schema = display_schema if display_schema and display_schema.columns else get_default_display_schema()
+    
+    # Add refs/outputs to results if needed (for default schema with Summary column)
+    if include_outputs:
+        for r in results:
+            if r.get("outputs"):
+                # Store formatted refs in result for display schema access
+                ref_lines = _format_refs_for_summary(r["outputs"])
+                r["refs_display"] = "\n".join(ref_lines) if ref_lines else ""
+    
+    # Use TableRenderer for schema-based rendering
+    renderer = TableRenderer(schema, console=console)
+    
+    # Pre-process results to combine goal + refs for default schema's Summary column
+    if not display_schema or not display_schema.columns:
+        # Using default schema - need to combine goal and refs into "goal" field
+        for r in results:
+            summary_parts = [r.get("goal", "")]
+            if include_outputs and r.get("refs_display"):
+                summary_parts.append(r["refs_display"])
+            r["goal"] = "\n".join(summary_parts)
+    
+    renderer.render(
+        results,
+        variant=variant,
+        show_summary=True,
+        total_count=total_count,
+        error_count=error_count,
+    )
 
 
 def _format_refs_for_markdown(outputs: dict | None) -> list[str]:
@@ -5259,12 +5262,22 @@ def _run_batch_objectives_analysis(
     # Default to brief for multi-conversation mode (token efficient)
     detail = "brief"
     assess = False
+    effective_variant = variant if variant else "brief"
     if variant:
         assess = variant.endswith("_assess")
         detail = variant.replace("_assess", "")
     
     # Default to minimal context for multi-conversation mode (token efficient)
     context_value = context if context else "minimal"
+    
+    # Resolve prompt metadata to get display schema (if variant has one)
+    from ohtv.prompts import resolve_prompt
+    display_schema = None
+    try:
+        prompt_meta = resolve_prompt("objs", effective_variant)
+        display_schema = prompt_meta.display
+    except ValueError:
+        pass  # Unknown variant - will use default display
 
     # Safety threshold for LLM analysis - require confirmation for large batches
     SUMMARY_CONFIRM_THRESHOLD = 20
@@ -5369,7 +5382,9 @@ def _run_batch_objectives_analysis(
                     display_goal = analysis.summary
                 elif analysis.primary_objectives:
                     display_goal = analysis.primary_objectives[0].description
-            return {
+            
+            # Build result dict with all analysis fields for display schema rendering
+            result_dict = {
                 "id": conv.id,
                 "short_id": conv.short_id,
                 "source": conv.source,
@@ -5377,7 +5392,23 @@ def _run_batch_objectives_analysis(
                 "goal": display_goal or "(no goal identified)",
                 "cached": analysis_result.from_cache,
                 "conv_dir": conv_dir,
-            }, None, analysis_result.cost, analysis_result.from_cache
+                # Include all analysis fields for variant-aware rendering
+                "status": analysis.status,
+                "primary_outcomes": analysis.primary_outcomes,
+                "secondary_outcomes": analysis.secondary_outcomes,
+                "primary_objectives": [
+                    {
+                        "description": obj.description,
+                        "status": obj.status.value if obj.status else None,
+                        "evidence": obj.evidence,
+                    }
+                    for obj in analysis.primary_objectives
+                ] if analysis.primary_objectives else [],
+                "summary": analysis.summary,
+                "detail_level": analysis.detail_level,
+                "assess": analysis.assess,
+            }
+            return result_dict, None, analysis_result.cost, analysis_result.from_cache
         except (ValueError, RuntimeError) as e:
             return None, (conv.short_id, str(e)[:50]), 0.0, False
         except Exception as e:
@@ -5551,7 +5582,12 @@ def _run_batch_objectives_analysis(
     elif fmt == "markdown":
         print(_format_summary_markdown(results, include_outputs=not no_outputs))
     else:
-        _print_summary_table(results, total_count, len(errors), include_outputs=not no_outputs)
+        _print_summary_table(
+            results, total_count, len(errors),
+            include_outputs=not no_outputs,
+            display_schema=display_schema,
+            variant=effective_variant,
+        )
 
     # Show cost and rate summary if any LLM calls were made
     if total_cost > 0 and fmt == "table":

--- a/src/ohtv/prompts/__init__.py
+++ b/src/ohtv/prompts/__init__.py
@@ -47,10 +47,21 @@ from ohtv.prompts.discovery import (
 )
 
 # Metadata types
-from ohtv.prompts.metadata import ContextLevel, EventFilter, PromptMetadata
+from ohtv.prompts.metadata import (
+    ContextLevel,
+    ColumnDef,
+    DisplaySchema,
+    EventFilter,
+    FieldRef,
+    PromptMetadata,
+)
 
 # Parser functions (for advanced usage)
 from ohtv.prompts.parser import parse_prompt_file
+
+# Formatters and rendering
+from ohtv.prompts.formatters import format_value, get_formatter, FORMATTERS
+from ohtv.prompts.renderer import TableRenderer, get_default_display_schema
 
 __all__ = [
     # Legacy API
@@ -70,9 +81,18 @@ __all__ = [
     "resolve_context",
     "resolve_prompt",
     # Metadata types
+    "ColumnDef",
     "ContextLevel",
+    "DisplaySchema",
     "EventFilter",
+    "FieldRef",
     "PromptMetadata",
     # Parser
     "parse_prompt_file",
+    # Formatters and rendering
+    "format_value",
+    "get_formatter",
+    "FORMATTERS",
+    "TableRenderer",
+    "get_default_display_schema",
 ]

--- a/src/ohtv/prompts/formatters.py
+++ b/src/ohtv/prompts/formatters.py
@@ -1,0 +1,167 @@
+"""Field formatters for display schema rendering.
+
+Formatters transform raw field values into display-ready strings.
+Each formatter is a function that takes a value and optional args, returning a string.
+"""
+
+import re
+from datetime import datetime
+from typing import Any, Callable
+
+
+def format_date(value: Any, args: str | None = None) -> str:
+    """Format a datetime value as YYYY-MM-DD.
+    
+    Args:
+        value: A datetime object or ISO format string
+        args: Unused
+        
+    Returns:
+        Formatted date string, or empty string if value is None
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    if isinstance(value, datetime):
+        local_time = value.astimezone()
+        return local_time.strftime("%Y-%m-%d")
+    return str(value)
+
+
+def format_status_badge(value: Any, args: str | None = None) -> str:
+    """Format a status value with emoji badge.
+    
+    Args:
+        value: Status string (achieved, not_achieved, in_progress)
+        args: Unused
+        
+    Returns:
+        Emoji + text representation
+    """
+    if value is None:
+        return ""
+    status = str(value).lower()
+    badges = {
+        "achieved": "✅",
+        "not_achieved": "❌",
+        "in_progress": "🔄",
+    }
+    badge = badges.get(status, "❓")
+    return f"{badge}"
+
+
+def format_bullet_list(value: Any, args: str | None = None) -> str:
+    """Format a list as bullet points.
+    
+    Args:
+        value: A list of strings
+        args: Unused
+        
+    Returns:
+        Bullet-formatted string with newlines
+    """
+    if value is None:
+        return ""
+    if not isinstance(value, list):
+        return str(value)
+    if not value:
+        return ""
+    return "\n".join(f"• {item}" for item in value)
+
+
+def format_truncate(value: Any, args: str | None = None) -> str:
+    """Truncate a string with ellipsis.
+    
+    Args:
+        value: String to truncate
+        args: Max length as string (e.g., "50"), defaults to 50
+        
+    Returns:
+        Truncated string with ellipsis if exceeded
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    max_len = int(args) if args else 50
+    if len(text) <= max_len:
+        return text
+    return text[:max_len - 1] + "…"
+
+
+def format_plain(value: Any, args: str | None = None) -> str:
+    """Default formatter that converts value to string.
+    
+    Args:
+        value: Any value
+        args: Unused
+        
+    Returns:
+        String representation
+    """
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
+# Registry of available formatters
+FORMATTERS: dict[str, Callable[[Any, str | None], str]] = {
+    "date": format_date,
+    "status_badge": format_status_badge,
+    "bullet_list": format_bullet_list,
+    "truncate": format_truncate,
+    "plain": format_plain,
+}
+
+
+def parse_format_spec(format_spec: str | None) -> tuple[str, str | None]:
+    """Parse a format specification into formatter name and args.
+    
+    Args:
+        format_spec: Format specification like "truncate(50)" or "date"
+        
+    Returns:
+        Tuple of (formatter_name, args) where args may be None
+    """
+    if format_spec is None:
+        return "plain", None
+    
+    # Check for function-style spec: "truncate(50)"
+    match = re.match(r"(\w+)\(([^)]*)\)", format_spec)
+    if match:
+        return match.group(1), match.group(2)
+    
+    return format_spec, None
+
+
+def get_formatter(format_spec: str | None) -> Callable[[Any], str]:
+    """Get a formatter function for the given specification.
+    
+    Args:
+        format_spec: Format specification like "truncate(50)" or "date"
+        
+    Returns:
+        Formatter function that takes a value and returns formatted string
+    """
+    name, args = parse_format_spec(format_spec)
+    formatter = FORMATTERS.get(name, format_plain)
+    return lambda value: formatter(value, args)
+
+
+def format_value(value: Any, format_spec: str | None = None) -> str:
+    """Format a value using the specified format.
+    
+    Args:
+        value: Value to format
+        format_spec: Format specification (e.g., "date", "truncate(50)")
+        
+    Returns:
+        Formatted string
+    """
+    formatter = get_formatter(format_spec)
+    return formatter(value)

--- a/src/ohtv/prompts/formatters.py
+++ b/src/ohtv/prompts/formatters.py
@@ -86,7 +86,7 @@ def format_truncate(value: Any, args: str | None = None) -> str:
     if value is None:
         return ""
     text = str(value)
-    max_len = int(args) if args else 50
+    max_len = int(args) if args and args.isdigit() else 50
     if len(text) <= max_len:
         return text
     return text[:max_len - 1] + "…"

--- a/src/ohtv/prompts/metadata.py
+++ b/src/ohtv/prompts/metadata.py
@@ -1,6 +1,55 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 from typing import Literal
+
+
+@dataclass
+class FieldRef:
+    """Reference to a field in the analysis output, with optional formatting."""
+    field_name: str
+    format: str | None = None
+    prefix: str | None = None
+
+
+@dataclass
+class ColumnDef:
+    """Column definition for table display."""
+    name: str
+    field: str | None = None
+    fields: list[FieldRef | str] = dataclass_field(default_factory=list)
+    format: str | None = None
+    width: int | None = None
+    combine: Literal["newline", "space", "comma"] = "newline"
+    show_when: str | None = None
+
+    def get_field_refs(self) -> list[FieldRef]:
+        """Get all field references as FieldRef objects.
+        
+        If `field` is set (single field), returns a single-item list.
+        If `fields` is set, returns the list with strings converted to FieldRef.
+        """
+        if self.field:
+            return [FieldRef(field_name=self.field, format=self.format)]
+        result = []
+        for f in self.fields:
+            if isinstance(f, str):
+                result.append(FieldRef(field_name=f))
+            else:
+                result.append(f)
+        return result
+
+
+@dataclass
+class DisplaySchema:
+    """Schema for displaying analysis results in table format."""
+    columns: list[ColumnDef] = dataclass_field(default_factory=list)
+
+    def get_column(self, name: str) -> ColumnDef | None:
+        """Get column definition by name."""
+        for col in self.columns:
+            if col.name == name:
+                return col
+        return None
 
 
 @dataclass
@@ -40,7 +89,7 @@ class ContextLevel:
     number: int
     name: str
     include: list[EventFilter]
-    exclude: list[EventFilter] = field(default_factory=list)
+    exclude: list[EventFilter] = dataclass_field(default_factory=list)
     truncate: int = 0
 
     def matches(self, event: dict) -> bool:
@@ -71,14 +120,15 @@ class PromptMetadata:
     variant: str
     description: str = ""
     default: bool = False
-    context_levels: dict[int, ContextLevel] = field(default_factory=dict)
+    context_levels: dict[int, ContextLevel] = dataclass_field(default_factory=dict)
     default_context: int = 1
     output_schema: dict | None = None
     handler: str | None = None
-    tags: list[str] = field(default_factory=list)
+    tags: list[str] = dataclass_field(default_factory=list)
     path: Path | None = None
     content: str = ""
     content_hash: str = ""
+    display: DisplaySchema | None = None
 
     def get_context_level(self, level: int | str) -> ContextLevel:
         """Get context level by number or name.

--- a/src/ohtv/prompts/objs/brief.md
+++ b/src/ohtv/prompts/objs/brief.md
@@ -39,6 +39,19 @@ output:
     properties:
       goal:
         type: string
+
+display:
+  table:
+    columns:
+      - name: ID
+        field: short_id
+        width: 7
+      - name: Date
+        field: created_at
+        format: date
+        width: 10
+      - name: Summary
+        field: goal
 ---
 Analyze this conversation between a user and an AI coding assistant.
 

--- a/src/ohtv/prompts/objs/standard_assess.md
+++ b/src/ohtv/prompts/objs/standard_assess.md
@@ -47,6 +47,31 @@ output:
         type: array
         items:
           type: string
+
+display:
+  table:
+    columns:
+      - name: ID
+        field: short_id
+        width: 7
+      - name: Date
+        field: created_at
+        format: date
+        width: 10
+      - name: Status
+        field: status
+        format: status_badge
+        width: 6
+      - name: Summary
+        fields:
+          - goal
+          - field: primary_outcomes
+            format: bullet_list
+            prefix: "Primary:"
+          - field: secondary_outcomes
+            format: bullet_list
+            prefix: "Secondary:"
+        combine: newline
 ---
 Analyze this conversation between a user and an AI coding assistant.
 

--- a/src/ohtv/prompts/parser.py
+++ b/src/ohtv/prompts/parser.py
@@ -1,7 +1,10 @@
 import hashlib
 import yaml
 from pathlib import Path
-from ohtv.prompts.metadata import EventFilter, ContextLevel, PromptMetadata
+from ohtv.prompts.metadata import (
+    EventFilter, ContextLevel, PromptMetadata,
+    DisplaySchema, ColumnDef, FieldRef
+)
 
 
 def parse_frontmatter(content: str) -> tuple[dict, str]:
@@ -66,6 +69,66 @@ def parse_context_level(data: dict) -> ContextLevel:
     )
 
 
+def parse_field_ref(data: dict | str) -> FieldRef:
+    """Parse a field reference from frontmatter data.
+    
+    Args:
+        data: Either a string (field name) or dict with 'field', optional 'format', 'prefix'
+        
+    Returns:
+        FieldRef instance
+    """
+    if isinstance(data, str):
+        return FieldRef(field_name=data)
+    return FieldRef(
+        field_name=data.get("field", ""),
+        format=data.get("format"),
+        prefix=data.get("prefix")
+    )
+
+
+def parse_column_def(data: dict) -> ColumnDef:
+    """Parse a column definition from frontmatter data.
+    
+    Args:
+        data: Dict with 'name', and either 'field' or 'fields' plus optional formatting
+        
+    Returns:
+        ColumnDef instance
+    """
+    fields = []
+    if "fields" in data:
+        fields = [parse_field_ref(f) for f in data["fields"]]
+    
+    return ColumnDef(
+        name=data.get("name", ""),
+        field=data.get("field"),
+        fields=fields,
+        format=data.get("format"),
+        width=data.get("width"),
+        combine=data.get("combine", "newline"),
+        show_when=data.get("show_when")
+    )
+
+
+def parse_display_schema(data: dict) -> DisplaySchema:
+    """Parse a display schema from frontmatter data.
+    
+    Args:
+        data: Dict with 'table' key containing column definitions
+        
+    Returns:
+        DisplaySchema instance
+    """
+    columns = []
+    if "table" in data:
+        table_data = data["table"]
+        if "columns" in table_data:
+            columns = [parse_column_def(c) for c in table_data["columns"]]
+    
+    return DisplaySchema(columns=columns)
+
+
 def parse_prompt_file(path: Path) -> PromptMetadata:
     """Parse a prompt file and extract metadata from YAML frontmatter.
     
@@ -119,6 +182,11 @@ def parse_prompt_file(path: Path) -> PromptMetadata:
     if output_schema is None and "output" in frontmatter:
         output_schema = frontmatter["output"].get("schema")
     
+    # Parse display schema if present
+    display = None
+    if "display" in frontmatter:
+        display = parse_display_schema(frontmatter["display"])
+    
     return PromptMetadata(
         id=prompt_id,
         family=family,
@@ -132,5 +200,6 @@ def parse_prompt_file(path: Path) -> PromptMetadata:
         tags=frontmatter.get("tags", []),
         path=path,
         content=prompt_content,
-        content_hash=content_hash
+        content_hash=content_hash,
+        display=display
     )

--- a/src/ohtv/prompts/renderer.py
+++ b/src/ohtv/prompts/renderer.py
@@ -1,0 +1,206 @@
+"""Table renderer for display schema-based output.
+
+The TableRenderer takes analysis results and a display schema,
+and renders them as a Rich table.
+"""
+
+from typing import Any
+from rich.console import Console
+from rich.table import Table
+
+from ohtv.prompts.metadata import DisplaySchema, ColumnDef, FieldRef
+from ohtv.prompts.formatters import format_value
+
+
+class TableRenderer:
+    """Renders analysis results as a Rich table using display schema."""
+    
+    def __init__(self, display_schema: DisplaySchema, console: Console | None = None):
+        """Initialize renderer with display schema.
+        
+        Args:
+            display_schema: Schema defining table columns and formatting
+            console: Rich console for output (creates new one if not provided)
+        """
+        self.schema = display_schema
+        self.console = console or Console()
+    
+    def _get_field_value(self, data: dict, field_name: str) -> Any:
+        """Get a field value from data dict, supporting nested paths.
+        
+        Args:
+            data: Data dictionary
+            field_name: Field name (can include dots for nested access)
+            
+        Returns:
+            Field value or None if not found
+        """
+        if "." in field_name:
+            parts = field_name.split(".")
+            value = data
+            for part in parts:
+                if isinstance(value, dict):
+                    value = value.get(part)
+                else:
+                    return None
+            return value
+        return data.get(field_name)
+    
+    def _format_field_ref(self, data: dict, field_ref: FieldRef) -> str:
+        """Format a single field reference.
+        
+        Args:
+            data: Data dictionary containing field values
+            field_ref: Field reference with formatting instructions
+            
+        Returns:
+            Formatted string for this field
+        """
+        value = self._get_field_value(data, field_ref.field_name)
+        if value is None:
+            return ""
+        
+        formatted = format_value(value, field_ref.format)
+        
+        if field_ref.prefix and formatted:
+            return f"{field_ref.prefix} {formatted}"
+        return formatted
+    
+    def _format_cell(self, data: dict, column: ColumnDef) -> str:
+        """Format a cell value for a column.
+        
+        Args:
+            data: Row data dictionary
+            column: Column definition
+            
+        Returns:
+            Formatted cell string
+        """
+        field_refs = column.get_field_refs()
+        if not field_refs:
+            return ""
+        
+        parts = []
+        for field_ref in field_refs:
+            formatted = self._format_field_ref(data, field_ref)
+            if formatted:
+                parts.append(formatted)
+        
+        if not parts:
+            return ""
+        
+        # Combine parts according to column specification
+        combiners = {
+            "newline": "\n\n",
+            "space": " ",
+            "comma": ", ",
+        }
+        separator = combiners.get(column.combine, "\n\n")
+        return separator.join(parts)
+    
+    def _should_show_column(self, column: ColumnDef, variant: str | None = None) -> bool:
+        """Check if column should be shown for current variant.
+        
+        Args:
+            column: Column definition
+            variant: Current prompt variant name
+            
+        Returns:
+            True if column should be displayed
+        """
+        if column.show_when is None:
+            return True
+        if variant is None:
+            return True
+        # show_when can be a variant name or comma-separated list
+        allowed = [v.strip() for v in column.show_when.split(",")]
+        return variant in allowed
+    
+    def create_table(self, variant: str | None = None) -> Table:
+        """Create a Rich Table with column definitions from schema.
+        
+        Args:
+            variant: Current prompt variant (for show_when filtering)
+            
+        Returns:
+            Configured Rich Table
+        """
+        table = Table(show_header=True, header_style="bold", show_lines=True)
+        
+        for col in self.schema.columns:
+            if not self._should_show_column(col, variant):
+                continue
+            
+            # Apply column styling based on column name
+            style = None
+            no_wrap = False
+            if col.name.lower() == "id":
+                style = "cyan"
+                no_wrap = True
+            elif col.name.lower() == "date":
+                no_wrap = True
+            
+            width = col.width
+            table.add_column(col.name, style=style, width=width, no_wrap=no_wrap)
+        
+        return table
+    
+    def render(
+        self,
+        results: list[dict],
+        variant: str | None = None,
+        show_summary: bool = True,
+        total_count: int | None = None,
+        error_count: int = 0,
+    ) -> None:
+        """Render results as a table to console.
+        
+        Args:
+            results: List of result dictionaries
+            variant: Current prompt variant (for show_when filtering)
+            show_summary: Whether to show summary line after table
+            total_count: Total count for summary (defaults to len(results))
+            error_count: Number of errors for summary
+        """
+        table = self.create_table(variant)
+        
+        for row_data in results:
+            row_values = []
+            for col in self.schema.columns:
+                if not self._should_show_column(col, variant):
+                    continue
+                cell_value = self._format_cell(row_data, col)
+                row_values.append(cell_value)
+            table.add_row(*row_values)
+        
+        self.console.print(table)
+        
+        if show_summary:
+            total = total_count if total_count is not None else len(results)
+            showing = len(results)
+            cached = sum(1 for r in results if r.get("cached", False))
+            
+            parts = [f"Showing {showing} of {total}"]
+            if showing > 0:
+                parts.append(f"({cached}/{showing} cached)")
+            if error_count > 0:
+                parts.append(f"{error_count} failed")
+            
+            self.console.print(f"[dim]{' '.join(parts)}[/dim]")
+
+
+def get_default_display_schema() -> DisplaySchema:
+    """Get the default display schema for backward compatibility.
+    
+    This matches the original hardcoded table format.
+    
+    Returns:
+        DisplaySchema with ID, Date, and Summary columns
+    """
+    from ohtv.prompts.metadata import ColumnDef, FieldRef
+    
+    return DisplaySchema(columns=[
+        ColumnDef(name="ID", field="short_id", width=7),
+        ColumnDef(name="Date", field="created_at", format="date", width=10),
+        ColumnDef(name="Summary", field="goal"),
+    ])

--- a/src/ohtv/prompts/renderer.py
+++ b/src/ohtv/prompts/renderer.py
@@ -197,6 +197,8 @@ def get_default_display_schema() -> DisplaySchema:
     Returns:
         DisplaySchema with ID, Date, and Summary columns
     """
+    # Import here to avoid circular dependency - cli.py imports from prompts/__init__.py
+    # which re-exports this function, and metadata.py is part of the same package
     from ohtv.prompts.metadata import ColumnDef, FieldRef
     
     return DisplaySchema(columns=[

--- a/src/ohtv/prompts/renderer.py
+++ b/src/ohtv/prompts/renderer.py
@@ -202,5 +202,8 @@ def get_default_display_schema() -> DisplaySchema:
     return DisplaySchema(columns=[
         ColumnDef(name="ID", field="short_id", width=7),
         ColumnDef(name="Date", field="created_at", format="date", width=10),
-        ColumnDef(name="Summary", field="goal"),
+        ColumnDef(name="Summary", fields=[
+            FieldRef(field_name="goal"),
+            FieldRef(field_name="refs_display"),
+        ], combine="newline"),
     ])

--- a/tests/integration/test_gen_objs_batch.py
+++ b/tests/integration/test_gen_objs_batch.py
@@ -560,3 +560,125 @@ class TestMigrationFromSummary:
         assert "--no-cache" in result.output
         # Old --refresh should NOT be present
         assert "--refresh" not in result.output or "-r, --refresh" not in result.output
+
+
+# =============================================================================
+# Display Schema Integration Tests
+# =============================================================================
+
+
+def create_mock_analysis_result_with_status(
+    goal: str = "Test goal",
+    status: str = "achieved",
+    primary_outcomes: list[str] | None = None,
+    secondary_outcomes: list[str] | None = None,
+    from_cache: bool = False,
+    cost: float = 0.001,
+):
+    """Create a mock AnalysisResult with status and outcomes for standard_assess."""
+    from ohtv.analysis.objectives import ObjectiveAnalysis, AnalysisResult
+    
+    analysis = ObjectiveAnalysis(
+        conversation_id="test123",
+        context_level="default",
+        detail_level="standard",
+        assess=True,
+        goal=goal,
+        status=status,
+        primary_outcomes=primary_outcomes or ["Outcome 1", "Outcome 2"],
+        secondary_outcomes=secondary_outcomes or ["Secondary 1"],
+        analyzed_at=datetime.now(timezone.utc),
+        model_used="test-model",
+        event_count=5,
+        content_hash="abc123",
+    )
+    return AnalysisResult(analysis=analysis, cost=cost, from_cache=from_cache)
+
+
+class TestDisplaySchemaIntegration:
+    """Integration tests for display schema rendering with different variants."""
+
+    def test_standard_assess_displays_status_badge(self, runner, tmp_path):
+        """Verify standard_assess variant shows Status column with emoji badge."""
+        # Create conversations in .openhands/conversations to match CLI expectations
+        convs_dir = tmp_path / ".openhands" / "conversations"
+        convs_dir.mkdir(parents=True)
+        
+        now = datetime.now(timezone.utc)
+        create_mock_conversation(
+            convs_dir, "test123abc456",
+            title="Test conversation",
+            created_at=now,
+        )
+
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}), \
+             patch("ohtv.analysis.analyze_objectives") as mock_analyze, \
+             patch("ohtv.cli._count_uncached_conversations_fast") as mock_count:
+            
+            mock_analyze.return_value = create_mock_analysis_result_with_status(
+                goal="Implement user authentication",
+                status="achieved",
+                primary_outcomes=["Login endpoint created", "Session management added"],
+            )
+            mock_count.return_value = 0
+            
+            result = runner.invoke(main, ["gen", "objs", "-v", "standard_assess"])
+            
+            # Should display the achieved status badge
+            assert "✅" in result.output, f"Expected status badge in output: {result.output}"
+
+    def test_standard_assess_displays_not_achieved_badge(self, runner, tmp_path):
+        """Verify not_achieved status shows ❌ badge."""
+        convs_dir = tmp_path / ".openhands" / "conversations"
+        convs_dir.mkdir(parents=True)
+        
+        now = datetime.now(timezone.utc)
+        create_mock_conversation(
+            convs_dir, "test456def789",
+            title="Failed task",
+            created_at=now,
+        )
+
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}), \
+             patch("ohtv.analysis.analyze_objectives") as mock_analyze, \
+             patch("ohtv.cli._count_uncached_conversations_fast") as mock_count:
+            
+            mock_analyze.return_value = create_mock_analysis_result_with_status(
+                goal="Deploy to production",
+                status="not_achieved",
+            )
+            mock_count.return_value = 0
+            
+            result = runner.invoke(main, ["gen", "objs", "-v", "standard_assess"])
+            
+            assert "❌" in result.output, f"Expected not_achieved badge in output: {result.output}"
+
+    def test_standard_assess_displays_outcomes(self, runner, tmp_path):
+        """Verify primary and secondary outcomes are displayed."""
+        convs_dir = tmp_path / ".openhands" / "conversations"
+        convs_dir.mkdir(parents=True)
+        
+        now = datetime.now(timezone.utc)
+        create_mock_conversation(
+            convs_dir, "test789ghi012",
+            title="Feature implementation",
+            created_at=now,
+        )
+
+        with patch.dict(os.environ, {"HOME": str(tmp_path)}), \
+             patch("ohtv.analysis.analyze_objectives") as mock_analyze, \
+             patch("ohtv.cli._count_uncached_conversations_fast") as mock_count:
+            
+            mock_analyze.return_value = create_mock_analysis_result_with_status(
+                goal="Add pagination to API",
+                status="achieved",
+                primary_outcomes=["Pagination endpoint added", "Tests written"],
+                secondary_outcomes=["Documentation updated"],
+            )
+            mock_count.return_value = 0
+            
+            result = runner.invoke(main, ["gen", "objs", "-v", "standard_assess"])
+            
+            # Check that outcomes are displayed (bullet format uses •)
+            assert "Primary:" in result.output or "Pagination" in result.output, \
+                f"Expected outcomes in output: {result.output}"

--- a/tests/unit/prompts/test_display_schema.py
+++ b/tests/unit/prompts/test_display_schema.py
@@ -382,3 +382,70 @@ class TestFormatValue:
         """Test format_value with None format uses plain."""
         result = format_value(["a", "b"], None)
         assert result == "a, b"
+
+
+class TestTableRenderer:
+    """Tests for TableRenderer class."""
+    
+    def test_nested_field_access(self):
+        """Test nested field access like user.name."""
+        from ohtv.prompts.renderer import TableRenderer
+        
+        schema = DisplaySchema(columns=[
+            ColumnDef(name="Author", field="user.name"),
+        ])
+        renderer = TableRenderer(schema)
+        
+        data = {"user": {"name": "Alice", "email": "alice@example.com"}}
+        value = renderer._get_field_value(data, "user.name")
+        assert value == "Alice"
+    
+    def test_nested_field_access_deep(self):
+        """Test deeply nested field access."""
+        from ohtv.prompts.renderer import TableRenderer
+        
+        schema = DisplaySchema(columns=[])
+        renderer = TableRenderer(schema)
+        
+        data = {"level1": {"level2": {"level3": "deep_value"}}}
+        value = renderer._get_field_value(data, "level1.level2.level3")
+        assert value == "deep_value"
+    
+    def test_nested_field_access_missing(self):
+        """Test nested field access with missing intermediate key."""
+        from ohtv.prompts.renderer import TableRenderer
+        
+        schema = DisplaySchema(columns=[])
+        renderer = TableRenderer(schema)
+        
+        data = {"user": {"name": "Bob"}}
+        value = renderer._get_field_value(data, "user.email.domain")
+        assert value is None
+    
+    def test_nested_field_access_non_dict(self):
+        """Test nested field access when intermediate value is not a dict."""
+        from ohtv.prompts.renderer import TableRenderer
+        
+        schema = DisplaySchema(columns=[])
+        renderer = TableRenderer(schema)
+        
+        data = {"user": "string_value"}
+        value = renderer._get_field_value(data, "user.name")
+        assert value is None
+
+
+class TestTruncateFormatterEdgeCases:
+    """Additional tests for truncate formatter edge cases."""
+    
+    def test_truncate_with_invalid_args(self):
+        """Test truncate gracefully handles non-numeric args."""
+        result = format_truncate("This is a test string", "invalid")
+        # Should fall back to default of 50
+        assert result == "This is a test string"  # String is shorter than 50
+    
+    def test_truncate_with_empty_args(self):
+        """Test truncate with empty string args."""
+        result = format_truncate("A" * 100, "")
+        # Should fall back to default of 50
+        assert len(result) == 50
+        assert result.endswith("…")

--- a/tests/unit/prompts/test_display_schema.py
+++ b/tests/unit/prompts/test_display_schema.py
@@ -1,0 +1,384 @@
+"""Tests for display schema parsing and rendering."""
+
+import pytest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from ohtv.prompts.metadata import DisplaySchema, ColumnDef, FieldRef
+from ohtv.prompts.parser import (
+    parse_field_ref,
+    parse_column_def,
+    parse_display_schema,
+    parse_prompt_file,
+)
+from ohtv.prompts.formatters import (
+    format_date,
+    format_status_badge,
+    format_bullet_list,
+    format_truncate,
+    format_value,
+    get_formatter,
+    parse_format_spec,
+)
+
+
+class TestFieldRef:
+    """Tests for FieldRef dataclass."""
+    
+    def test_basic_field_ref(self):
+        """Test basic field reference creation."""
+        ref = FieldRef(field_name="goal")
+        assert ref.field_name == "goal"
+        assert ref.format is None
+        assert ref.prefix is None
+    
+    def test_field_ref_with_format(self):
+        """Test field reference with format."""
+        ref = FieldRef(field_name="created_at", format="date")
+        assert ref.field_name == "created_at"
+        assert ref.format == "date"
+    
+    def test_field_ref_with_prefix(self):
+        """Test field reference with prefix."""
+        ref = FieldRef(field_name="outcomes", format="bullet_list", prefix="Primary:")
+        assert ref.field_name == "outcomes"
+        assert ref.prefix == "Primary:"
+
+
+class TestColumnDef:
+    """Tests for ColumnDef dataclass."""
+    
+    def test_single_field_column(self):
+        """Test column with single field."""
+        col = ColumnDef(name="ID", field="short_id", width=7)
+        refs = col.get_field_refs()
+        assert len(refs) == 1
+        assert refs[0].field_name == "short_id"
+    
+    def test_multi_field_column(self):
+        """Test column with multiple fields."""
+        col = ColumnDef(
+            name="Summary",
+            fields=[
+                FieldRef(field_name="goal"),
+                FieldRef(field_name="outcomes", format="bullet_list"),
+            ],
+            combine="newline"
+        )
+        refs = col.get_field_refs()
+        assert len(refs) == 2
+        assert refs[0].field_name == "goal"
+        assert refs[1].field_name == "outcomes"
+    
+    def test_fields_with_strings(self):
+        """Test column where fields contains string shortcuts."""
+        col = ColumnDef(
+            name="Summary",
+            fields=["goal", "status"]
+        )
+        refs = col.get_field_refs()
+        assert len(refs) == 2
+        assert refs[0].field_name == "goal"
+        assert refs[1].field_name == "status"
+    
+    def test_show_when_filtering(self):
+        """Test show_when attribute."""
+        col = ColumnDef(name="Status", field="status", show_when="standard_assess")
+        assert col.show_when == "standard_assess"
+
+
+class TestDisplaySchema:
+    """Tests for DisplaySchema dataclass."""
+    
+    def test_empty_schema(self):
+        """Test empty display schema."""
+        schema = DisplaySchema()
+        assert len(schema.columns) == 0
+    
+    def test_get_column(self):
+        """Test get_column method."""
+        schema = DisplaySchema(columns=[
+            ColumnDef(name="ID", field="short_id"),
+            ColumnDef(name="Date", field="created_at"),
+        ])
+        col = schema.get_column("ID")
+        assert col is not None
+        assert col.field == "short_id"
+    
+    def test_get_column_not_found(self):
+        """Test get_column returns None for unknown column."""
+        schema = DisplaySchema(columns=[
+            ColumnDef(name="ID", field="short_id"),
+        ])
+        assert schema.get_column("Unknown") is None
+
+
+class TestParseFieldRef:
+    """Tests for parse_field_ref function."""
+    
+    def test_string_input(self):
+        """Test parsing string as field name."""
+        ref = parse_field_ref("goal")
+        assert ref.field_name == "goal"
+        assert ref.format is None
+    
+    def test_dict_input(self):
+        """Test parsing dict with all fields."""
+        ref = parse_field_ref({
+            "field": "outcomes",
+            "format": "bullet_list",
+            "prefix": "Results:"
+        })
+        assert ref.field_name == "outcomes"
+        assert ref.format == "bullet_list"
+        assert ref.prefix == "Results:"
+    
+    def test_dict_minimal(self):
+        """Test parsing dict with only field."""
+        ref = parse_field_ref({"field": "status"})
+        assert ref.field_name == "status"
+        assert ref.format is None
+
+
+class TestParseColumnDef:
+    """Tests for parse_column_def function."""
+    
+    def test_single_field(self):
+        """Test parsing column with single field."""
+        col = parse_column_def({
+            "name": "ID",
+            "field": "short_id",
+            "width": 7
+        })
+        assert col.name == "ID"
+        assert col.field == "short_id"
+        assert col.width == 7
+    
+    def test_multiple_fields(self):
+        """Test parsing column with multiple fields."""
+        col = parse_column_def({
+            "name": "Summary",
+            "fields": [
+                "goal",
+                {"field": "outcomes", "format": "bullet_list"}
+            ],
+            "combine": "newline"
+        })
+        assert col.name == "Summary"
+        assert len(col.fields) == 2
+        assert col.combine == "newline"
+    
+    def test_with_format(self):
+        """Test parsing column with format."""
+        col = parse_column_def({
+            "name": "Date",
+            "field": "created_at",
+            "format": "date"
+        })
+        assert col.format == "date"
+
+
+class TestParseDisplaySchema:
+    """Tests for parse_display_schema function."""
+    
+    def test_full_schema(self):
+        """Test parsing complete display schema."""
+        schema = parse_display_schema({
+            "table": {
+                "columns": [
+                    {"name": "ID", "field": "short_id", "width": 7},
+                    {"name": "Date", "field": "created_at", "format": "date"},
+                    {"name": "Summary", "field": "goal"}
+                ]
+            }
+        })
+        assert len(schema.columns) == 3
+        assert schema.columns[0].name == "ID"
+        assert schema.columns[1].format == "date"
+    
+    def test_empty_schema(self):
+        """Test parsing empty display section."""
+        schema = parse_display_schema({})
+        assert len(schema.columns) == 0
+    
+    def test_no_columns(self):
+        """Test parsing display with no columns."""
+        schema = parse_display_schema({"table": {}})
+        assert len(schema.columns) == 0
+
+
+class TestPromptFileWithDisplay:
+    """Tests for parsing prompt files with display sections."""
+    
+    def test_prompt_with_display_section(self):
+        """Test parsing prompt file with display section."""
+        content = """---
+id: test.variant
+description: Test prompt
+
+display:
+  table:
+    columns:
+      - name: ID
+        field: short_id
+        width: 7
+      - name: Status
+        field: status
+        format: status_badge
+---
+Prompt content"""
+        
+        with NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+        
+        try:
+            meta = parse_prompt_file(path)
+            assert meta.display is not None
+            assert len(meta.display.columns) == 2
+            assert meta.display.columns[0].name == "ID"
+            assert meta.display.columns[1].format == "status_badge"
+        finally:
+            path.unlink()
+    
+    def test_prompt_without_display_section(self):
+        """Test parsing prompt file without display section."""
+        content = """---
+id: test.basic
+---
+Simple prompt"""
+        
+        with NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write(content)
+            f.flush()
+            path = Path(f.name)
+        
+        try:
+            meta = parse_prompt_file(path)
+            assert meta.display is None
+        finally:
+            path.unlink()
+
+
+class TestFormatters:
+    """Tests for field formatters."""
+    
+    def test_format_date_datetime(self):
+        """Test formatting datetime object."""
+        dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=timezone.utc)
+        result = format_date(dt)
+        assert "2024-03-15" in result
+    
+    def test_format_date_string(self):
+        """Test formatting ISO string."""
+        result = format_date("2024-03-15T10:30:00Z")
+        assert "2024-03-15" in result
+    
+    def test_format_date_none(self):
+        """Test formatting None."""
+        result = format_date(None)
+        assert result == ""
+    
+    def test_format_status_badge_achieved(self):
+        """Test formatting achieved status."""
+        result = format_status_badge("achieved")
+        assert "✅" in result
+    
+    def test_format_status_badge_not_achieved(self):
+        """Test formatting not_achieved status."""
+        result = format_status_badge("not_achieved")
+        assert "❌" in result
+    
+    def test_format_status_badge_in_progress(self):
+        """Test formatting in_progress status."""
+        result = format_status_badge("in_progress")
+        assert "🔄" in result
+    
+    def test_format_bullet_list(self):
+        """Test formatting list as bullets."""
+        result = format_bullet_list(["item1", "item2", "item3"])
+        assert "• item1" in result
+        assert "• item2" in result
+        assert "• item3" in result
+    
+    def test_format_bullet_list_empty(self):
+        """Test formatting empty list."""
+        result = format_bullet_list([])
+        assert result == ""
+    
+    def test_format_truncate(self):
+        """Test truncating long text."""
+        result = format_truncate("This is a very long text that needs to be truncated", "20")
+        assert len(result) == 20
+        assert result.endswith("…")
+    
+    def test_format_truncate_short_text(self):
+        """Test truncate with short text."""
+        result = format_truncate("Short", "50")
+        assert result == "Short"
+
+
+class TestFormatSpecParsing:
+    """Tests for format specification parsing."""
+    
+    def test_simple_spec(self):
+        """Test parsing simple format spec."""
+        name, args = parse_format_spec("date")
+        assert name == "date"
+        assert args is None
+    
+    def test_spec_with_args(self):
+        """Test parsing format spec with arguments."""
+        name, args = parse_format_spec("truncate(50)")
+        assert name == "truncate"
+        assert args == "50"
+    
+    def test_none_spec(self):
+        """Test parsing None spec."""
+        name, args = parse_format_spec(None)
+        assert name == "plain"
+        assert args is None
+
+
+class TestGetFormatter:
+    """Tests for get_formatter function."""
+    
+    def test_get_date_formatter(self):
+        """Test getting date formatter."""
+        formatter = get_formatter("date")
+        dt = datetime(2024, 3, 15, tzinfo=timezone.utc)
+        assert "2024-03-15" in formatter(dt)
+    
+    def test_get_truncate_formatter_with_args(self):
+        """Test getting truncate formatter with length arg."""
+        formatter = get_formatter("truncate(10)")
+        result = formatter("This is a long text")
+        assert len(result) == 10
+    
+    def test_get_unknown_formatter(self):
+        """Test getting unknown formatter returns plain."""
+        formatter = get_formatter("unknown_format")
+        result = formatter("test value")
+        assert result == "test value"
+
+
+class TestFormatValue:
+    """Tests for format_value function."""
+    
+    def test_format_value_date(self):
+        """Test format_value with date."""
+        dt = datetime(2024, 3, 15, tzinfo=timezone.utc)
+        result = format_value(dt, "date")
+        assert "2024-03-15" in result
+    
+    def test_format_value_status_badge(self):
+        """Test format_value with status_badge."""
+        result = format_value("achieved", "status_badge")
+        assert "✅" in result
+    
+    def test_format_value_none_format(self):
+        """Test format_value with None format uses plain."""
+        result = format_value(["a", "b"], None)
+        assert result == "a, b"


### PR DESCRIPTION
## Summary

Implements #23 - When running `ohtv gen objs -v standard_assess` in batch mode, the output now correctly displays all fields returned by the LLM (status, primary_outcomes, secondary_outcomes) instead of just showing the goal.

## Problem

The `_analyze_one` function only extracted the `goal` field, and `_print_summary_table` had hardcoded column definitions, ignoring the richer data returned by variants like `standard_assess`.

## Solution

Extended prompt frontmatter with a `display` section that defines how to render results for each variant. This keeps display configuration co-located with the prompt that produces those fields.

### Example: `objs/standard_assess.md`

```yaml
display:
  table:
    columns:
      - name: ID
        field: short_id
        width: 7
      - name: Date
        field: created_at
        format: date
        width: 10
      - name: Status
        field: status
        format: status_badge
        width: 6
      - name: Summary
        fields:
          - goal
          - field: primary_outcomes
            format: bullet_list
            prefix: "Primary:"
          - field: secondary_outcomes
            format: bullet_list
            prefix: "Secondary:"
        combine: newline
```

### Key Features

1. **Single field columns**: `field: status` 
2. **Combined columns**: `fields: [goal, primary_outcomes, ...]` with `combine: newline`
3. **Formatters**: `format: date | status_badge | bullet_list | truncate(50)`
4. **Conditional display**: `show_when: assess` for columns only shown in assessed variants
5. **Width hints**: Optional `width` for consistent column sizing

## Changes

### New Components
- `FieldRef`, `ColumnDef`, `DisplaySchema` dataclasses in `metadata.py`
- `parse_field_ref`, `parse_column_def`, `parse_display_schema` in `parser.py`
- `formatters.py` with pluggable formatters (date, status_badge, bullet_list, truncate)
- `renderer.py` with `TableRenderer` class for schema-based rendering

### Integration
- Updated `_analyze_one` to include all analysis fields in result dict
- Updated `_print_summary_table` to use `TableRenderer` when display schema available
- Added `display` field to `PromptMetadata` dataclass
- Exported new types and functions from `prompts/__init__.py`

### Prompt Updates
- Added display schema to `objs/brief.md`
- Added display schema to `objs/standard_assess.md` with Status column

### Tests
- Added `test_display_schema.py` with 40 tests covering all new functionality

## Fallback Behavior

If no `display` section exists in prompt frontmatter, uses current hardcoded brief-style table (backward compatible).

## Testing

```bash
uv run python -m pytest tests/unit/prompts/ -v  # All 99 tests pass
uv run python -m pytest tests/unit/ --ignore=tests/unit/test_cli_helpers.py -v  # 539 tests pass
```

---
*This PR was created by an AI assistant (OpenHands) on behalf of jpshackelford.*

Closes #23

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5abb27af-209f-4771-9da4-de33790cada4)