### PR TITLE
Add parallel downloads and progress bar to sync command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,17 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - Event loading/transcript building: <100ms
     - Cache operations: <10ms
 
-20. **Parallel LLM processing**: The `gen objs` command (batch mode) automatically uses parallel processing (20 workers) when analyzing multiple conversations. This is an internal optimization - no CLI option needed. Uses `ThreadPoolExecutor` with thread-safe counters. **Graceful shutdown**: SIGINT/SIGTERM signals are caught - in-flight LLM requests complete and cache is saved before exit, preventing data corruption. **Confirmation prompt**: Shows model name when analyzing >20 conversations.
+20. **Parallel processing**: Multiple commands use parallel processing with 20 workers:
+    - **`gen objs`** (batch mode): Parallel LLM analysis of conversations
+    - **`sync`**: Parallel download of conversations from cloud
+    - **`db embed`**: Parallel embedding generation
+    
+    All use `ThreadPoolExecutor` with thread-safe counters. **Graceful shutdown**: SIGINT/SIGTERM signals are caught - in-flight requests complete before exit, preventing data corruption. **Progress display**: Rich progress bar shows processing rate.
+    
+    The `ohtv.parallel` module provides shared utilities:
+    - `format_rate(count, elapsed, unit)` - Format processing rate
+    - `RateTracker` - Thread-safe rate tracking with smoothing
+    - `run_parallel(items, process_fn, ...)` - Generic parallel execution helper
 
 21. **Model configuration**: LLM model can be set via:
     - CLI: `--model/-m` option on `gen objs` command

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -563,7 +563,7 @@ def _run_sync_with_progress(
         expected_total: If known, the expected total number of items to sync
     """
     import signal
-    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
     
     if quiet:
         return sync_fn(None, None)
@@ -581,24 +581,30 @@ def _run_sync_with_progress(
     # Counters for progress display
     start_time = time.perf_counter()
     processed_count = [0]
-    download_count = [0]  # Count of actual downloads (new + updated)
+    success_count = [0]  # new + updated
+    failed_count = [0]
     current_total = [expected_total]  # Mutable to allow update from callback
     
     # Rate tracking with smoothing
     last_rate_str = [""]
     last_rate_update = [0.0]
     
-    def _format_rate_smooth(downloaded: int, elapsed: float) -> str:
-        """Format rate with smoothing to avoid jitter."""
-        if elapsed < 0.1 or downloaded == 0:
-            return ""
-        # Only recalculate every 0.5s
-        if elapsed - last_rate_update[0] < 0.5 and last_rate_str[0]:
-            return last_rate_str[0]
-        last_rate_update[0] = elapsed
-        rate = downloaded / (elapsed / 60.0)
-        last_rate_str[0] = f"{rate:.1f}/min"
-        return last_rate_str[0]
+    def _format_stats(success: int, failed: int, elapsed: float) -> str:
+        """Format stats string with success/fail counts and rate."""
+        if elapsed < 0.1 or success == 0:
+            if failed > 0:
+                return f"[green]{success}[/green] ok, [red]{failed}[/red] failed"
+            return f"[green]{success}[/green] ok"
+        
+        # Only recalculate rate every 0.5s
+        if elapsed - last_rate_update[0] >= 0.5 or not last_rate_str[0]:
+            last_rate_update[0] = elapsed
+            rate = success / (elapsed / 60.0)
+            last_rate_str[0] = f"{rate:.1f}/min"
+        
+        if failed > 0:
+            return f"[green]{success}[/green] ok, [red]{failed}[/red] failed • {last_rate_str[0]}"
+        return f"[green]{success}[/green] ok • {last_rate_str[0]}"
     
     try:
         with Progress(
@@ -606,14 +612,15 @@ def _run_sync_with_progress(
             TextColumn("[bold blue]Syncing"),
             BarColumn(),
             TaskProgressColumn(),
-            TextColumn("[dim]{task.fields[rate]}[/dim]"),
+            TimeRemainingColumn(),
+            TextColumn("{task.fields[stats]}"),
             console=console,
             transient=True,
         ) as progress:
             task = progress.add_task(
                 "Syncing",
                 total=expected_total,
-                rate="starting..."
+                stats="starting..."
             )
             
             def progress_callback(conv_id: str, title: str, action: str, total: int | None = None) -> None:
@@ -638,15 +645,17 @@ def _run_sync_with_progress(
                 
                 processed_count[0] += 1
                 
-                # Count actual downloads for rate calculation
+                # Track success/failure
                 if action in ("new", "updated"):
-                    download_count[0] += 1
+                    success_count[0] += 1
+                elif action == "failed":
+                    failed_count[0] += 1
                 
                 elapsed = time.perf_counter() - start_time
-                rate_str = _format_rate_smooth(download_count[0], elapsed)
+                stats_str = _format_stats(success_count[0], failed_count[0], elapsed)
                 
                 # Update progress bar
-                progress.update(task, completed=processed_count[0], rate=rate_str)
+                progress.update(task, completed=processed_count[0], stats=stats_str)
             
             def shutdown_check() -> bool:
                 return shutdown_requested[0]

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -564,7 +564,6 @@ def _run_sync_with_progress(
     """
     import signal
     from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
-    from ohtv.parallel import format_rate
     
     if quiet:
         return sync_fn(None, None)
@@ -583,6 +582,7 @@ def _run_sync_with_progress(
     start_time = time.perf_counter()
     processed_count = [0]
     download_count = [0]  # Count of actual downloads (new + updated)
+    current_total = [expected_total]  # Mutable to allow update from callback
     
     # Rate tracking with smoothing
     last_rate_str = [""]
@@ -616,8 +616,26 @@ def _run_sync_with_progress(
                 rate="starting..."
             )
             
-            def progress_callback(conv_id: str, title: str, action: str) -> None:
-                """Progress callback that updates the Rich progress bar."""
+            def progress_callback(conv_id: str, title: str, action: str, total: int | None = None) -> None:
+                """Progress callback that updates the Rich progress bar.
+                
+                Args:
+                    conv_id: Conversation ID
+                    title: Conversation title  
+                    action: Action taken (new, updated, unchanged, failed, skipped)
+                    total: If provided, update the total count for the progress bar
+                """
+                nonlocal current_total
+                
+                # Update total if provided (first call from sync after categorization)
+                if total is not None and current_total[0] is None:
+                    current_total[0] = total
+                    progress.update(task, total=total)
+                
+                # Skip counting skipped items in progress
+                if action == "skipped":
+                    return
+                
                 processed_count[0] += 1
                 
                 # Count actual downloads for rate calculation
@@ -628,19 +646,15 @@ def _run_sync_with_progress(
                 rate_str = _format_rate_smooth(download_count[0], elapsed)
                 
                 # Update progress bar
-                if expected_total is not None:
-                    progress.update(task, advance=1, rate=rate_str)
-                else:
-                    # Unknown total - just show count
-                    progress.update(task, completed=processed_count[0], rate=rate_str)
+                progress.update(task, completed=processed_count[0], rate=rate_str)
             
             def shutdown_check() -> bool:
                 return shutdown_requested[0]
             
             result = sync_fn(progress_callback, shutdown_check)
             
-            # Final update to show completion
-            if expected_total is None:
+            # Final update to ensure completion is shown
+            if current_total[0] is None:
                 progress.update(task, total=processed_count[0], completed=processed_count[0])
         
         if shutdown_requested[0]:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -280,12 +280,12 @@ def sync(
     try:
         # Handle --force -n combination (reset to N newest)
         if force and max_new is not None:
-            result = _run_force_reset(manager, max_new, dry_run, quiet)
+            result, elapsed = _run_force_reset(manager, max_new, dry_run, quiet)
         else:
-            result = _run_sync(manager, force, since, dry_run, max_new, quiet)
+            result, elapsed = _run_sync(manager, force, since, dry_run, max_new, quiet)
         
         if not quiet:
-            _show_result(result, dry_run)
+            _show_result(result, dry_run, elapsed)
         
         # Always run processing stages after sync (unless dry-run)
         if not dry_run:
@@ -304,7 +304,7 @@ def _run_force_reset(
     max_new: int,
     dry_run: bool,
     quiet: bool,
-) -> SyncResult:
+) -> tuple[SyncResult, float]:
     """Handle --force -n combination: reset to N newest conversations."""
     from rich.prompt import Confirm
     
@@ -532,7 +532,7 @@ def _run_sync(
     dry_run: bool,
     max_new: int | None,
     quiet: bool,
-) -> SyncResult:
+) -> tuple[SyncResult, float]:
     """Execute sync with progress display."""
     if not quiet:
         _print_sync_header(force, since, dry_run, max_new)
@@ -554,19 +554,25 @@ def _run_sync_with_progress(
     sync_fn,
     quiet: bool,
     expected_total: int | None = None,
-) -> SyncResult:
+) -> tuple[SyncResult, float]:
     """Run a sync operation with Rich progress bar and graceful shutdown handling.
     
     Args:
         sync_fn: Function that takes (progress_callback, shutdown_check) and returns SyncResult
         quiet: If True, skip progress display
         expected_total: If known, the expected total number of items to sync
+        
+    Returns:
+        Tuple of (SyncResult, elapsed_seconds)
     """
     import signal
-    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
+    
+    start_time = time.perf_counter()
     
     if quiet:
-        return sync_fn(None, None)
+        result = sync_fn(None, None)
+        return result, time.perf_counter() - start_time
     
     # Shutdown handling
     shutdown_requested = [False]
@@ -579,7 +585,6 @@ def _run_sync_with_progress(
     old_sigterm = signal.signal(signal.SIGTERM, _handle_shutdown)
     
     # Counters for progress display
-    start_time = time.perf_counter()
     processed_count = [0]
     success_count = [0]  # new + updated
     failed_count = [0]
@@ -589,33 +594,41 @@ def _run_sync_with_progress(
     last_rate_str = [""]
     last_rate_update = [0.0]
     
-    def _format_counts(success: int, failed: int) -> str:
-        """Format success/fail counts."""
+    def _format_remaining(total: int | None, processed: int, failed: int) -> str:
+        """Format remaining count (counting down)."""
+        if total is None:
+            # Unknown total - show what we've done
+            if failed > 0:
+                return f"[green]{processed - failed}[/green] ok [red]{failed}[/red] err"
+            return f"[green]{processed}[/green] ok"
+        
+        remaining = total - processed
         if failed > 0:
-            return f"[green]{success}[/green] ok [red]{failed}[/red] err"
-        return f"[green]{success}[/green] ok"
+            return f"[dim]{remaining}[/dim] left [red]{failed}[/red] err"
+        return f"[dim]{remaining}[/dim] left"
     
-    def _format_rate(success: int, elapsed: float) -> str:
+    def _format_rate(processed: int, elapsed: float) -> str:
         """Format rate with smoothing."""
-        if elapsed < 0.1 or success == 0:
+        if elapsed < 0.5 or processed < 2:
             return ""
         # Only recalculate every 0.5s
         if elapsed - last_rate_update[0] >= 0.5 or not last_rate_str[0]:
             last_rate_update[0] = elapsed
-            rate = success / (elapsed / 60.0)
+            rate = processed / (elapsed / 60.0)
             last_rate_str[0] = f"{rate:.0f}/min"
         return last_rate_str[0]
     
     try:
-        # Layout: Syncing ━━━━━━━━━ 62% 115 ok 7 err │ 2:15 119/min
+        # Layout: Syncing ━━━━━━━━━ 62% 190 left │ ETA 0:02:15 119/min
         with Progress(
             SpinnerColumn(),
             TextColumn("[bold blue]Syncing"),
             BarColumn(),
             TaskProgressColumn(),
-            TextColumn("{task.fields[counts]}"),
+            TextColumn("{task.fields[remaining]}"),
             TextColumn("[dim]│[/dim]"),
-            TimeElapsedColumn(),
+            TextColumn("[dim]ETA[/dim]"),
+            TimeRemainingColumn(),
             TextColumn("[dim]{task.fields[rate]}[/dim]"),
             console=console,
             transient=True,
@@ -623,7 +636,7 @@ def _run_sync_with_progress(
             task = progress.add_task(
                 "Syncing",
                 total=expected_total,
-                counts="",
+                remaining="",
                 rate=""
             )
             
@@ -649,11 +662,11 @@ def _run_sync_with_progress(
                     failed_count[0] += 1
                 
                 elapsed = time.perf_counter() - start_time
-                counts_str = _format_counts(success_count[0], failed_count[0])
-                rate_str = _format_rate(success_count[0], elapsed)
+                remaining_str = _format_remaining(current_total[0], processed_count[0], failed_count[0])
+                rate_str = _format_rate(processed_count[0], elapsed)
                 
                 # Update progress bar
-                progress.update(task, completed=processed_count[0], counts=counts_str, rate=rate_str)
+                progress.update(task, completed=processed_count[0], remaining=remaining_str, rate=rate_str)
             
             def shutdown_check() -> bool:
                 return shutdown_requested[0]
@@ -664,14 +677,29 @@ def _run_sync_with_progress(
             if current_total[0] is None:
                 progress.update(task, total=processed_count[0], completed=processed_count[0])
         
-        if shutdown_requested[0]:
-            console.print("[yellow]Sync interrupted. Partial results saved.[/yellow]")
+        elapsed = time.perf_counter() - start_time
         
-        return result
+        if shutdown_requested[0]:
+            console.print(f"[yellow]Sync interrupted after {_format_elapsed(elapsed)}. Partial results saved.[/yellow]")
+        
+        return result, elapsed
     
     finally:
         signal.signal(signal.SIGINT, old_sigint)
         signal.signal(signal.SIGTERM, old_sigterm)
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format elapsed time as human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    if minutes < 60:
+        return f"{minutes}m {secs}s"
+    hours = minutes // 60
+    mins = minutes % 60
+    return f"{hours}h {mins}m"
 
 
 def _print_sync_header(force: bool, since: datetime | None, dry_run: bool, max_new: int | None) -> None:
@@ -686,13 +714,14 @@ def _print_sync_header(force: bool, since: datetime | None, dry_run: bool, max_n
         console.print(f"{mode}Syncing cloud conversations{limit_suffix}...")
 
 
-def _show_result(result: SyncResult, dry_run: bool) -> None:
+def _show_result(result: SyncResult, dry_run: bool, elapsed: float | None = None) -> None:
     """Display sync result summary."""
     console.print()
     if dry_run:
         console.print("[yellow]Would sync:[/yellow]")
     else:
-        console.print("[green]Sync complete:[/green]")
+        elapsed_str = f" in {_format_elapsed(elapsed)}" if elapsed else ""
+        console.print(f"[green]Sync complete{elapsed_str}:[/green]")
 
     console.print(f"  New:       {result.new}")
     console.print(f"  Updated:   {result.updated}")

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -321,8 +321,16 @@ def _run_force_reset(
                 console.print("[dim]Cancelled.[/dim]")
                 raise SystemExit(0)
     
-    on_progress = None if quiet else _make_progress_callback()
-    return manager.reset_to_n_newest(max_new, dry_run=dry_run, on_progress=on_progress)
+    return _run_sync_with_progress(
+        lambda progress_cb, shutdown_check: manager.reset_to_n_newest(
+            max_new, 
+            dry_run=dry_run, 
+            on_progress=progress_cb,
+            shutdown_check=shutdown_check,
+        ),
+        quiet=quiet,
+        expected_total=max_new,
+    )
 
 
 @main.command()
@@ -529,8 +537,120 @@ def _run_sync(
     if not quiet:
         _print_sync_header(force, since, dry_run, max_new)
 
-    on_progress = None if quiet else _make_progress_callback()
-    return manager.sync(force=force, since=since, dry_run=dry_run, max_new=max_new, on_progress=on_progress)
+    return _run_sync_with_progress(
+        lambda progress_cb, shutdown_check: manager.sync(
+            force=force, 
+            since=since, 
+            dry_run=dry_run, 
+            max_new=max_new, 
+            on_progress=progress_cb,
+            shutdown_check=shutdown_check,
+        ),
+        quiet=quiet,
+    )
+
+
+def _run_sync_with_progress(
+    sync_fn,
+    quiet: bool,
+    expected_total: int | None = None,
+) -> SyncResult:
+    """Run a sync operation with Rich progress bar and graceful shutdown handling.
+    
+    Args:
+        sync_fn: Function that takes (progress_callback, shutdown_check) and returns SyncResult
+        quiet: If True, skip progress display
+        expected_total: If known, the expected total number of items to sync
+    """
+    import signal
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+    from ohtv.parallel import format_rate
+    
+    if quiet:
+        return sync_fn(None, None)
+    
+    # Shutdown handling
+    shutdown_requested = [False]
+    
+    def _handle_shutdown(signum, frame):
+        shutdown_requested[0] = True
+        console.print("\n[yellow]Shutdown requested - finishing current downloads...[/yellow]")
+    
+    old_sigint = signal.signal(signal.SIGINT, _handle_shutdown)
+    old_sigterm = signal.signal(signal.SIGTERM, _handle_shutdown)
+    
+    # Counters for progress display
+    start_time = time.perf_counter()
+    processed_count = [0]
+    download_count = [0]  # Count of actual downloads (new + updated)
+    
+    # Rate tracking with smoothing
+    last_rate_str = [""]
+    last_rate_update = [0.0]
+    
+    def _format_rate_smooth(downloaded: int, elapsed: float) -> str:
+        """Format rate with smoothing to avoid jitter."""
+        if elapsed < 0.1 or downloaded == 0:
+            return ""
+        # Only recalculate every 0.5s
+        if elapsed - last_rate_update[0] < 0.5 and last_rate_str[0]:
+            return last_rate_str[0]
+        last_rate_update[0] = elapsed
+        rate = downloaded / (elapsed / 60.0)
+        last_rate_str[0] = f"{rate:.1f}/min"
+        return last_rate_str[0]
+    
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]Syncing"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TextColumn("[dim]{task.fields[rate]}[/dim]"),
+            console=console,
+            transient=True,
+        ) as progress:
+            task = progress.add_task(
+                "Syncing",
+                total=expected_total,
+                rate="starting..."
+            )
+            
+            def progress_callback(conv_id: str, title: str, action: str) -> None:
+                """Progress callback that updates the Rich progress bar."""
+                processed_count[0] += 1
+                
+                # Count actual downloads for rate calculation
+                if action in ("new", "updated"):
+                    download_count[0] += 1
+                
+                elapsed = time.perf_counter() - start_time
+                rate_str = _format_rate_smooth(download_count[0], elapsed)
+                
+                # Update progress bar
+                if expected_total is not None:
+                    progress.update(task, advance=1, rate=rate_str)
+                else:
+                    # Unknown total - just show count
+                    progress.update(task, completed=processed_count[0], rate=rate_str)
+            
+            def shutdown_check() -> bool:
+                return shutdown_requested[0]
+            
+            result = sync_fn(progress_callback, shutdown_check)
+            
+            # Final update to show completion
+            if expected_total is None:
+                progress.update(task, total=processed_count[0], completed=processed_count[0])
+        
+        if shutdown_requested[0]:
+            console.print("[yellow]Sync interrupted. Partial results saved.[/yellow]")
+        
+        return result
+    
+    finally:
+        signal.signal(signal.SIGINT, old_sigint)
+        signal.signal(signal.SIGTERM, old_sigterm)
 
 
 def _print_sync_header(force: bool, since: datetime | None, dry_run: bool, max_new: int | None) -> None:
@@ -543,24 +663,6 @@ def _print_sync_header(force: bool, since: datetime | None, dry_run: bool, max_n
         console.print(f"{mode}Syncing conversations since {since.isoformat()}{limit_suffix}...")
     else:
         console.print(f"{mode}Syncing cloud conversations{limit_suffix}...")
-
-
-def _make_progress_callback():
-    """Create progress callback for sync."""
-
-    def callback(conv_id: str, title: str, action: str) -> None:
-        short_id = conv_id[:7]
-        status_style = {
-            "new": "green",
-            "updated": "yellow",
-            "unchanged": "dim",
-            "failed": "red",
-            "skipped": "dim cyan",
-        }
-        style = status_style.get(action, "")
-        console.print(f"  [{style}]{short_id}[/{style}] {title[:40]}... ({action})")
-
-    return callback
 
 
 def _show_result(result: SyncResult, dry_run: bool) -> None:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -563,7 +563,7 @@ def _run_sync_with_progress(
         expected_total: If known, the expected total number of items to sync
     """
     import signal
-    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn
     
     if quiet:
         return sync_fn(None, None)
@@ -589,49 +589,46 @@ def _run_sync_with_progress(
     last_rate_str = [""]
     last_rate_update = [0.0]
     
-    def _format_stats(success: int, failed: int, elapsed: float) -> str:
-        """Format stats string with success/fail counts and rate."""
+    def _format_counts(success: int, failed: int) -> str:
+        """Format success/fail counts."""
+        if failed > 0:
+            return f"[green]{success}[/green] ok [red]{failed}[/red] err"
+        return f"[green]{success}[/green] ok"
+    
+    def _format_rate(success: int, elapsed: float) -> str:
+        """Format rate with smoothing."""
         if elapsed < 0.1 or success == 0:
-            if failed > 0:
-                return f"[green]{success}[/green] ok, [red]{failed}[/red] failed"
-            return f"[green]{success}[/green] ok"
-        
-        # Only recalculate rate every 0.5s
+            return ""
+        # Only recalculate every 0.5s
         if elapsed - last_rate_update[0] >= 0.5 or not last_rate_str[0]:
             last_rate_update[0] = elapsed
             rate = success / (elapsed / 60.0)
-            last_rate_str[0] = f"{rate:.1f}/min"
-        
-        if failed > 0:
-            return f"[green]{success}[/green] ok, [red]{failed}[/red] failed • {last_rate_str[0]}"
-        return f"[green]{success}[/green] ok • {last_rate_str[0]}"
+            last_rate_str[0] = f"{rate:.0f}/min"
+        return last_rate_str[0]
     
     try:
+        # Layout: Syncing ━━━━━━━━━ 62% 115 ok 7 err │ 2:15 119/min
         with Progress(
             SpinnerColumn(),
             TextColumn("[bold blue]Syncing"),
             BarColumn(),
             TaskProgressColumn(),
-            TimeRemainingColumn(),
-            TextColumn("{task.fields[stats]}"),
+            TextColumn("{task.fields[counts]}"),
+            TextColumn("[dim]│[/dim]"),
+            TimeElapsedColumn(),
+            TextColumn("[dim]{task.fields[rate]}[/dim]"),
             console=console,
             transient=True,
         ) as progress:
             task = progress.add_task(
                 "Syncing",
                 total=expected_total,
-                stats="starting..."
+                counts="",
+                rate=""
             )
             
             def progress_callback(conv_id: str, title: str, action: str, total: int | None = None) -> None:
-                """Progress callback that updates the Rich progress bar.
-                
-                Args:
-                    conv_id: Conversation ID
-                    title: Conversation title  
-                    action: Action taken (new, updated, unchanged, failed, skipped)
-                    total: If provided, update the total count for the progress bar
-                """
+                """Progress callback that updates the Rich progress bar."""
                 nonlocal current_total
                 
                 # Update total if provided (first call from sync after categorization)
@@ -652,10 +649,11 @@ def _run_sync_with_progress(
                     failed_count[0] += 1
                 
                 elapsed = time.perf_counter() - start_time
-                stats_str = _format_stats(success_count[0], failed_count[0], elapsed)
+                counts_str = _format_counts(success_count[0], failed_count[0])
+                rate_str = _format_rate(success_count[0], elapsed)
                 
                 # Update progress bar
-                progress.update(task, completed=processed_count[0], stats=stats_str)
+                progress.update(task, completed=processed_count[0], counts=counts_str, rate=rate_str)
             
             def shutdown_check() -> bool:
                 return shutdown_requested[0]

--- a/src/ohtv/parallel.py
+++ b/src/ohtv/parallel.py
@@ -1,0 +1,209 @@
+"""Utilities for parallel processing with progress display."""
+
+import signal
+import threading
+import time
+from collections.abc import Callable, Iterator
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def format_rate(count: int, elapsed_seconds: float, unit: str = "items") -> str:
+    """Format processing rate as items/min.
+    
+    Args:
+        count: Number of items processed
+        elapsed_seconds: Time elapsed in seconds
+        unit: Unit name for display (e.g., "items", "conv")
+    
+    Returns:
+        Formatted rate string like "42.5 items/min" or "-- items/min" if not calculable
+    """
+    if elapsed_seconds < 0.1 or count == 0:
+        return f"-- {unit}/min"
+    rate = count / (elapsed_seconds / 60.0)
+    return f"{rate:.1f} {unit}/min"
+
+
+@dataclass
+class ParallelResult:
+    """Results from parallel processing."""
+    
+    processed: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    errors: list[tuple[str, str]] = field(default_factory=list)  # (id, error_message)
+
+
+@dataclass
+class WorkItem:
+    """A unit of work for parallel processing."""
+    
+    id: str
+    data: dict
+
+
+@contextmanager
+def graceful_shutdown_handler(
+    console,
+    shutdown_flag: list[bool],
+) -> Iterator[None]:
+    """Context manager for graceful shutdown handling on SIGINT/SIGTERM.
+    
+    Args:
+        console: Rich console for printing messages
+        shutdown_flag: Mutable list with single bool element, set to True on shutdown
+    
+    Usage:
+        shutdown_flag = [False]
+        with graceful_shutdown_handler(console, shutdown_flag):
+            while not shutdown_flag[0]:
+                # do work
+    """
+    def _handle_shutdown(signum, frame):
+        shutdown_flag[0] = True
+        console.print("\n[yellow]Shutdown requested - finishing current work...[/yellow]")
+    
+    old_sigint = signal.signal(signal.SIGINT, _handle_shutdown)
+    old_sigterm = signal.signal(signal.SIGTERM, _handle_shutdown)
+    
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, old_sigint)
+        signal.signal(signal.SIGTERM, old_sigterm)
+
+
+def run_parallel(
+    items: list[T],
+    process_fn: Callable[[T], R],
+    max_workers: int = 20,
+    on_result: Callable[[T, R], None] | None = None,
+    on_error: Callable[[T, Exception], None] | None = None,
+    shutdown_check: Callable[[], bool] | None = None,
+) -> list[tuple[T, R | None, Exception | None]]:
+    """Run a function on items in parallel with a thread pool.
+    
+    Args:
+        items: Items to process
+        process_fn: Function to call on each item, returns result
+        max_workers: Maximum worker threads (default 20 for API calls)
+        on_result: Optional callback after each successful result
+        on_error: Optional callback after each error
+        shutdown_check: Optional function that returns True if shutdown requested
+    
+    Returns:
+        List of (item, result, error) tuples. Error is None if successful.
+    """
+    if not items:
+        return []
+    
+    results: list[tuple[T, R | None, Exception | None]] = []
+    lock = threading.Lock()
+    
+    actual_workers = min(max_workers, len(items))
+    
+    if actual_workers == 1:
+        # Sequential processing
+        for item in items:
+            if shutdown_check and shutdown_check():
+                break
+            try:
+                result = process_fn(item)
+                results.append((item, result, None))
+                if on_result:
+                    on_result(item, result)
+            except Exception as e:
+                results.append((item, None, e))
+                if on_error:
+                    on_error(item, e)
+    else:
+        # Parallel processing
+        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+            future_to_item: dict[Future, T] = {
+                executor.submit(process_fn, item): item
+                for item in items
+            }
+            
+            pending = set(future_to_item.keys())
+            while pending:
+                if shutdown_check and shutdown_check():
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    break
+                
+                # Wait with timeout to allow shutdown check
+                done, pending = wait(pending, timeout=0.5, return_when=FIRST_COMPLETED)
+                
+                for future in done:
+                    item = future_to_item[future]
+                    try:
+                        result = future.result()
+                        with lock:
+                            results.append((item, result, None))
+                        if on_result:
+                            on_result(item, result)
+                    except Exception as e:
+                        with lock:
+                            results.append((item, None, e))
+                        if on_error:
+                            on_error(item, e)
+    
+    return results
+
+
+class RateTracker:
+    """Thread-safe rate tracker for progress display."""
+    
+    def __init__(self, unit: str = "items", update_interval: float = 0.5):
+        """Initialize rate tracker.
+        
+        Args:
+            unit: Unit name for display
+            update_interval: Minimum seconds between rate recalculations (smooths jitter)
+        """
+        self.unit = unit
+        self.update_interval = update_interval
+        self._lock = threading.Lock()
+        self._start_time = time.perf_counter()
+        self._count = 0
+        self._last_rate_str = ""
+        self._last_rate_update = 0.0
+    
+    def increment(self, n: int = 1) -> None:
+        """Increment the count."""
+        with self._lock:
+            self._count += n
+    
+    @property
+    def count(self) -> int:
+        """Get current count."""
+        with self._lock:
+            return self._count
+    
+    @property
+    def elapsed(self) -> float:
+        """Get elapsed time in seconds."""
+        return time.perf_counter() - self._start_time
+    
+    def get_rate_str(self) -> str:
+        """Get current rate string, smoothed to avoid jitter."""
+        elapsed = self.elapsed
+        with self._lock:
+            count = self._count
+            
+            if elapsed < 0.1 or count == 0:
+                return f"-- {self.unit}/min"
+            
+            # Only recalculate periodically to smooth jitter
+            if elapsed - self._last_rate_update < self.update_interval and self._last_rate_str:
+                return self._last_rate_str
+            
+            self._last_rate_update = elapsed
+            rate = count / (elapsed / 60.0)
+            self._last_rate_str = f"{rate:.1f} {self.unit}/min"
+            return self._last_rate_str

--- a/src/ohtv/parallel.py
+++ b/src/ohtv/parallel.py
@@ -40,14 +40,6 @@ class ParallelResult:
     errors: list[tuple[str, str]] = field(default_factory=list)  # (id, error_message)
 
 
-@dataclass
-class WorkItem:
-    """A unit of work for parallel processing."""
-    
-    id: str
-    data: dict
-
-
 @contextmanager
 def graceful_shutdown_handler(
     console,

--- a/src/ohtv/sources/cloud.py
+++ b/src/ohtv/sources/cloud.py
@@ -129,6 +129,7 @@ class CloudClient:
         self,
         method: str,
         path: str,
+        max_retries: int = 50,
         **kwargs,
     ) -> httpx.Response:
         """Make request with shared rate limiter and exponential backoff.
@@ -138,14 +139,21 @@ class CloudClient:
         API's rate limit bucket instead of having each worker retry
         independently.
         
-        Rate limit retries are unlimited - we'll keep backing off until
-        it succeeds. Rate limits are always temporary and fixable with patience.
+        Args:
+            method: HTTP method
+            path: API path
+            max_retries: Maximum retry attempts for rate limiting (default 50).
+                        With exponential backoff capped at 60s, this allows
+                        for ~50 minutes of retrying before giving up.
+            **kwargs: Additional arguments passed to httpx.request
+        
+        Raises:
+            RateLimitExceededError: If max_retries is exhausted
         """
         base_delay = 2.0  # Start with 2 seconds
         max_delay = 60.0  # Cap at 1 minute
-        attempt = 0
         
-        while True:
+        for attempt in range(max_retries):
             # Wait if another request recently got rate limited
             _global_rate_limiter.wait_if_needed()
             
@@ -155,16 +163,18 @@ class CloudClient:
                 return response
             
             # Calculate delay and notify the shared rate limiter
-            attempt += 1
             delay = self._get_retry_delay(response, base_delay, attempt, max_delay)
-            log.warning("Rate limited (429) on %s, blocking all requests for %.1fs (attempt %d)", 
-                       path, delay, attempt)
+            log.warning("Rate limited (429) on %s, blocking all requests for %.1fs (attempt %d/%d)", 
+                       path, delay, attempt + 1, max_retries)
             
             # Record this in the shared rate limiter so all workers wait
             _global_rate_limiter.record_rate_limit(delay)
             
             # This worker also waits
             time.sleep(delay)
+        
+        log.error("Rate limit retries exhausted for %s after %d attempts", path, max_retries)
+        raise RateLimitExceededError(f"Rate limit retries exhausted for {path} after {max_retries} attempts")
 
     def _get_retry_delay(self, response: httpx.Response, base_delay: float, attempt: int, max_delay: float) -> float:
         """Calculate retry delay from headers or exponential backoff with jitter."""
@@ -186,11 +196,7 @@ class CloudClient:
 
 
 class RateLimitExceededError(Exception):
-    """Legacy exception - no longer raised since we retry rate limits forever.
-    
-    Kept for backward compatibility but CloudClient now retries indefinitely
-    with exponential backoff when rate limited.
-    """
+    """Raised when rate limit retries are exhausted."""
 
 
 def parse_conversation_info(data: dict) -> ConversationInfo:

--- a/src/ohtv/sources/cloud.py
+++ b/src/ohtv/sources/cloud.py
@@ -88,28 +88,53 @@ class CloudClient:
         self,
         method: str,
         path: str,
-        max_retries: int = 5,
+        max_retries: int = 10,
         **kwargs,
     ) -> httpx.Response:
-        """Make request with exponential backoff on rate limiting."""
-        base_delay = 1.0
+        """Make request with aggressive exponential backoff on rate limiting.
+        
+        Uses longer delays and more retries to handle rate limiting gracefully,
+        especially when running parallel downloads.
+        """
+        base_delay = 2.0  # Start with 2 seconds
+        max_delay = 120.0  # Cap at 2 minutes
+        
         for attempt in range(max_retries):
             response = self._client.request(method, path, **kwargs)
             if response.status_code != 429:
                 response.raise_for_status()
                 return response
-            delay = self._get_retry_delay(response, base_delay, attempt)
+            
+            delay = self._get_retry_delay(response, base_delay, attempt, max_delay)
             log.warning("Rate limited (429), retrying in %.1fs (attempt %d/%d)", delay, attempt + 1, max_retries)
             time.sleep(delay)
-        log.error("Rate limit retries exhausted for %s", path)
+        
+        log.error("Rate limit retries exhausted for %s after %d attempts", path, max_retries)
         raise RateLimitExceededError(f"Rate limit retries exhausted for {path}")
 
-    def _get_retry_delay(self, response: httpx.Response, base_delay: float, attempt: int) -> float:
-        """Calculate retry delay from headers or exponential backoff."""
+    def _get_retry_delay(self, response: httpx.Response, base_delay: float, attempt: int, max_delay: float) -> float:
+        """Calculate retry delay from headers or exponential backoff with jitter.
+        
+        Uses exponential backoff with random jitter to prevent thundering herd
+        when multiple parallel requests all get rate limited at the same time.
+        """
+        import random
+        
+        # Prefer server-provided Retry-After header
         retry_after = response.headers.get("Retry-After")
         if retry_after:
-            return float(retry_after)
-        return base_delay * (2**attempt)
+            try:
+                return min(float(retry_after), max_delay)
+            except ValueError:
+                pass
+        
+        # Exponential backoff: 2, 4, 8, 16, 32, 64, 120, 120, 120, 120...
+        delay = base_delay * (2 ** attempt)
+        delay = min(delay, max_delay)
+        
+        # Add jitter (±25%) to prevent thundering herd
+        jitter = delay * 0.25 * (2 * random.random() - 1)
+        return delay + jitter
 
 
 class RateLimitExceededError(Exception):

--- a/src/ohtv/sources/cloud.py
+++ b/src/ohtv/sources/cloud.py
@@ -129,7 +129,6 @@ class CloudClient:
         self,
         method: str,
         path: str,
-        max_retries: int = 10,
         **kwargs,
     ) -> httpx.Response:
         """Make request with shared rate limiter and exponential backoff.
@@ -138,11 +137,15 @@ class CloudClient:
         ALL workers pause before retrying. This properly respects the
         API's rate limit bucket instead of having each worker retry
         independently.
+        
+        Rate limit retries are unlimited - we'll keep backing off until
+        it succeeds. Rate limits are always temporary and fixable with patience.
         """
         base_delay = 2.0  # Start with 2 seconds
         max_delay = 60.0  # Cap at 1 minute
+        attempt = 0
         
-        for attempt in range(max_retries):
+        while True:
             # Wait if another request recently got rate limited
             _global_rate_limiter.wait_if_needed()
             
@@ -152,18 +155,16 @@ class CloudClient:
                 return response
             
             # Calculate delay and notify the shared rate limiter
+            attempt += 1
             delay = self._get_retry_delay(response, base_delay, attempt, max_delay)
-            log.warning("Rate limited (429) on %s, blocking all requests for %.1fs (attempt %d/%d)", 
-                       path, delay, attempt + 1, max_retries)
+            log.warning("Rate limited (429) on %s, blocking all requests for %.1fs (attempt %d)", 
+                       path, delay, attempt)
             
             # Record this in the shared rate limiter so all workers wait
             _global_rate_limiter.record_rate_limit(delay)
             
             # This worker also waits
             time.sleep(delay)
-        
-        log.error("Rate limit retries exhausted for %s after %d attempts", path, max_retries)
-        raise RateLimitExceededError(f"Rate limit retries exhausted for {path}")
 
     def _get_retry_delay(self, response: httpx.Response, base_delay: float, attempt: int, max_delay: float) -> float:
         """Calculate retry delay from headers or exponential backoff with jitter."""
@@ -185,7 +186,11 @@ class CloudClient:
 
 
 class RateLimitExceededError(Exception):
-    """Raised when rate limit retries are exhausted."""
+    """Legacy exception - no longer raised since we retry rate limits forever.
+    
+    Kept for backward compatibility but CloudClient now retries indefinitely
+    with exponential backoff when rate limited.
+    """
 
 
 def parse_conversation_info(data: dict) -> ConversationInfo:

--- a/src/ohtv/sources/cloud.py
+++ b/src/ohtv/sources/cloud.py
@@ -1,6 +1,8 @@
 """Cloud API client for OpenHands conversations."""
 
 import logging
+import random
+import threading
 import time
 from datetime import datetime
 
@@ -9,6 +11,45 @@ import httpx
 from ohtv.sources.base import ConversationInfo
 
 log = logging.getLogger("ohtv")
+
+
+class RateLimiter:
+    """Thread-safe rate limiter with shared backoff.
+    
+    When any request gets rate limited, all subsequent requests will wait
+    until the backoff period expires. This prevents thundering herd and
+    respects the API's rate limit bucket.
+    """
+    
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._blocked_until = 0.0  # timestamp when we can make requests again
+    
+    def wait_if_needed(self) -> None:
+        """Wait if we're currently in a backoff period."""
+        with self._lock:
+            now = time.time()
+            if now < self._blocked_until:
+                wait_time = self._blocked_until - now
+                log.debug("Rate limiter: waiting %.1fs before request", wait_time)
+        
+        # Wait outside the lock so other threads can check too
+        now = time.time()
+        if now < self._blocked_until:
+            time.sleep(self._blocked_until - now)
+    
+    def record_rate_limit(self, retry_after: float) -> None:
+        """Record that we hit a rate limit - block all requests for retry_after seconds."""
+        with self._lock:
+            new_blocked_until = time.time() + retry_after
+            # Only extend if this would block longer than current
+            if new_blocked_until > self._blocked_until:
+                self._blocked_until = new_blocked_until
+                log.info("Rate limiter: blocking all requests for %.1fs", retry_after)
+
+
+# Global rate limiter shared across all CloudClient instances
+_global_rate_limiter = RateLimiter()
 
 
 class CloudClient:
@@ -91,35 +132,41 @@ class CloudClient:
         max_retries: int = 10,
         **kwargs,
     ) -> httpx.Response:
-        """Make request with aggressive exponential backoff on rate limiting.
+        """Make request with shared rate limiter and exponential backoff.
         
-        Uses longer delays and more retries to handle rate limiting gracefully,
-        especially when running parallel downloads.
+        Uses a global rate limiter so that when ANY request hits a 429,
+        ALL workers pause before retrying. This properly respects the
+        API's rate limit bucket instead of having each worker retry
+        independently.
         """
         base_delay = 2.0  # Start with 2 seconds
-        max_delay = 120.0  # Cap at 2 minutes
+        max_delay = 60.0  # Cap at 1 minute
         
         for attempt in range(max_retries):
+            # Wait if another request recently got rate limited
+            _global_rate_limiter.wait_if_needed()
+            
             response = self._client.request(method, path, **kwargs)
             if response.status_code != 429:
                 response.raise_for_status()
                 return response
             
+            # Calculate delay and notify the shared rate limiter
             delay = self._get_retry_delay(response, base_delay, attempt, max_delay)
-            log.warning("Rate limited (429), retrying in %.1fs (attempt %d/%d)", delay, attempt + 1, max_retries)
+            log.warning("Rate limited (429) on %s, blocking all requests for %.1fs (attempt %d/%d)", 
+                       path, delay, attempt + 1, max_retries)
+            
+            # Record this in the shared rate limiter so all workers wait
+            _global_rate_limiter.record_rate_limit(delay)
+            
+            # This worker also waits
             time.sleep(delay)
         
         log.error("Rate limit retries exhausted for %s after %d attempts", path, max_retries)
         raise RateLimitExceededError(f"Rate limit retries exhausted for {path}")
 
     def _get_retry_delay(self, response: httpx.Response, base_delay: float, attempt: int, max_delay: float) -> float:
-        """Calculate retry delay from headers or exponential backoff with jitter.
-        
-        Uses exponential backoff with random jitter to prevent thundering herd
-        when multiple parallel requests all get rate limited at the same time.
-        """
-        import random
-        
+        """Calculate retry delay from headers or exponential backoff with jitter."""
         # Prefer server-provided Retry-After header
         retry_after = response.headers.get("Retry-After")
         if retry_after:
@@ -128,12 +175,12 @@ class CloudClient:
             except ValueError:
                 pass
         
-        # Exponential backoff: 2, 4, 8, 16, 32, 64, 120, 120, 120, 120...
+        # Exponential backoff: 2, 4, 8, 16, 32, 60, 60...
         delay = base_delay * (2 ** attempt)
         delay = min(delay, max_delay)
         
-        # Add jitter (±25%) to prevent thundering herd
-        jitter = delay * 0.25 * (2 * random.random() - 1)
+        # Small jitter (±10%) just to prevent exact synchronization
+        jitter = delay * 0.1 * (2 * random.random() - 1)
         return delay + jitter
 
 

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -18,8 +18,9 @@ from ohtv.sources.cloud import CloudClient, RateLimitExceededError
 
 log = logging.getLogger("ohtv")
 
-# Number of parallel workers for API calls (API rate limits are the bottleneck)
-DEFAULT_MAX_WORKERS = 20
+# Number of parallel workers for API calls
+# Lower than gen (which uses 20) because download API has stricter rate limits
+DEFAULT_MAX_WORKERS = 5
 
 
 class SyncAuthError(Exception):
@@ -41,6 +42,7 @@ class SyncResult:
     skipped_new: int = 0  # New conversations skipped due to max_new limit
     errors: list[tuple[str, str]] = field(default_factory=list)
     failed_ids: list[str] = field(default_factory=list)
+    total_to_process: int = 0  # Total conversations to process (for progress display)
 
     @property
     def total_synced(self) -> int:
@@ -53,6 +55,11 @@ class SyncResult:
     @property
     def has_skipped_new(self) -> bool:
         return self.skipped_new > 0
+    
+    @property
+    def processed_count(self) -> int:
+        """Total processed (excluding skipped_new which aren't processed)."""
+        return self.new + self.updated + self.unchanged + self.failed
 
 
 @dataclass
@@ -203,22 +210,34 @@ class SyncManager:
         # This handles max_new limit correctly before parallel processing
         work_items = self._categorize_conversations(conversations, force, max_new, result)
         
+        # Set total for progress display (excluding skipped items)
+        result.total_to_process = sum(1 for _, action in work_items if action != "skipped")
+        
         # Phase 2: Handle dry-run or unchanged (no download needed)
+        # Also notify progress callback of total on first call
+        first_progress_call = True
         to_download = []
         for conv, action in work_items:
             if action in ("unchanged", "skipped") or dry_run:
                 self._update_result(result, action)
                 if on_progress:
-                    on_progress(conv["id"], conv.get("title", "")[:50], action)
+                    # Pass total on first call so progress bar can set its total
+                    if first_progress_call:
+                        on_progress(conv["id"], conv.get("title", "")[:50], action, result.total_to_process)
+                        first_progress_call = False
+                    else:
+                        on_progress(conv["id"], conv.get("title", "")[:50], action)
             else:
                 to_download.append((conv, action))
         
         # Phase 3: Download conversations (parallel or sequential)
         if to_download:
+            # If no items were processed in phase 2, pass total on first download callback
+            pass_total = first_progress_call
             if parallel and len(to_download) > 1:
-                self._download_parallel(client, to_download, result, on_progress, shutdown_check)
+                self._download_parallel(client, to_download, result, on_progress, shutdown_check, pass_total)
             else:
-                self._download_sequential(client, to_download, result, on_progress, shutdown_check)
+                self._download_sequential(client, to_download, result, on_progress, shutdown_check, pass_total)
 
         if not dry_run:
             self._finalize_sync(result)
@@ -262,10 +281,12 @@ class SyncManager:
         result: SyncResult,
         on_progress: Callable[[str, str, str], None] | None,
         shutdown_check: Callable[[], bool] | None = None,
+        pass_total_on_first: bool = False,
     ) -> None:
         """Download conversations sequentially."""
         consecutive_failures = 0
         max_consecutive_failures = 5
+        first_callback = True
         
         for conv, planned_action in work_items:
             if shutdown_check and shutdown_check():
@@ -285,7 +306,11 @@ class SyncManager:
             )
             self._update_result(result, actual_action)
             if on_progress:
-                on_progress(conv_id, title, actual_action)
+                if first_callback and pass_total_on_first:
+                    on_progress(conv_id, title, actual_action, result.total_to_process)
+                    first_callback = False
+                else:
+                    on_progress(conv_id, title, actual_action)
             
             consecutive_failures = self._check_abort(actual_action, consecutive_failures, max_consecutive_failures)
 
@@ -296,6 +321,7 @@ class SyncManager:
         result: SyncResult,
         on_progress: Callable[[str, str, str], None] | None,
         shutdown_check: Callable[[], bool] | None = None,
+        pass_total_on_first: bool = False,
     ) -> None:
         """Download conversations in parallel using a thread pool."""
         max_workers = min(DEFAULT_MAX_WORKERS, len(work_items))
@@ -307,6 +333,7 @@ class SyncManager:
         total_failures = 0
         max_total_failures = len(work_items) // 2 + 5  # Allow up to ~50% failures before aborting
         abort_requested = False
+        first_callback = [True]  # Mutable for thread-safe first-call detection
         
         def download_one(item: tuple[dict, str]) -> tuple[dict, str, str]:
             """Download a single conversation. Returns (conv, planned_action, actual_action)."""
@@ -368,7 +395,15 @@ class SyncManager:
                     
                     # Progress callback
                     if on_progress:
-                        on_progress(conv["id"], conv.get("title", "")[:50], actual_action)
+                        with lock:
+                            is_first = first_callback[0]
+                            if is_first:
+                                first_callback[0] = False
+                        
+                        if is_first and pass_total_on_first:
+                            on_progress(conv["id"], conv.get("title", "")[:50], actual_action, result.total_to_process)
+                        else:
+                            on_progress(conv["id"], conv.get("title", "")[:50], actual_action)
 
     def _check_abort(self, action: str, consecutive_failures: int, max_failures: int) -> int:
         """Check if we should abort due to too many consecutive failures."""
@@ -569,12 +604,13 @@ class SyncManager:
                 
                 # Download using the same infrastructure as regular sync
                 result = SyncResult()
+                result.total_to_process = len(conversations_to_sync)
                 work_items = [(conv, "new") for conv in conversations_to_sync]
                 
                 if parallel and len(work_items) > 1:
-                    self._download_parallel(client, work_items, result, on_progress, shutdown_check)
+                    self._download_parallel(client, work_items, result, on_progress, shutdown_check, pass_total_on_first=True)
                 else:
-                    self._download_sequential(client, work_items, result, on_progress, shutdown_check)
+                    self._download_sequential(client, work_items, result, on_progress, shutdown_check, pass_total_on_first=True)
                 
                 # Track how many were available but not synced
                 if len(conversations) > n:

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import shutil
+import threading
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,6 +17,9 @@ from ohtv.exporter import TrajectoryExporter, count_events
 from ohtv.sources.cloud import CloudClient, RateLimitExceededError
 
 log = logging.getLogger("ohtv")
+
+# Number of parallel workers for API calls (API rate limits are the bottleneck)
+DEFAULT_MAX_WORKERS = 20
 
 
 class SyncAuthError(Exception):
@@ -100,6 +105,8 @@ class SyncManager:
         dry_run: bool = False,
         max_new: int | None = None,
         on_progress: Callable[[str, str, str], None] | None = None,
+        parallel: bool = True,
+        shutdown_check: Callable[[], bool] | None = None,
     ) -> SyncResult:
         """Sync conversations from cloud.
         
@@ -109,19 +116,25 @@ class SyncManager:
             dry_run: Show what would sync without downloading
             max_new: Maximum number of NEW conversations to sync (no limit on updates)
             on_progress: Callback for progress updates (conv_id, title, action)
+            parallel: Use parallel downloads (default True, uses 20 workers)
+            shutdown_check: Optional function that returns True to request graceful shutdown
         """
         if not self.config.api_key:
             raise ValueError("API key required. Set OH_API_KEY environment variable.")
 
         cutoff = self._determine_cutoff(force, since)
-        log.info("Starting sync (force=%s, cutoff=%s, dry_run=%s, max_new=%s)", force, cutoff, dry_run, max_new)
+        log.info("Starting sync (force=%s, cutoff=%s, dry_run=%s, max_new=%s, parallel=%s)", 
+                 force, cutoff, dry_run, max_new, parallel)
 
         try:
             with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
                 conversations = client.search_all_conversations(updated_since=cutoff)
                 conversations = self._add_failed_conversations(conversations)
                 log.info("Found %d conversations to process", len(conversations))
-                return self._process_conversations(client, conversations, force, dry_run, max_new, on_progress)
+                return self._process_conversations(
+                    client, conversations, force, dry_run, max_new, on_progress, 
+                    parallel=parallel, shutdown_check=shutdown_check
+                )
         except httpx.HTTPStatusError as e:
             log.error("HTTP error during sync: %s %s", e.response.status_code, e.response.reason_phrase)
             if e.response.status_code in (401, 403):
@@ -169,20 +182,193 @@ class SyncManager:
         dry_run: bool,
         max_new: int | None,
         on_progress: Callable[[str, str, str], None] | None,
+        parallel: bool = True,
+        shutdown_check: Callable[[], bool] | None = None,
     ) -> SyncResult:
-        """Process each conversation that needs syncing."""
+        """Process each conversation that needs syncing.
+        
+        Args:
+            client: Cloud API client
+            conversations: List of conversation dicts from API
+            force: Re-download all conversations
+            dry_run: Don't actually download, just report what would happen
+            max_new: Limit on number of new conversations to sync
+            on_progress: Callback for progress updates
+            parallel: Use parallel downloads (default True)
+            shutdown_check: Optional function that returns True to request graceful shutdown
+        """
         result = SyncResult()
-        consecutive_failures = 0
-        max_consecutive_failures = 5
-
-        for conv in conversations:
-            action = self._sync_one(client, conv, force, dry_run, max_new, on_progress, result)
-            self._update_result(result, action)
-            consecutive_failures = self._check_abort(action, consecutive_failures, max_consecutive_failures)
+        
+        # Phase 1: Determine what action to take for each conversation
+        # This handles max_new limit correctly before parallel processing
+        work_items = self._categorize_conversations(conversations, force, max_new, result)
+        
+        # Phase 2: Handle dry-run or unchanged (no download needed)
+        to_download = []
+        for conv, action in work_items:
+            if action in ("unchanged", "skipped") or dry_run:
+                self._update_result(result, action)
+                if on_progress:
+                    on_progress(conv["id"], conv.get("title", "")[:50], action)
+            else:
+                to_download.append((conv, action))
+        
+        # Phase 3: Download conversations (parallel or sequential)
+        if to_download:
+            if parallel and len(to_download) > 1:
+                self._download_parallel(client, to_download, result, on_progress, shutdown_check)
+            else:
+                self._download_sequential(client, to_download, result, on_progress, shutdown_check)
 
         if not dry_run:
             self._finalize_sync(result)
         return result
+
+    def _categorize_conversations(
+        self,
+        conversations: list[dict],
+        force: bool,
+        max_new: int | None,
+        result: SyncResult,
+    ) -> list[tuple[dict, str]]:
+        """Determine action for each conversation, respecting max_new limit.
+        
+        Returns list of (conv, action) tuples.
+        """
+        work_items = []
+        new_count = 0
+        
+        for conv in conversations:
+            conv_id = conv["id"]
+            cloud_updated_at = conv.get("updated_at", "")
+            action = self._determine_action(conv_id, cloud_updated_at, force)
+            
+            # Handle max_new limit
+            if action == "new":
+                if max_new is not None and new_count >= max_new:
+                    action = "skipped"
+                    result.skipped_new += 1
+                else:
+                    new_count += 1
+            
+            work_items.append((conv, action))
+        
+        return work_items
+
+    def _download_sequential(
+        self,
+        client: CloudClient,
+        work_items: list[tuple[dict, str]],
+        result: SyncResult,
+        on_progress: Callable[[str, str, str], None] | None,
+        shutdown_check: Callable[[], bool] | None = None,
+    ) -> None:
+        """Download conversations sequentially."""
+        consecutive_failures = 0
+        max_consecutive_failures = 5
+        
+        for conv, planned_action in work_items:
+            if shutdown_check and shutdown_check():
+                log.info("Shutdown requested, stopping sync")
+                break
+            
+            conv_id = conv["id"]
+            cloud_updated_at = conv.get("updated_at", "")
+            title = conv.get("title", "")[:50]
+            
+            # Clean up for force mode
+            if planned_action == "updated":
+                self._cleanup_conversation_dir(conv_id)
+            
+            actual_action = self._download_and_update(
+                client, conv, conv_id, cloud_updated_at, planned_action, result
+            )
+            self._update_result(result, actual_action)
+            if on_progress:
+                on_progress(conv_id, title, actual_action)
+            
+            consecutive_failures = self._check_abort(actual_action, consecutive_failures, max_consecutive_failures)
+
+    def _download_parallel(
+        self,
+        client: CloudClient,
+        work_items: list[tuple[dict, str]],
+        result: SyncResult,
+        on_progress: Callable[[str, str, str], None] | None,
+        shutdown_check: Callable[[], bool] | None = None,
+    ) -> None:
+        """Download conversations in parallel using a thread pool."""
+        max_workers = min(DEFAULT_MAX_WORKERS, len(work_items))
+        log.info("Starting parallel download with %d workers for %d conversations", 
+                 max_workers, len(work_items))
+        
+        # Thread-safe lock for result updates
+        lock = threading.Lock()
+        total_failures = 0
+        max_total_failures = len(work_items) // 2 + 5  # Allow up to ~50% failures before aborting
+        abort_requested = False
+        
+        def download_one(item: tuple[dict, str]) -> tuple[dict, str, str]:
+            """Download a single conversation. Returns (conv, planned_action, actual_action)."""
+            conv, planned_action = item
+            conv_id = conv["id"]
+            cloud_updated_at = conv.get("updated_at", "")
+            
+            # Clean up for force mode (thread-safe - each conv has its own dir)
+            if planned_action == "updated":
+                self._cleanup_conversation_dir(conv_id)
+            
+            actual_action = self._download_and_update(
+                client, conv, conv_id, cloud_updated_at, planned_action, result
+            )
+            return conv, planned_action, actual_action
+        
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_item = {executor.submit(download_one, item): item for item in work_items}
+            
+            pending = set(future_to_item.keys())
+            while pending:
+                # Check for shutdown
+                if shutdown_check and shutdown_check():
+                    log.info("Shutdown requested, cancelling remaining downloads")
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    break
+                
+                if abort_requested:
+                    log.info("Aborting due to too many failures")
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    break
+                
+                # Wait with timeout to allow shutdown check
+                done, pending = wait(pending, timeout=0.5, return_when=FIRST_COMPLETED)
+                
+                for future in done:
+                    try:
+                        conv, planned_action, actual_action = future.result()
+                    except SyncAuthError:
+                        # Re-raise auth errors - they apply to all requests
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        raise
+                    except Exception as e:
+                        # Unexpected error in the download function
+                        item = future_to_item[future]
+                        conv, _ = item
+                        log.error("Unexpected error downloading %s: %s", conv["id"], e)
+                        actual_action = "failed"
+                        with lock:
+                            self._record_failure(result, conv["id"], str(e))
+                    
+                    # Update result (thread-safe)
+                    with lock:
+                        self._update_result(result, actual_action)
+                        if actual_action == "failed":
+                            total_failures += 1
+                            if total_failures >= max_total_failures:
+                                abort_requested = True
+                    
+                    # Progress callback
+                    if on_progress:
+                        on_progress(conv["id"], conv.get("title", "")[:50], actual_action)
 
     def _check_abort(self, action: str, consecutive_failures: int, max_failures: int) -> int:
         """Check if we should abort due to too many consecutive failures."""
@@ -193,45 +379,6 @@ class SyncManager:
                 raise SyncAbortedError(f"Aborting after {max_failures} consecutive failures")
             return consecutive_failures
         return 0  # Reset on success
-
-    def _sync_one(
-        self,
-        client: CloudClient,
-        conv: dict,
-        force: bool,
-        dry_run: bool,
-        max_new: int | None,
-        on_progress: Callable[[str, str, str], None] | None,
-        result: SyncResult,
-    ) -> str:
-        """Sync a single conversation. Returns action taken: 'new', 'updated', 'unchanged', 'failed', 'skipped'."""
-        conv_id = conv["id"]
-        cloud_updated_at = conv.get("updated_at", "")
-        title = conv.get("title", "")[:50]
-
-        planned_action = self._determine_action(conv_id, cloud_updated_at, force)
-
-        # Check if we should skip this new conversation due to max_new limit
-        if planned_action == "new" and max_new is not None and result.new >= max_new:
-            if on_progress:
-                on_progress(conv_id, title, "skipped")
-            return "skipped"
-
-        if planned_action == "unchanged" or dry_run:
-            if on_progress:
-                on_progress(conv_id, title, planned_action)
-            return planned_action
-
-        # For force mode, clean up existing directory before re-download
-        if force and planned_action == "updated":
-            self._cleanup_conversation_dir(conv_id)
-
-        actual_action = self._download_and_update(
-            client, conv, conv_id, cloud_updated_at, planned_action, result
-        )
-        if on_progress:
-            on_progress(conv_id, title, actual_action)
-        return actual_action
 
     def _cleanup_conversation_dir(self, conv_id: str) -> None:
         """Remove existing conversation directory before re-download."""
@@ -366,6 +513,8 @@ class SyncManager:
         n: int,
         dry_run: bool = False,
         on_progress: Callable[[str, str, str], None] | None = None,
+        parallel: bool = True,
+        shutdown_check: Callable[[], bool] | None = None,
     ) -> SyncResult:
         """Reset local storage to only the N most recently updated conversations.
         
@@ -379,11 +528,13 @@ class SyncManager:
             n: Number of conversations to keep
             dry_run: Show what would happen without making changes
             on_progress: Callback for progress updates
+            parallel: Use parallel downloads (default True, uses 20 workers)
+            shutdown_check: Optional function that returns True to request graceful shutdown
         """
         if not self.config.api_key:
             raise ValueError("API key required. Set OH_API_KEY environment variable.")
 
-        log.info("Resetting to %d newest conversations (dry_run=%s)", n, dry_run)
+        log.info("Resetting to %d newest conversations (dry_run=%s, parallel=%s)", n, dry_run, parallel)
 
         try:
             with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
@@ -416,19 +567,14 @@ class SyncManager:
                 self.manifest.conversations = {}
                 self.manifest.failed_ids = []
                 
-                # Download the N newest conversations
+                # Download using the same infrastructure as regular sync
                 result = SyncResult()
-                consecutive_failures = 0
-                max_consecutive_failures = 5
+                work_items = [(conv, "new") for conv in conversations_to_sync]
                 
-                for conv in conversations_to_sync:
-                    action = self._download_and_update(
-                        client, conv, conv["id"], conv.get("updated_at", ""), "new", result
-                    )
-                    self._update_result(result, action)
-                    if on_progress:
-                        on_progress(conv["id"], conv.get("title", "")[:50], action)
-                    consecutive_failures = self._check_abort(action, consecutive_failures, max_consecutive_failures)
+                if parallel and len(work_items) > 1:
+                    self._download_parallel(client, work_items, result, on_progress, shutdown_check)
+                else:
+                    self._download_sequential(client, work_items, result, on_progress, shutdown_check)
                 
                 # Track how many were available but not synced
                 if len(conversations) > n:

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -323,9 +323,12 @@ class SyncManager:
         shutdown_check: Callable[[], bool] | None = None,
         pass_total_on_first: bool = False,
     ) -> None:
-        """Download conversations in parallel using a thread pool."""
-        import time as time_module
+        """Download conversations in parallel using a thread pool.
         
+        Rate limiting is handled by a shared rate limiter in the CloudClient,
+        so when one worker hits a 429, all workers will pause before making
+        new requests.
+        """
         max_workers = min(DEFAULT_MAX_WORKERS, len(work_items))
         log.info("Starting parallel download with %d workers for %d conversations", 
                  max_workers, len(work_items))
@@ -337,21 +340,8 @@ class SyncManager:
         abort_requested = False
         first_callback = [True]  # Mutable for thread-safe first-call detection
         
-        # Track worker index for staggered delays
-        worker_index = [0]
-        
         def download_one(item: tuple[dict, str]) -> tuple[dict, str, str]:
             """Download a single conversation. Returns (conv, planned_action, actual_action)."""
-            # Stagger initial requests to avoid thundering herd
-            with lock:
-                idx = worker_index[0]
-                worker_index[0] += 1
-            
-            # Small delay based on worker index (0, 0.2s, 0.4s, ...)
-            # This spreads out the initial burst of requests
-            if idx > 0 and idx < max_workers * 2:
-                time_module.sleep(0.2 * idx)
-            
             conv, planned_action = item
             conv_id = conv["id"]
             cloud_updated_at = conv.get("updated_at", "")

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -19,8 +19,8 @@ from ohtv.sources.cloud import CloudClient, RateLimitExceededError
 log = logging.getLogger("ohtv")
 
 # Number of parallel workers for API calls
-# Lower than gen (which uses 20) because download API has stricter rate limits
-DEFAULT_MAX_WORKERS = 5
+# Conservative value to avoid overwhelming rate limits on download API
+DEFAULT_MAX_WORKERS = 3
 
 
 class SyncAuthError(Exception):
@@ -324,6 +324,8 @@ class SyncManager:
         pass_total_on_first: bool = False,
     ) -> None:
         """Download conversations in parallel using a thread pool."""
+        import time as time_module
+        
         max_workers = min(DEFAULT_MAX_WORKERS, len(work_items))
         log.info("Starting parallel download with %d workers for %d conversations", 
                  max_workers, len(work_items))
@@ -335,8 +337,21 @@ class SyncManager:
         abort_requested = False
         first_callback = [True]  # Mutable for thread-safe first-call detection
         
+        # Track worker index for staggered delays
+        worker_index = [0]
+        
         def download_one(item: tuple[dict, str]) -> tuple[dict, str, str]:
             """Download a single conversation. Returns (conv, planned_action, actual_action)."""
+            # Stagger initial requests to avoid thundering herd
+            with lock:
+                idx = worker_index[0]
+                worker_index[0] += 1
+            
+            # Small delay based on worker index (0, 0.2s, 0.4s, ...)
+            # This spreads out the initial burst of requests
+            if idx > 0 and idx < max_workers * 2:
+                time_module.sleep(0.2 * idx)
+            
             conv, planned_action = item
             conv_id = conv["id"]
             cloud_updated_at = conv.get("updated_at", "")

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -1,0 +1,148 @@
+"""Unit tests for the parallel module."""
+
+import threading
+import time
+
+import pytest
+
+from ohtv.parallel import format_rate, RateTracker, run_parallel
+
+
+class TestFormatRate:
+    """Tests for format_rate function."""
+
+    def test_returns_rate_for_valid_inputs(self):
+        # 10 items in 60 seconds = 10/min
+        result = format_rate(10, 60.0)
+        assert result == "10.0 items/min"
+
+    def test_returns_placeholder_for_zero_count(self):
+        result = format_rate(0, 60.0)
+        assert result == "-- items/min"
+
+    def test_returns_placeholder_for_short_elapsed(self):
+        result = format_rate(10, 0.05)
+        assert result == "-- items/min"
+
+    def test_custom_unit(self):
+        result = format_rate(30, 60.0, unit="conv")
+        assert result == "30.0 conv/min"
+
+    def test_fractional_rate(self):
+        # 5 items in 30 seconds = 10/min
+        result = format_rate(5, 30.0)
+        assert result == "10.0 items/min"
+
+
+class TestRateTracker:
+    """Tests for RateTracker class."""
+
+    def test_initial_count_is_zero(self):
+        tracker = RateTracker()
+        assert tracker.count == 0
+
+    def test_increment_increases_count(self):
+        tracker = RateTracker()
+        tracker.increment()
+        assert tracker.count == 1
+        tracker.increment(5)
+        assert tracker.count == 6
+
+    def test_elapsed_time_increases(self):
+        tracker = RateTracker()
+        time.sleep(0.1)
+        assert tracker.elapsed >= 0.1
+
+    def test_get_rate_str_returns_placeholder_initially(self):
+        tracker = RateTracker()
+        assert "--" in tracker.get_rate_str()
+
+    def test_thread_safety(self):
+        """Test that RateTracker is thread-safe."""
+        tracker = RateTracker()
+        threads = []
+        
+        def increment_many():
+            for _ in range(100):
+                tracker.increment()
+        
+        for _ in range(10):
+            t = threading.Thread(target=increment_many)
+            threads.append(t)
+            t.start()
+        
+        for t in threads:
+            t.join()
+        
+        assert tracker.count == 1000
+
+
+class TestRunParallel:
+    """Tests for run_parallel function."""
+
+    def test_empty_list_returns_empty(self):
+        results = run_parallel([], lambda x: x)
+        assert results == []
+
+    def test_single_item_processed_sequentially(self):
+        results = run_parallel([1], lambda x: x * 2)
+        assert len(results) == 1
+        item, result, error = results[0]
+        assert item == 1
+        assert result == 2
+        assert error is None
+
+    def test_multiple_items_processed(self):
+        items = [1, 2, 3, 4, 5]
+        results = run_parallel(items, lambda x: x * 2, max_workers=2)
+        
+        assert len(results) == 5
+        result_values = {r[1] for r in results if r[2] is None}
+        assert result_values == {2, 4, 6, 8, 10}
+
+    def test_errors_captured(self):
+        def may_fail(x):
+            if x == 3:
+                raise ValueError("Test error")
+            return x
+        
+        results = run_parallel([1, 2, 3, 4], may_fail)
+        
+        errors = [r for r in results if r[2] is not None]
+        assert len(errors) == 1
+        assert errors[0][0] == 3
+
+    def test_on_result_callback(self):
+        callback_items = []
+        
+        def on_result(item, result):
+            callback_items.append((item, result))
+        
+        run_parallel([1, 2], lambda x: x * 2, on_result=on_result)
+        
+        assert len(callback_items) == 2
+        assert (1, 2) in callback_items
+        assert (2, 4) in callback_items
+
+    def test_shutdown_check_stops_processing(self):
+        processed = []
+        call_count = [0]
+        
+        def process(x):
+            processed.append(x)
+            time.sleep(0.1)  # Simulate work
+            return x
+        
+        def shutdown_after_2():
+            call_count[0] += 1
+            return call_count[0] > 2
+        
+        run_parallel(
+            list(range(10)), 
+            process, 
+            max_workers=1,  # Sequential to test shutdown
+            shutdown_check=shutdown_after_2
+        )
+        
+        # Should have processed 2 or 3 items before shutdown
+        assert len(processed) <= 3

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -124,7 +124,8 @@ class TestRunParallel:
         assert (1, 2) in callback_items
         assert (2, 4) in callback_items
 
-    def test_shutdown_check_stops_processing(self):
+    def test_shutdown_check_stops_processing_sequential(self):
+        """Test shutdown_check with sequential processing (max_workers=1)."""
         processed = []
         call_count = [0]
         
@@ -146,3 +147,34 @@ class TestRunParallel:
         
         # Should have processed 2 or 3 items before shutdown
         assert len(processed) <= 3
+
+    def test_shutdown_check_stops_processing_parallel(self):
+        """Test shutdown_check with parallel processing (multiple workers)."""
+        processed = []
+        processed_lock = threading.Lock()
+        shutdown_requested = [False]
+        
+        def process(x):
+            time.sleep(0.05)  # Simulate work
+            with processed_lock:
+                processed.append(x)
+            return x
+        
+        def request_shutdown_after_some():
+            with processed_lock:
+                # Request shutdown after some items are processed
+                if len(processed) >= 2:
+                    shutdown_requested[0] = True
+            return shutdown_requested[0]
+        
+        run_parallel(
+            list(range(20)), 
+            process, 
+            max_workers=4,  # Parallel processing
+            shutdown_check=request_shutdown_after_some
+        )
+        
+        # With 4 workers and shutdown after 2 processed, we might have up to
+        # 4 in-flight + 2 already done before shutdown is detected
+        # Due to timing, some extra items may complete - allow reasonable tolerance
+        assert len(processed) < 20, "Should stop before all items are processed"

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -175,67 +175,76 @@ class TestSyncManagerMaxNew:
             }
             return mgr
 
-    def test_sync_one_skips_new_when_limit_reached(self, manager):
+    def test_categorize_skips_new_when_limit_reached(self, manager):
         """Test that new conversations are skipped when max_new limit is reached."""
-        result = SyncResult(new=5)  # Already at limit
+        result = SyncResult()
         
-        conv = {"id": "newconv123", "updated_at": "2024-01-02T12:00:00Z", "title": "New Conv"}
+        # 6 new conversations, but limit is 5
+        conversations = [
+            {"id": f"newconv{i:03d}", "updated_at": "2024-01-02T12:00:00Z", "title": f"New Conv {i}"}
+            for i in range(6)
+        ]
         
-        action = manager._sync_one(
-            client=MagicMock(),
-            conv=conv,
+        work_items = manager._categorize_conversations(
+            conversations=conversations,
             force=False,
-            dry_run=False,
-            max_new=5,  # Limit already reached
-            on_progress=None,
+            max_new=5,
             result=result,
         )
         
-        assert action == "skipped"
+        # First 5 should be "new", 6th should be "skipped"
+        actions = [action for _, action in work_items]
+        assert actions.count("new") == 5
+        assert actions.count("skipped") == 1
+        assert result.skipped_new == 1
 
-    def test_sync_one_allows_new_when_under_limit(self, manager):
+    def test_categorize_allows_new_when_under_limit(self, manager):
         """Test that new conversations are allowed when under max_new limit."""
-        result = SyncResult(new=2)  # Under limit
+        result = SyncResult()
         
-        conv = {"id": "newconv123", "updated_at": "2024-01-02T12:00:00Z", "title": "New Conv"}
+        # 3 new conversations, limit is 5
+        conversations = [
+            {"id": f"newconv{i:03d}", "updated_at": "2024-01-02T12:00:00Z", "title": f"New Conv {i}"}
+            for i in range(3)
+        ]
         
-        # Mock the download to succeed
-        mock_client = MagicMock()
-        mock_client.download_trajectory.return_value = _create_minimal_zip()
-        
-        action = manager._sync_one(
-            client=mock_client,
-            conv=conv,
+        work_items = manager._categorize_conversations(
+            conversations=conversations,
             force=False,
-            dry_run=False,
             max_new=5,  # Still under limit
-            on_progress=None,
             result=result,
         )
         
-        assert action == "new"
+        # All 3 should be "new"
+        actions = [action for _, action in work_items]
+        assert all(a == "new" for a in actions)
+        assert result.skipped_new == 0
 
-    def test_sync_one_allows_updates_regardless_of_limit(self, manager):
+    def test_categorize_allows_updates_regardless_of_limit(self, manager):
         """Test that updates are always allowed, even when max_new limit is reached."""
-        result = SyncResult(new=5)  # At new limit
+        result = SyncResult()
         
-        conv = {"id": "existing001", "updated_at": "2024-01-02T12:00:00Z", "title": "Updated"}
+        # 5 new + 1 update, limit is 5
+        conversations = [
+            {"id": f"newconv{i:03d}", "updated_at": "2024-01-02T12:00:00Z", "title": f"New Conv {i}"}
+            for i in range(5)
+        ]
+        # Add an update (existing001 is in manager.manifest.conversations)
+        conversations.append({"id": "existing001", "updated_at": "2024-01-02T12:00:00Z", "title": "Updated"})
         
-        # Mock the download to succeed
-        mock_client = MagicMock()
-        mock_client.download_trajectory.return_value = _create_minimal_zip()
-        
-        action = manager._sync_one(
-            client=mock_client,
-            conv=conv,
+        work_items = manager._categorize_conversations(
+            conversations=conversations,
             force=False,
-            dry_run=False,
-            max_new=5,  # Limit reached, but this is an update
-            on_progress=None,
+            max_new=5,  # Limit reached for new, but updates should still work
             result=result,
         )
         
-        assert action == "updated"
+        # First 5 new + 1 update
+        actions = [action for _, action in work_items]
+        assert actions.count("new") == 5
+        assert actions.count("updated") == 1
+        assert "skipped" not in actions
+        assert result.skipped_new == 0
 
 
 class TestSyncManagerFinalizeSync:
@@ -339,6 +348,108 @@ class TestSyncManagerGetLocalConversationCount:
             "conv3": {},
         }
         assert manager.get_local_conversation_count() == 3
+
+
+class TestSyncManagerParallel:
+    """Tests for parallel sync functionality."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.synced_conversations_dir.mkdir(parents=True)
+        config.api_key = "test-key"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_download_parallel_processes_all_items(self, manager):
+        """Test that parallel download processes all work items."""
+        result = SyncResult()
+        
+        # Create work items
+        work_items = [
+            ({"id": f"conv{i:03d}", "updated_at": "2024-01-01T00:00:00Z", "title": f"Conv {i}"}, "new")
+            for i in range(5)
+        ]
+        
+        # Mock client
+        mock_client = MagicMock()
+        mock_client.download_trajectory.return_value = _create_minimal_zip()
+        
+        # Track progress calls
+        progress_calls = []
+        def track_progress(conv_id, title, action):
+            progress_calls.append((conv_id, action))
+        
+        manager._download_parallel(
+            client=mock_client,
+            work_items=work_items,
+            result=result,
+            on_progress=track_progress,
+        )
+        
+        # All should succeed
+        assert result.new == 5
+        assert result.failed == 0
+        assert len(progress_calls) == 5
+
+    def test_download_sequential_processes_all_items(self, manager):
+        """Test that sequential download processes all work items."""
+        result = SyncResult()
+        
+        work_items = [
+            ({"id": f"conv{i:03d}", "updated_at": "2024-01-01T00:00:00Z", "title": f"Conv {i}"}, "new")
+            for i in range(3)
+        ]
+        
+        mock_client = MagicMock()
+        mock_client.download_trajectory.return_value = _create_minimal_zip()
+        
+        progress_calls = []
+        def track_progress(conv_id, title, action):
+            progress_calls.append((conv_id, action))
+        
+        manager._download_sequential(
+            client=mock_client,
+            work_items=work_items,
+            result=result,
+            on_progress=track_progress,
+        )
+        
+        assert result.new == 3
+        assert len(progress_calls) == 3
+
+    def test_shutdown_check_stops_parallel_download(self, manager):
+        """Test that shutdown_check stops parallel processing."""
+        result = SyncResult()
+        
+        # Create many work items
+        work_items = [
+            ({"id": f"conv{i:03d}", "updated_at": "2024-01-01T00:00:00Z", "title": f"Conv {i}"}, "new")
+            for i in range(20)
+        ]
+        
+        mock_client = MagicMock()
+        mock_client.download_trajectory.return_value = _create_minimal_zip()
+        
+        # Shutdown after first few items
+        call_count = [0]
+        def shutdown_after_3():
+            call_count[0] += 1
+            return call_count[0] > 3
+        
+        manager._download_parallel(
+            client=mock_client,
+            work_items=work_items,
+            result=result,
+            on_progress=None,
+            shutdown_check=shutdown_after_3,
+        )
+        
+        # Should have processed some but not all
+        assert result.new < 20
 
 
 def _create_minimal_zip() -> bytes:


### PR DESCRIPTION
This PR adds the same performance improvements that `gen` has to the `sync` command:

## Summary

The `gen` command has a nice progress bar and spins up a pool of workers to speed things up. This PR brings the same improvements to `sync`:

- **Rich Progress Bar**: Shows syncing progress with processing rate
- **Parallel Downloads**: Uses 3 workers via ThreadPoolExecutor (conservative to avoid rate limits on the download API)
- **Graceful Shutdown**: Ctrl+C finishes current downloads before exiting
- **Shared Utilities**: Extracted common parallel processing code for reuse
- **Circuit Breaker**: Rate limiting retries cap at 50 attempts (~50 min) before failing

## Changes

### New `parallel.py` utility module
- `format_rate()` - Format processing rate as items/min  
- `RateTracker` - Thread-safe rate tracking with smoothing
- `run_parallel()` - Generic parallel execution helper
- `graceful_shutdown_handler()` - Context manager for SIGINT/SIGTERM handling

### `sync.py` parallel download support
- Added `_categorize_conversations()` to determine actions before download
- Added `_download_parallel()` using ThreadPoolExecutor with 3 workers
- Added `_download_sequential()` for single item or fallback
- Thread-safe result counter updates
- Graceful shutdown handling during parallel downloads
- Updated `reset_to_n_newest()` to use parallel infrastructure

### `cloud.py` rate limiting improvements
- Global rate limiter shared across all workers
- Circuit breaker: max_retries=50 prevents infinite hang on persistent rate limits
- Exponential backoff with jitter (2s → 60s cap)

### `cli.py` progress bar for sync
- Added Rich Progress bar showing processing rate
- Rate display with smoothing to avoid jitter
- Graceful shutdown handling (Ctrl+C finishes current downloads)
- Transient progress bar that clears after completion

### Tests
- Added 17 tests for `parallel.py` module (including parallel shutdown)
- Added 3 new tests for sync parallel functionality  
- Updated 3 existing sync tests to use new `_categorize_conversations()` method
- Total: **808 tests passing**

## Code Reusability

The code is now more reusable:
1. **`parallel.py`** provides generic parallel execution utilities
2. Both `sync` and `gen` commands use similar patterns (ThreadPoolExecutor, graceful shutdown, progress display)
3. The `RateTracker` class can be used by any command that needs rate tracking with smoothing

## Performance

With 3 parallel workers, sync should be faster when downloading multiple conversations while staying conservative on rate limits.

---
_This PR was created by an AI assistant (OpenHands)._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/280fc416-4aa0-4ae3-ae3e-19d3876bad04)