### PR TITLE
fix(prompts): add refs_display to display schemas

### DIFF
--- a/src/ohtv/prompts/objs/brief.md
+++ b/src/ohtv/prompts/objs/brief.md
@@ -51,7 +51,10 @@ display:
         format: date
         width: 10
       - name: Summary
-        field: goal
+        fields:
+          - goal
+          - refs_display
+        combine: newline
 ---
 Analyze this conversation between a user and an AI coding assistant.
 

--- a/src/ohtv/prompts/objs/standard_assess.md
+++ b/src/ohtv/prompts/objs/standard_assess.md
@@ -71,6 +71,7 @@ display:
           - field: secondary_outcomes
             format: bullet_list
             prefix: "Secondary:"
+          - refs_display
         combine: newline
 ---
 Analyze this conversation between a user and an AI coding assistant.


### PR DESCRIPTION
## Summary

Fixes refs data (Repos, PRs, Issues) missing from the table output when using `gen objs -W` or other batch modes.

## Problem

After PR #24 introduced the display schema system, prompts that define their own display schemas were no longer showing refs data in the Summary column. The `brief.md` and `standard_assess.md` prompts had display schemas that only included the `goal` field but not the `refs_display` field.

## Root Cause Analysis

1. The default display schema (in `get_default_display_schema()`) correctly includes both `goal` and `refs_display` in the Summary column
2. When a prompt defines its own display schema, the code uses that schema instead of the default
3. The prompt-specific schemas didn't include `refs_display`

## Solution

Add `refs_display` to the Summary column's `fields` list in both `brief.md` and `standard_assess.md` prompts.

## Before

```
┃ ID      ┃ Date       ┃ Summary                           ┃
├─────────┼────────────┼───────────────────────────────────┤
│ bb44af5 │ 2026-04-21 │ Clone the GitHub pull request...  │
```

## After

```
┃ ID      ┃ Date       ┃ Summary                           ┃
├─────────┼────────────┼───────────────────────────────────┤
│ bb44af5 │ 2026-04-21 │ Clone the GitHub pull request...  │
│         │            │                                   │
│         │            │ Repos: jpshackelford/ohtv [...]   │
│         │            │ PRs: jpshackelford/ohtv/pull/24   │
```

## Testing

- ✅ Verified `ohtv gen objs -W` now shows refs data in table
- ✅ All 46 display schema unit tests pass
- ✅ All 3 display schema integration tests pass

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a5dfee29-56ba-451c-b3e3-a93395f4cbc4)