### PR TITLE
feat: enhance RAG citations with conversation URLs, dates, and refs

### DIFF
--- a/docs/DESIGN_RAG_CITATIONS.md
+++ b/docs/DESIGN_RAG_CITATIONS.md
@@ -1,0 +1,181 @@
+# RAG Citations Enhancement
+
+## Overview
+
+This document describes the enhanced citation system for the `ohtv ask` command, implementing the requirements from [GitHub issue #32](https://github.com/jpshackelford/ohtv/issues/32).
+
+## Features
+
+1. **Contextual Chunk Enrichment**: Prepends date, summary, and refs to chunks before embedding (Anthropic's "contextual retrieval" technique)
+2. **Database Schema**: Added `summary` column to `conversations` table
+3. **Full cloud URLs** for source conversations (only within 14-day retention)
+4. **Conversation dates and summaries** in citation output
+5. **"See Also" section** with related PRs, issues, and repositories
+6. **Improved LLM prompts** for better source attribution with ref disambiguation
+
+## Architecture
+
+### New Data Structures (rag.py)
+
+```python
+@dataclass
+class RefInfo:
+    """A reference (PR/issue) associated with a conversation."""
+    ref_type: str  # "pr" or "issue"
+    url: str
+    fqn: str  # e.g., "owner/repo#123"
+    display_name: str
+    link_type: str  # "read" or "write"
+
+@dataclass 
+class RepoInfo:
+    """A repository associated with a conversation."""
+    url: str
+    fqn: str  # e.g., "owner/repo"
+    short_name: str
+    link_type: str
+
+@dataclass
+class ConversationSource:
+    """Full source information for a conversation."""
+    conversation_id: str
+    title: str
+    summary: str | None
+    source: str  # "local" or "cloud"
+    cloud_url: str | None
+    created_at: datetime | None
+    repos: list[RepoInfo]
+    prs: list[RefInfo]
+    issues: list[RefInfo]
+```
+
+### Extended ContextChunk
+
+```python
+@dataclass
+class ContextChunk:
+    conversation_id: str
+    title: str
+    embed_type: str
+    source_text: str
+    score: float
+    summary: str | None = None      # NEW
+    cloud_url: str | None = None    # NEW
+    created_at: datetime | None = None  # NEW
+    conv_source: str = "local"      # NEW
+    source: ConversationSource | None = None  # NEW
+```
+
+### Extended RAGAnswer
+
+```python
+@dataclass
+class RAGAnswer:
+    # ... existing fields ...
+    related_repos: list[RepoInfo] | None = None   # NEW
+    related_prs: list[RefInfo] | None = None      # NEW
+    related_issues: list[RefInfo] | None = None   # NEW
+```
+
+## LLM Context vs User Display
+
+**LLM receives** (for accurate citation):
+- Title
+- Date/age (e.g., "3 days ago")
+- Summary
+- Linked refs with FQN (e.g., "PR jpshackelford/ohtv#23")
+
+**User sees** (in CLI output):
+- Clickable URLs (for cloud conversations within 14-day retention)
+- Full conversation IDs
+- Conversation summaries
+- "See Also" section with aggregated refs
+
+## Contextual Chunk Enrichment
+
+Based on Anthropic's [Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval) research (2024), chunks are enriched with contextual preambles before embedding:
+
+```
+Date: 2026-04-19
+Summary: Configure MCP secrets handling
+Related: PR jpshackelford/ohtv#23, Issue jpshackelford/ohtv#42
+---
+[actual chunk content]
+```
+
+This improves retrieval accuracy for queries that reference specific dates, PRs, or issues.
+
+## Database Changes
+
+Migration `009_add_summary_column.py` adds:
+- `summary TEXT` column to `conversations` table
+
+Summaries are populated via:
+1. The `summaries` processing stage (extracts goal from objective analysis)
+2. Automatic extraction during embedding generation (fallback to analysis goal)
+
+## Usage
+
+Ensure refs are indexed and summaries generated:
+
+```bash
+# Sync and run all processing including summary generation
+ohtv sync -p
+
+# Or run processing stages manually
+ohtv db scan
+ohtv db process refs
+ohtv db process summaries
+
+# Generate embeddings with contextual preambles
+ohtv db embed
+
+# Ask questions
+ohtv ask "how did we fix the authentication bug?"
+```
+
+## Expected Output
+
+```
+$ ohtv ask "help me find the PR discussion about mcp configuration"
+
+Answer:
+In the conversation "Configure MCP secrets handling" from 3 days ago, the team 
+discussed the approach for handling MCP secrets. The key decision was to use 
+environment variable injection rather than storing secrets in config files...
+
+─────────────────────────────────────────────────
+Sources (2 conversations):
+• [4403c7fb] Configure MCP secrets handling (2026-04-19)
+  User wanted to configure MCP secrets handling for the plugin system.
+  https://app.all-hands.dev/conversations/4403c7fb01ac40b0b4a6fc727314c7c2
+• [a1b2c3d4] MCP security review (2026-04-17)
+  Security review of MCP integration with focus on secret handling.
+  https://app.all-hands.dev/conversations/a1b2c3d4e5f6789012345678901234ab
+
+See Also:
+  Pull Requests:
+  • jpshackelford/ohtv #42
+  Issues:
+  • jpshackelford/ohtv #38
+  Repositories:
+  • jpshackelford/ohtv
+
+Search: 0.15s | Generation: 2.34s | Model: openai/gpt-4o-mini
+```
+
+## Cloud URL Retention
+
+Cloud conversations have a 14-day retention period. URLs are only displayed for conversations within this window to avoid broken links.
+
+## Graceful Degradation
+
+The system gracefully handles missing components:
+- If ref stores are not available, citations show basic info without refs
+- If summaries are not generated, the `summary` field is `None`
+- If conversations are local (not cloud), no URL is displayed
+
+## References
+
+- [GitHub Issue #32](https://github.com/jpshackelford/ohtv/issues/32)
+- [Anthropic Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval)

--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -344,12 +344,12 @@ class AnalysisCacheManager:
         """
         try:
             from ohtv.db import get_connection, migrate
-            from ohtv.db.stores import AnalysisCacheStore
+            from ohtv.db.stores import AnalysisCacheStore, ConversationStore
             from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry
             
             with get_connection() as conn:
                 migrate(conn)
-                store = AnalysisCacheStore(conn)
+                cache_store = AnalysisCacheStore(conn)
                 entry = AnalysisCacheEntry(
                     conversation_id=conversation_id,
                     cache_key=cache_key,
@@ -357,7 +357,16 @@ class AnalysisCacheManager:
                     content_hash=analysis.content_hash,
                     analyzed_at=analysis.analyzed_at,
                 )
-                store.upsert_cache(entry)
+                cache_store.upsert_cache(entry)
+                
+                # Also sync goal to conversation summary
+                analysis_dict = analysis.model_dump() if hasattr(analysis, 'model_dump') else {}
+                goal = analysis_dict.get("goal")
+                if goal:
+                    conv_store = ConversationStore(conn)
+                    conv_store.update_summary(conversation_id, goal)
+                    log.debug("Updated conversation summary: %s", conversation_id)
+                
                 conn.commit()
                 log.debug("Synced cache to DB: %s (key: %s)", conversation_id, cache_key)
         except Exception as e:

--- a/src/ohtv/analysis/embeddings/__init__.py
+++ b/src/ohtv/analysis/embeddings/__init__.py
@@ -30,6 +30,7 @@ from .client import (
 
 # Text building exports
 from .text_builders import (
+    ConversationMetadata,
     ConversationTexts,
     TextChunk,
     build_analysis_text,
@@ -66,6 +67,7 @@ __all__ = [
     "EmbeddingStats",
     "TextChunk",
     "ConversationTexts",
+    "ConversationMetadata",
     # Constants
     "DEFAULT_EMBEDDING_MODEL",
     "KNOWN_COSTS",

--- a/src/ohtv/analysis/embeddings/__init__.py
+++ b/src/ohtv/analysis/embeddings/__init__.py
@@ -50,12 +50,16 @@ from .chunking import (
 
 # Operations exports
 from .operations import (
+    EmbeddingBatch,
     EmbeddingStats,
+    EmbeddingWriter,
+    PendingEmbedding,
     check_embedding_status,
     check_embedding_types,
     embed_conversation,
     embed_conversation_full,
     estimate_conversation_tokens,
+    generate_embeddings_only,
 )
 
 EmbedType = Literal["analysis", "summary", "content"]
@@ -91,7 +95,11 @@ __all__ = [
     # Operations
     "embed_conversation",
     "embed_conversation_full",
+    "generate_embeddings_only",
     "estimate_conversation_tokens",
     "check_embedding_status",
     "check_embedding_types",
+    "EmbeddingBatch",
+    "PendingEmbedding",
+    "EmbeddingWriter",
 ]

--- a/src/ohtv/analysis/embeddings/__init__.py
+++ b/src/ohtv/analysis/embeddings/__init__.py
@@ -26,6 +26,7 @@ from .client import (
     get_embedding,
     get_embedding_dimension,
     get_embedding_model,
+    reset_rate_limiter,
 )
 
 # Text building exports
@@ -83,6 +84,7 @@ __all__ = [
     "get_embedding_model",
     "get_embedding_dimension",
     "estimate_cost",
+    "reset_rate_limiter",
     # Text builders
     "build_analysis_text",
     "build_summary_text",

--- a/src/ohtv/analysis/embeddings/chunking.py
+++ b/src/ohtv/analysis/embeddings/chunking.py
@@ -2,7 +2,10 @@
 
 from .text_builders import TextChunk
 
-CHUNK_SIZE = 1000  # Target tokens per chunk
+# Target tokens per chunk
+# Note: Contextual preambles are handled by smart truncation in
+# ConversationMetadata.prepend_to_text() which accounts for preamble size
+CHUNK_SIZE = 1000
 CHUNK_OVERLAP = 100  # Overlap between chunks
 
 

--- a/src/ohtv/analysis/embeddings/client.py
+++ b/src/ohtv/analysis/embeddings/client.py
@@ -5,10 +5,15 @@ Handles configuration, API interaction, and result types.
 Supports two modes:
 - LiteLLM: Uses LLM_API_KEY and LLM_BASE_URL for cloud embeddings
 - Ollama: Uses local Ollama server (set EMBEDDING_MODEL=ollama/nomic-embed-text)
+
+Includes a global rate limiter that coordinates backoff across all threads
+when errors are encountered.
 """
 
 import logging
 import os
+import threading
+import time
 from dataclasses import dataclass
 
 import litellm
@@ -17,6 +22,103 @@ import litellm
 litellm.suppress_debug_info = True
 
 log = logging.getLogger("ohtv")
+
+
+class GlobalRateLimiter:
+    """Thread-safe global rate limiter with exponential backoff.
+    
+    When any thread encounters an error (429, 500, etc.), all threads
+    pause for the backoff period. This prevents thundering herd issues
+    where all threads retry simultaneously.
+    
+    Usage:
+        limiter = GlobalRateLimiter()
+        
+        # Before making a request
+        limiter.wait_if_needed()
+        
+        # After an error
+        limiter.record_error()
+        
+        # After success (optional, resets backoff)
+        limiter.record_success()
+    """
+    
+    def __init__(self, base_delay: float = 1.0, max_delay: float = 60.0, max_retries: int = 5):
+        self._lock = threading.Lock()
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._max_retries = max_retries
+        self._consecutive_errors = 0
+        self._blocked_until = 0.0  # timestamp when we can proceed
+    
+    def wait_if_needed(self) -> None:
+        """Wait if we're in a backoff period."""
+        with self._lock:
+            now = time.time()
+            if now < self._blocked_until:
+                wait_time = self._blocked_until - now
+                log.debug("Rate limiter: waiting %.1fs before next request", wait_time)
+        
+        # Wait outside the lock so other threads can also check
+        now = time.time()
+        if now < self._blocked_until:
+            time.sleep(self._blocked_until - now)
+    
+    def record_error(self, error_code: int | None = None) -> bool:
+        """Record an error and set backoff. Returns True if should retry."""
+        with self._lock:
+            self._consecutive_errors += 1
+            
+            if self._consecutive_errors > self._max_retries:
+                log.warning("Rate limiter: max retries (%d) exceeded", self._max_retries)
+                return False
+            
+            # Calculate exponential backoff with jitter
+            delay = min(
+                self._base_delay * (2 ** (self._consecutive_errors - 1)),
+                self._max_delay
+            )
+            # Add some jitter (±20%) to prevent synchronized retries
+            import random
+            delay *= (0.8 + random.random() * 0.4)
+            
+            self._blocked_until = time.time() + delay
+            
+            log.warning(
+                "Rate limiter: error %s (attempt %d/%d), backing off %.1fs",
+                error_code or "unknown",
+                self._consecutive_errors,
+                self._max_retries,
+                delay
+            )
+            return True
+    
+    def record_success(self) -> None:
+        """Record a success - resets consecutive error count."""
+        with self._lock:
+            if self._consecutive_errors > 0:
+                log.debug("Rate limiter: success after %d errors, resetting", self._consecutive_errors)
+            self._consecutive_errors = 0
+    
+    def get_retry_count(self) -> int:
+        """Get current consecutive error count."""
+        with self._lock:
+            return self._consecutive_errors
+
+
+# Global rate limiter shared by all embedding threads
+_rate_limiter = GlobalRateLimiter(base_delay=1.0, max_delay=30.0, max_retries=5)
+
+
+def reset_rate_limiter() -> None:
+    """Reset the global rate limiter state.
+    
+    Call this at the start of a new embedding operation to clear any
+    accumulated error state from previous operations.
+    """
+    global _rate_limiter
+    _rate_limiter = GlobalRateLimiter(base_delay=1.0, max_delay=30.0, max_retries=5)
 
 DEFAULT_EMBEDDING_MODEL = "openai/text-embedding-3-small"
 
@@ -96,6 +198,9 @@ def estimate_cost(token_count: int, model: str | None = None) -> float:
 def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
     """Get embedding from local Ollama server.
     
+    Uses global rate limiter to coordinate backoff across all threads
+    when errors are encountered.
+    
     Args:
         text: Text to embed
         model: Model name (e.g., 'ollama/nomic-embed-text')
@@ -103,7 +208,6 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
     Returns:
         EmbeddingResult with embedding vector and metadata
     """
-    import time
     import urllib.request
     import urllib.error
     import json
@@ -134,12 +238,12 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
         "prompt": text,
     }).encode("utf-8")
     
-    # Retry logic for transient Ollama errors
-    max_retries = 3
-    retry_delay = 1.0  # seconds
     last_error = None
     
-    for attempt in range(max_retries):
+    while True:
+        # Wait if global rate limiter says we should back off
+        _rate_limiter.wait_if_needed()
+        
         req = urllib.request.Request(
             f"{ollama_url}/api/embeddings",
             data=request_data,
@@ -153,6 +257,9 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
             embedding = result.get("embedding", [])
             if not embedding:
                 raise RuntimeError(f"Ollama returned empty embedding. Response: {result}")
+            
+            # Success - reset the global rate limiter
+            _rate_limiter.record_success()
             
             # Rough estimate: ~1.3 tokens per word (Ollama doesn't report token usage)
             # Precision matters less for local/free models than for paid APIs
@@ -172,16 +279,25 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
                 error_body = e.read().decode("utf-8")
             except Exception:
                 pass
-            log.debug("Ollama HTTP %d error (attempt %d): %s", e.code, attempt + 1, error_body or str(e))
-            # Retry on 500 errors (Ollama overloaded) with linear backoff
-            if e.code == 500 and attempt < max_retries - 1:
-                time.sleep(retry_delay * (attempt + 1))  # 1s, 2s, 3s...
-                continue
+            log.debug("Ollama HTTP %d error: %s", e.code, error_body or str(e))
+            
+            # Retry on 429 (rate limit) or 500-599 (server errors)
+            if e.code == 429 or (500 <= e.code < 600):
+                should_retry = _rate_limiter.record_error(e.code)
+                if should_retry:
+                    continue
+            
             raise RuntimeError(
-                f"Ollama connection failed: {e}. Body: {error_body}. "
+                f"Ollama connection failed: HTTP {e.code}. Body: {error_body}. "
                 f"Is Ollama running? Try: ollama serve"
             ) from e
         except urllib.error.URLError as e:
+            last_error = e
+            # Connection errors might be transient - try backing off
+            should_retry = _rate_limiter.record_error(None)
+            if should_retry:
+                log.debug("Ollama connection error, will retry: %s", e)
+                continue
             raise RuntimeError(
                 f"Ollama connection failed: {e}. "
                 f"Is Ollama running? Try: ollama serve"
@@ -190,7 +306,7 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
             raise RuntimeError(f"Ollama embedding failed: {e}") from e
     
     # Should not reach here, but just in case
-    raise RuntimeError(f"Ollama embedding failed after {max_retries} retries: {last_error}")
+    raise RuntimeError(f"Ollama embedding failed after retries: {last_error}")
 
 
 def get_embedding(text: str, model: str | None = None) -> EmbeddingResult:
@@ -198,6 +314,8 @@ def get_embedding(text: str, model: str | None = None) -> EmbeddingResult:
 
     Uses LLM_API_KEY and LLM_BASE_URL for cloud embeddings,
     or local Ollama server for ollama/* models.
+    
+    Uses global rate limiter to coordinate backoff across all threads.
 
     Args:
         text: Text to embed
@@ -230,23 +348,49 @@ def get_embedding(text: str, model: str | None = None) -> EmbeddingResult:
 
     log.debug("Getting embedding with model %s", model)
 
-    try:
-        response = litellm.embedding(
-            model=model,
-            input=[text],
-            api_key=api_key,
-            api_base=api_base,
-        )
-    except Exception as e:
-        raise RuntimeError(f"Embedding API call failed: {e}") from e
+    last_error = None
+    
+    while True:
+        # Wait if global rate limiter says we should back off
+        _rate_limiter.wait_if_needed()
+        
+        try:
+            response = litellm.embedding(
+                model=model,
+                input=[text],
+                api_key=api_key,
+                api_base=api_base,
+            )
+            
+            # Success - reset the rate limiter
+            _rate_limiter.record_success()
+            
+            embedding = response.data[0]["embedding"]
+            token_count = response.usage.total_tokens
+            dimensions = len(embedding)
 
-    embedding = response.data[0]["embedding"]
-    token_count = response.usage.total_tokens
-    dimensions = len(embedding)
-
-    return EmbeddingResult(
-        embedding=embedding,
-        token_count=token_count,
-        model=model,
-        dimensions=dimensions,
-    )
+            return EmbeddingResult(
+                embedding=embedding,
+                token_count=token_count,
+                model=model,
+                dimensions=dimensions,
+            )
+        except Exception as e:
+            last_error = e
+            error_str = str(e).lower()
+            
+            # Check for rate limit or server errors that should trigger backoff
+            is_rate_limit = "429" in error_str or "rate" in error_str or "limit" in error_str
+            is_server_error = "500" in error_str or "502" in error_str or "503" in error_str or "504" in error_str
+            
+            if is_rate_limit or is_server_error:
+                error_code = 429 if is_rate_limit else 500
+                should_retry = _rate_limiter.record_error(error_code)
+                if should_retry:
+                    log.debug("LiteLLM error, will retry: %s", e)
+                    continue
+            
+            raise RuntimeError(f"Embedding API call failed: {e}") from e
+    
+    # Should not reach here
+    raise RuntimeError(f"Embedding API call failed after retries: {last_error}")

--- a/src/ohtv/analysis/embeddings/client.py
+++ b/src/ohtv/analysis/embeddings/client.py
@@ -108,7 +108,8 @@ class GlobalRateLimiter:
 
 
 # Global rate limiter shared by all embedding threads
-_rate_limiter = GlobalRateLimiter(base_delay=1.0, max_delay=30.0, max_retries=5)
+# With 10 retries and 30s max delay, we'll wait up to ~3 minutes for recovery
+_rate_limiter = GlobalRateLimiter(base_delay=1.0, max_delay=30.0, max_retries=10)
 
 
 def reset_rate_limiter() -> None:
@@ -118,7 +119,7 @@ def reset_rate_limiter() -> None:
     accumulated error state from previous operations.
     """
     global _rate_limiter
-    _rate_limiter = GlobalRateLimiter(base_delay=1.0, max_delay=30.0, max_retries=5)
+    _rate_limiter = GlobalRateLimiter(base_delay=1.0, max_delay=30.0, max_retries=10)
 
 DEFAULT_EMBEDDING_MODEL = "openai/text-embedding-3-small"
 

--- a/src/ohtv/analysis/embeddings/client.py
+++ b/src/ohtv/analysis/embeddings/client.py
@@ -219,8 +219,11 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
     
     # nomic-embed-text has 2048 token context (from model_info)
     # BERT tokenizer averages ~4 chars/token, so ~8000 chars max
-    # But we see failures at 6342 chars, so use conservative 4000 char limit
-    MAX_CHARS = 4000
+    # But in practice we see failures even at 4000 chars, likely due to:
+    # - Special tokens added by the model
+    # - Non-ASCII characters counting as multiple tokens
+    # Use conservative 3000 char limit to avoid context length errors
+    MAX_CHARS = 3000
     original_len = len(text)
     if original_len > MAX_CHARS:
         # Truncate at word boundary to avoid cutting mid-word
@@ -281,6 +284,14 @@ def _get_ollama_embedding(text: str, model: str) -> EmbeddingResult:
             except Exception:
                 pass
             log.debug("Ollama HTTP %d error: %s", e.code, error_body or str(e))
+            
+            # Context length errors are NOT transient - don't retry, just fail
+            # Ollama returns these as 500 but they're really input validation errors
+            if "context length" in error_body.lower() or "input length" in error_body.lower():
+                raise RuntimeError(
+                    f"Text too long for Ollama model (even after truncation). "
+                    f"Consider using smaller chunks. Error: {error_body}"
+                ) from e
             
             # Retry on 429 (rate limit) or 500-599 (server errors)
             if e.code == 429 or (500 <= e.code < 600):

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -65,6 +65,9 @@ def embed_conversation_full(
     - analysis: From cached LLM analysis (if available)
     - summary: User messages + refs + file paths
     - content: File contents, chunked if large
+    
+    Uses contextual chunk enrichment (Anthropic's "contextual retrieval" 
+    technique) to prepend date, summary, and refs to chunks before embedding.
 
     Args:
         conv_dir: Path to conversation directory
@@ -78,9 +81,9 @@ def embed_conversation_full(
         EmbeddingStats with counts and totals
     """
     from ohtv.analysis.cache import load_events, load_analysis
-    from ohtv.db.stores import EmbeddingStore, LinkStore, ReferenceStore
+    from ohtv.db.stores import EmbeddingStore, LinkStore, ReferenceStore, ConversationStore
     from .client import get_embedding, get_embedding_model
-    from .text_builders import build_conversation_texts
+    from .text_builders import build_conversation_texts, ConversationMetadata
 
     conv_id = conv_dir.name
     store = EmbeddingStore(conn)
@@ -93,7 +96,9 @@ def embed_conversation_full(
 
     if analysis is None:
         analysis = load_analysis(conv_dir)
-
+    
+    # Build ref FQNs list for contextual enrichment
+    ref_fqns: list[str] = []
     if refs is None:
         try:
             link_store = LinkStore(conn)
@@ -104,10 +109,38 @@ def embed_conversation_full(
                 ref = ref_store.get_by_id(ref_id)
                 if ref:
                     refs.append({"ref_type": ref.ref_type.value, "url": ref.url})
+                    if ref.fqn:
+                        ref_fqns.append(ref.fqn)
         except Exception:
             refs = []
+    else:
+        # Extract FQNs from provided refs if available
+        for ref in refs:
+            fqn = ref.get("fqn")
+            if fqn:
+                ref_fqns.append(fqn)
+    
+    # Get conversation metadata for contextual enrichment
+    metadata = None
+    try:
+        conv_store = ConversationStore(conn)
+        conv = conv_store.get(conv_id)
+        if conv:
+            # Use analysis goal as summary if summary not set
+            summary = conv.summary
+            if not summary and analysis:
+                summary = analysis.get("goal")
+            
+            metadata = ConversationMetadata(
+                conversation_id=conv_id,
+                created_at=conv.created_at,
+                summary=summary,
+                ref_fqns=ref_fqns,
+            )
+    except Exception:
+        log.debug("Could not load conversation metadata for %s", conv_id)
 
-    texts = build_conversation_texts(events, analysis, refs)
+    texts = build_conversation_texts(events, analysis, refs, metadata)
 
     if model is None:
         model = get_embedding_model()

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -1,8 +1,11 @@
 """High-level embedding operations for conversations."""
 
 import logging
-from dataclasses import dataclass
+import queue
+import threading
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Callable
 
 log = logging.getLogger("ohtv")
 
@@ -17,6 +20,28 @@ class EmbeddingStats:
     content_chunks: int = 0
     total_tokens: int = 0
     embeddings_created: int = 0
+
+
+@dataclass
+class PendingEmbedding:
+    """An embedding ready to be written to the database."""
+    conversation_id: str
+    embedding: list[float]
+    model: str
+    embed_type: str
+    chunk_index: int
+    token_count: int
+    source_text: str
+
+
+@dataclass
+class EmbeddingBatch:
+    """A batch of embeddings from one conversation."""
+    conversation_id: str
+    embeddings: list[PendingEmbedding] = field(default_factory=list)
+    fts_text: str | None = None  # For FTS indexing
+    stats: EmbeddingStats | None = None
+    error: str | None = None
 
 
 def embed_conversation(
@@ -298,3 +323,316 @@ def check_embedding_types(
         "summary": store.has_embedding(conversation_id, "summary"),
         "content": store.has_embedding(conversation_id, "content"),
     }
+
+
+def generate_embeddings_only(
+    conv_dir: Path,
+    conn,
+    model: str | None = None,
+    analysis: dict | None = None,
+    refs: list[dict] | None = None,
+    skip_existing: bool = True,
+) -> EmbeddingBatch:
+    """Generate embeddings for a conversation WITHOUT writing to DB.
+    
+    This is designed for parallel processing - multiple threads can call
+    this function to generate embeddings, then a single writer thread
+    collects the results and writes them to the database.
+    
+    Args:
+        conv_dir: Path to conversation directory
+        conn: Database connection (only used to check existing embeddings)
+        model: Model name (uses EMBEDDING_MODEL env var if None)
+        analysis: Cached analysis dict (if not provided, tries to load from cache)
+        refs: Git refs (if not provided, tries to load from database)
+        skip_existing: Skip embedding types that already exist
+    
+    Returns:
+        EmbeddingBatch containing all generated embeddings ready for DB write
+    """
+    from ohtv.analysis.cache import load_events, load_analysis
+    from ohtv.db.stores import EmbeddingStore, LinkStore, ReferenceStore, ConversationStore
+    from .client import get_embedding, get_embedding_model
+    from .text_builders import build_conversation_texts, build_summary_text, ConversationMetadata
+
+    conv_id = conv_dir.name
+    batch = EmbeddingBatch(conversation_id=conv_id)
+    stats = EmbeddingStats(conversation_id=conv_id)
+    
+    try:
+        store = EmbeddingStore(conn)
+        
+        events = load_events(conv_dir)
+        if not events:
+            log.debug("No events in conversation %s", conv_id)
+            batch.stats = stats
+            return batch
+
+        if analysis is None:
+            analysis = load_analysis(conv_dir)
+        
+        # Build ref FQNs list for contextual enrichment
+        ref_fqns: list[str] = []
+        if refs is None:
+            try:
+                link_store = LinkStore(conn)
+                ref_store = ReferenceStore(conn)
+                ref_links = link_store.get_refs_for_conversation(conv_id)
+                refs = []
+                for ref_id, _link_type in ref_links:
+                    ref = ref_store.get_by_id(ref_id)
+                    if ref:
+                        refs.append({"ref_type": ref.ref_type.value, "url": ref.url})
+                        if ref.fqn:
+                            ref_fqns.append(ref.fqn)
+            except Exception:
+                refs = []
+        else:
+            for ref in refs:
+                fqn = ref.get("fqn")
+                if fqn:
+                    ref_fqns.append(fqn)
+        
+        # Get conversation metadata for contextual enrichment
+        metadata = None
+        try:
+            conv_store = ConversationStore(conn)
+            conv = conv_store.get(conv_id)
+            if conv:
+                summary = conv.summary
+                if not summary and analysis:
+                    summary = analysis.get("goal")
+                
+                metadata = ConversationMetadata(
+                    conversation_id=conv_id,
+                    created_at=conv.created_at,
+                    summary=summary,
+                    ref_fqns=ref_fqns,
+                )
+        except Exception:
+            log.debug("Could not load conversation metadata for %s", conv_id)
+
+        texts = build_conversation_texts(events, analysis, refs, metadata)
+
+        if model is None:
+            model = get_embedding_model()
+
+        # Generate analysis embedding
+        if texts.analysis_text:
+            if not skip_existing or not store.has_embedding(conv_id, "analysis"):
+                result = get_embedding(texts.analysis_text, model=model)
+                batch.embeddings.append(PendingEmbedding(
+                    conversation_id=conv_id,
+                    embedding=result.embedding,
+                    model=result.model,
+                    embed_type="analysis",
+                    chunk_index=0,
+                    token_count=result.token_count,
+                    source_text=texts.analysis_text,
+                ))
+                stats.analysis_tokens = result.token_count
+                stats.embeddings_created += 1
+
+        # Generate summary embeddings
+        if texts.summary_text:
+            from .chunking import chunk_text
+            summary_chunks = chunk_text(texts.summary_text)
+            
+            for chunk in summary_chunks:
+                if skip_existing and store.has_embedding(conv_id, "summary", chunk.chunk_index):
+                    continue
+                result = get_embedding(chunk.text, model=model)
+                batch.embeddings.append(PendingEmbedding(
+                    conversation_id=conv_id,
+                    embedding=result.embedding,
+                    model=result.model,
+                    embed_type="summary",
+                    chunk_index=chunk.chunk_index,
+                    token_count=result.token_count,
+                    source_text=chunk.text,
+                ))
+                stats.summary_tokens += result.token_count
+                stats.embeddings_created += 1
+
+        # Generate content embeddings
+        if texts.content_chunks:
+            for chunk in texts.content_chunks:
+                if skip_existing and store.has_embedding(conv_id, "content", chunk.chunk_index):
+                    continue
+                result = get_embedding(chunk.text, model=model)
+                batch.embeddings.append(PendingEmbedding(
+                    conversation_id=conv_id,
+                    embedding=result.embedding,
+                    model=result.model,
+                    embed_type="content",
+                    chunk_index=chunk.chunk_index,
+                    token_count=result.token_count,
+                    source_text=chunk.text,
+                ))
+                stats.content_tokens += result.token_count
+                stats.content_chunks += 1
+                stats.embeddings_created += 1
+
+        stats.total_tokens = stats.analysis_tokens + stats.summary_tokens + stats.content_tokens
+        batch.stats = stats
+        
+        # Generate FTS text for keyword search
+        if stats.embeddings_created > 0:
+            batch.fts_text = build_summary_text(events)
+            
+    except Exception as e:
+        batch.error = str(e)
+        log.debug("Error generating embeddings for %s: %s", conv_id, e)
+    
+    return batch
+
+
+class EmbeddingWriter:
+    """Thread-safe writer for batching embedding database writes.
+    
+    This class collects embeddings from multiple worker threads and writes
+    them to the database in batches, avoiding SQLite locking issues.
+    
+    Usage:
+        writer = EmbeddingWriter(conn, batch_size=50)
+        writer.start()
+        
+        # Worker threads submit batches
+        writer.submit(batch1)
+        writer.submit(batch2)
+        
+        # When done, stop and wait for all writes
+        writer.stop()
+        stats = writer.get_stats()
+    """
+    
+    def __init__(self, conn, batch_size: int = 50, on_batch_complete: Callable[[int], None] | None = None):
+        """Initialize the writer.
+        
+        Args:
+            conn: Database connection (must be created in the writer thread)
+            batch_size: Number of conversations to batch before writing
+            on_batch_complete: Callback called after each batch write with count
+        """
+        self._conn = conn
+        self._batch_size = batch_size
+        self._on_batch_complete = on_batch_complete
+        self._queue: queue.Queue[EmbeddingBatch | None] = queue.Queue()
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        
+        # Stats
+        self._lock = threading.Lock()
+        self._written = 0
+        self._errors = 0
+        self._total_embeddings = 0
+    
+    def start(self) -> None:
+        """Start the writer thread."""
+        self._thread = threading.Thread(target=self._writer_loop, daemon=True)
+        self._thread.start()
+    
+    def submit(self, batch: EmbeddingBatch) -> None:
+        """Submit a batch for writing."""
+        self._queue.put(batch)
+    
+    def stop(self, timeout: float = 30.0) -> None:
+        """Stop the writer and wait for pending writes.
+        
+        Args:
+            timeout: Maximum seconds to wait for pending writes
+        """
+        self._stop_event.set()
+        self._queue.put(None)  # Sentinel to wake up the thread
+        if self._thread:
+            self._thread.join(timeout=timeout)
+    
+    def get_stats(self) -> dict:
+        """Get write statistics."""
+        with self._lock:
+            return {
+                "written": self._written,
+                "errors": self._errors,
+                "total_embeddings": self._total_embeddings,
+            }
+    
+    def _writer_loop(self) -> None:
+        """Main writer loop - collects batches and writes to DB."""
+        from ohtv.db.stores import EmbeddingStore
+        
+        store = EmbeddingStore(self._conn)
+        pending: list[EmbeddingBatch] = []
+        
+        while True:
+            try:
+                # Wait for batches with timeout to allow periodic flushing
+                try:
+                    batch = self._queue.get(timeout=0.5)
+                except queue.Empty:
+                    batch = None
+                
+                if batch is None:
+                    if self._stop_event.is_set():
+                        # Flush remaining and exit
+                        if pending:
+                            self._write_batches(store, pending)
+                        break
+                    continue
+                
+                if batch.error:
+                    with self._lock:
+                        self._errors += 1
+                    continue
+                
+                pending.append(batch)
+                
+                # Write when we have enough batches
+                if len(pending) >= self._batch_size:
+                    self._write_batches(store, pending)
+                    pending = []
+                    
+            except Exception as e:
+                log.error("Error in embedding writer: %s", e)
+    
+    def _write_batches(self, store, batches: list[EmbeddingBatch]) -> None:
+        """Write a list of batches to the database."""
+        try:
+            count = 0
+            embed_count = 0
+            
+            for batch in batches:
+                if not batch.embeddings and not batch.fts_text:
+                    continue
+                    
+                for emb in batch.embeddings:
+                    store.upsert(
+                        conversation_id=emb.conversation_id,
+                        embedding=emb.embedding,
+                        model=emb.model,
+                        embed_type=emb.embed_type,
+                        chunk_index=emb.chunk_index,
+                        token_count=emb.token_count,
+                        source_text=emb.source_text,
+                    )
+                    embed_count += 1
+                
+                if batch.fts_text:
+                    store.upsert_fts(batch.conversation_id, batch.fts_text)
+                
+                count += 1
+            
+            self._conn.commit()
+            
+            with self._lock:
+                self._written += count
+                self._total_embeddings += embed_count
+            
+            if self._on_batch_complete:
+                self._on_batch_complete(count)
+                
+            log.debug("Wrote %d batches (%d embeddings)", count, embed_count)
+            
+        except Exception as e:
+            log.error("Error writing embedding batches: %s", e)
+            with self._lock:
+                self._errors += len(batches)

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -487,8 +487,11 @@ class EmbeddingWriter:
     This class collects embeddings from multiple worker threads and writes
     them to the database in batches, avoiding SQLite locking issues.
     
+    The writer creates its own database connection in its thread, since
+    SQLite connections cannot be shared across threads.
+    
     Usage:
-        writer = EmbeddingWriter(conn, batch_size=50)
+        writer = EmbeddingWriter(batch_size=50)
         writer.start()
         
         # Worker threads submit batches
@@ -500,15 +503,13 @@ class EmbeddingWriter:
         stats = writer.get_stats()
     """
     
-    def __init__(self, conn, batch_size: int = 50, on_batch_complete: Callable[[int], None] | None = None):
+    def __init__(self, batch_size: int = 50, on_batch_complete: Callable[[int], None] | None = None):
         """Initialize the writer.
         
         Args:
-            conn: Database connection (must be created in the writer thread)
             batch_size: Number of conversations to batch before writing
             on_batch_complete: Callback called after each batch write with count
         """
-        self._conn = conn
         self._batch_size = batch_size
         self._on_batch_complete = on_batch_complete
         self._queue: queue.Queue[EmbeddingBatch | None] = queue.Queue()
@@ -553,42 +554,45 @@ class EmbeddingWriter:
     def _writer_loop(self) -> None:
         """Main writer loop - collects batches and writes to DB."""
         from ohtv.db.stores import EmbeddingStore
+        from ohtv.db.connection import get_connection
         
-        store = EmbeddingStore(self._conn)
-        pending: list[EmbeddingBatch] = []
-        
-        while True:
-            try:
-                # Wait for batches with timeout to allow periodic flushing
+        # Create connection in this thread - SQLite connections can't cross threads
+        with get_connection() as conn:
+            store = EmbeddingStore(conn)
+            pending: list[EmbeddingBatch] = []
+            
+            while True:
                 try:
-                    batch = self._queue.get(timeout=0.5)
-                except queue.Empty:
-                    batch = None
-                
-                if batch is None:
-                    if self._stop_event.is_set():
-                        # Flush remaining and exit
-                        if pending:
-                            self._write_batches(store, pending)
-                        break
-                    continue
-                
-                if batch.error:
-                    with self._lock:
-                        self._errors += 1
-                    continue
-                
-                pending.append(batch)
-                
-                # Write when we have enough batches
-                if len(pending) >= self._batch_size:
-                    self._write_batches(store, pending)
-                    pending = []
+                    # Wait for batches with timeout to allow periodic flushing
+                    try:
+                        batch = self._queue.get(timeout=0.5)
+                    except queue.Empty:
+                        batch = None
                     
-            except Exception as e:
-                log.error("Error in embedding writer: %s", e)
+                    if batch is None:
+                        if self._stop_event.is_set():
+                            # Flush remaining and exit
+                            if pending:
+                                self._write_batches(store, conn, pending)
+                            break
+                        continue
+                    
+                    if batch.error:
+                        with self._lock:
+                            self._errors += 1
+                        continue
+                    
+                    pending.append(batch)
+                    
+                    # Write when we have enough batches
+                    if len(pending) >= self._batch_size:
+                        self._write_batches(store, conn, pending)
+                        pending = []
+                        
+                except Exception as e:
+                    log.error("Error in embedding writer: %s", e)
     
-    def _write_batches(self, store, batches: list[EmbeddingBatch]) -> None:
+    def _write_batches(self, store, conn, batches: list[EmbeddingBatch]) -> None:
         """Write a list of batches to the database."""
         try:
             count = 0
@@ -615,7 +619,7 @@ class EmbeddingWriter:
                 
                 count += 1
             
-            self._conn.commit()
+            conn.commit()
             
             with self._lock:
                 self._written += count

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -170,43 +170,41 @@ def embed_conversation_full(
     if model is None:
         model = get_embedding_model()
 
-    if texts.analysis_text:
-        if not skip_existing or not store.has_embedding(conv_id, "analysis"):
-            result = get_embedding(texts.analysis_text, model=model)
-            store.upsert(
-                conversation_id=conv_id,
-                embedding=result.embedding,
-                model=result.model,
-                embed_type="analysis",
-                chunk_index=0,
-                token_count=result.token_count,
-                source_text=texts.analysis_text,
-            )
-            stats.analysis_tokens = result.token_count
-            stats.embeddings_created += 1
+    # Process analysis chunks
+    for chunk in texts.analysis_chunks:
+        if skip_existing and store.has_embedding(conv_id, "analysis", chunk.chunk_index):
+            continue
+        result = get_embedding(chunk.text, model=model)
+        store.upsert(
+            conversation_id=conv_id,
+            embedding=result.embedding,
+            model=result.model,
+            embed_type="analysis",
+            chunk_index=chunk.chunk_index,
+            token_count=result.token_count,
+            source_text=chunk.text,
+        )
+        stats.analysis_tokens += result.token_count
+        stats.embeddings_created += 1
 
-    if texts.summary_text:
-        # Chunk summary text if it's too long for the model
-        from .chunking import chunk_text
-        summary_chunks = chunk_text(texts.summary_text)
-        
-        for chunk in summary_chunks:
-            # Check per-chunk existence to handle interrupted runs correctly
-            if skip_existing and store.has_embedding(conv_id, "summary", chunk.chunk_index):
-                continue
-            result = get_embedding(chunk.text, model=model)
-            store.upsert(
-                conversation_id=conv_id,
-                embedding=result.embedding,
-                model=result.model,
-                embed_type="summary",
-                chunk_index=chunk.chunk_index,
-                token_count=result.token_count,
-                source_text=chunk.text,
-            )
-            stats.summary_tokens += result.token_count
-            stats.embeddings_created += 1
+    # Process summary chunks
+    for chunk in texts.summary_chunks:
+        if skip_existing and store.has_embedding(conv_id, "summary", chunk.chunk_index):
+            continue
+        result = get_embedding(chunk.text, model=model)
+        store.upsert(
+            conversation_id=conv_id,
+            embedding=result.embedding,
+            model=result.model,
+            embed_type="summary",
+            chunk_index=chunk.chunk_index,
+            token_count=result.token_count,
+            source_text=chunk.text,
+        )
+        stats.summary_tokens += result.token_count
+        stats.embeddings_created += 1
 
+    # Process content chunks
     if texts.content_chunks:
         for chunk in texts.content_chunks:
             # Check per-chunk existence to handle interrupted runs correctly
@@ -260,18 +258,18 @@ def estimate_conversation_tokens(
     texts = build_conversation_texts(events, analysis, refs)
 
     # Check if there's any embeddable content
-    if not texts.analysis_text and not texts.summary_text and not texts.content_chunks:
+    if not texts.analysis_chunks and not texts.summary_chunks and not texts.content_chunks:
         return 0, 0
 
     total_tokens = 0
     total_embeddings = 0
 
-    if texts.analysis_text:
-        total_tokens += estimate_tokens(texts.analysis_text)
+    for chunk in texts.analysis_chunks:
+        total_tokens += chunk.estimated_tokens
         total_embeddings += 1
 
-    if texts.summary_text:
-        total_tokens += estimate_tokens(texts.summary_text)
+    for chunk in texts.summary_chunks:
+        total_tokens += chunk.estimated_tokens
         total_embeddings += 1
 
     for chunk in texts.content_chunks:
@@ -417,61 +415,57 @@ def generate_embeddings_only(
         if model is None:
             model = get_embedding_model()
 
-        # Generate analysis embedding
-        if texts.analysis_text:
-            if not skip_existing or not store.has_embedding(conv_id, "analysis"):
-                result = get_embedding(texts.analysis_text, model=model)
-                batch.embeddings.append(PendingEmbedding(
-                    conversation_id=conv_id,
-                    embedding=result.embedding,
-                    model=result.model,
-                    embed_type="analysis",
-                    chunk_index=0,
-                    token_count=result.token_count,
-                    source_text=texts.analysis_text,
-                ))
-                stats.analysis_tokens = result.token_count
-                stats.embeddings_created += 1
+        # Generate analysis embeddings
+        for chunk in texts.analysis_chunks:
+            if skip_existing and store.has_embedding(conv_id, "analysis", chunk.chunk_index):
+                continue
+            result = get_embedding(chunk.text, model=model)
+            batch.embeddings.append(PendingEmbedding(
+                conversation_id=conv_id,
+                embedding=result.embedding,
+                model=result.model,
+                embed_type="analysis",
+                chunk_index=chunk.chunk_index,
+                token_count=result.token_count,
+                source_text=chunk.text,
+            ))
+            stats.analysis_tokens += result.token_count
+            stats.embeddings_created += 1
 
         # Generate summary embeddings
-        if texts.summary_text:
-            from .chunking import chunk_text
-            summary_chunks = chunk_text(texts.summary_text)
-            
-            for chunk in summary_chunks:
-                if skip_existing and store.has_embedding(conv_id, "summary", chunk.chunk_index):
-                    continue
-                result = get_embedding(chunk.text, model=model)
-                batch.embeddings.append(PendingEmbedding(
-                    conversation_id=conv_id,
-                    embedding=result.embedding,
-                    model=result.model,
-                    embed_type="summary",
-                    chunk_index=chunk.chunk_index,
-                    token_count=result.token_count,
-                    source_text=chunk.text,
-                ))
-                stats.summary_tokens += result.token_count
-                stats.embeddings_created += 1
+        for chunk in texts.summary_chunks:
+            if skip_existing and store.has_embedding(conv_id, "summary", chunk.chunk_index):
+                continue
+            result = get_embedding(chunk.text, model=model)
+            batch.embeddings.append(PendingEmbedding(
+                conversation_id=conv_id,
+                embedding=result.embedding,
+                model=result.model,
+                embed_type="summary",
+                chunk_index=chunk.chunk_index,
+                token_count=result.token_count,
+                source_text=chunk.text,
+            ))
+            stats.summary_tokens += result.token_count
+            stats.embeddings_created += 1
 
         # Generate content embeddings
-        if texts.content_chunks:
-            for chunk in texts.content_chunks:
-                if skip_existing and store.has_embedding(conv_id, "content", chunk.chunk_index):
-                    continue
-                result = get_embedding(chunk.text, model=model)
-                batch.embeddings.append(PendingEmbedding(
-                    conversation_id=conv_id,
-                    embedding=result.embedding,
-                    model=result.model,
-                    embed_type="content",
-                    chunk_index=chunk.chunk_index,
-                    token_count=result.token_count,
-                    source_text=chunk.text,
-                ))
-                stats.content_tokens += result.token_count
-                stats.content_chunks += 1
-                stats.embeddings_created += 1
+        for chunk in texts.content_chunks:
+            if skip_existing and store.has_embedding(conv_id, "content", chunk.chunk_index):
+                continue
+            result = get_embedding(chunk.text, model=model)
+            batch.embeddings.append(PendingEmbedding(
+                conversation_id=conv_id,
+                embedding=result.embedding,
+                model=result.model,
+                embed_type="content",
+                chunk_index=chunk.chunk_index,
+                token_count=result.token_count,
+                source_text=chunk.text,
+            ))
+            stats.content_tokens += result.token_count
+            stats.content_chunks += 1
+            stats.embeddings_created += 1
 
         stats.total_tokens = stats.analysis_tokens + stats.summary_tokens + stats.content_tokens
         batch.stats = stats

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -476,7 +476,7 @@ def generate_embeddings_only(
             
     except Exception as e:
         batch.error = str(e)
-        log.debug("Error generating embeddings for %s: %s", conv_id, e)
+        log.warning("Error generating embeddings for %s: %s", conv_id, e)
     
     return batch
 

--- a/src/ohtv/analysis/embeddings/text_builders.py
+++ b/src/ohtv/analysis/embeddings/text_builders.py
@@ -7,6 +7,11 @@ Supports contextual chunk enrichment (Anthropic's "contextual retrieval" techniq
 from dataclasses import dataclass, field
 from datetime import datetime
 
+# Minimum characters required for content after subtracting preamble.
+# If preamble is so long that less than this remains for content,
+# we truncate the preamble to ensure meaningful content is embedded.
+MIN_CONTENT_SPACE = 100
+
 
 @dataclass
 class ConversationMetadata:
@@ -72,7 +77,7 @@ class ConversationMetadata:
         # Calculate available space for content
         available_for_content = max_chars - len(preamble)
         
-        if available_for_content < 100:
+        if available_for_content < MIN_CONTENT_SPACE:
             # Preamble is too long - shouldn't happen, but handle it
             available_for_content = 500
             preamble = preamble[:max_chars - 500]

--- a/src/ohtv/analysis/embeddings/text_builders.py
+++ b/src/ohtv/analysis/embeddings/text_builders.py
@@ -46,6 +46,50 @@ class ConversationMetadata:
         if parts:
             return "\n".join(parts) + "\n---\n"
         return ""
+    
+    def prepend_to_text(self, content: str, max_chars: int = 3000, max_refs: int = 7) -> str:
+        """Prepend preamble to content, truncating content to fit max_chars.
+        
+        This ensures the combined text (preamble + content) doesn't exceed
+        the model's context window, while preserving the full preamble.
+        
+        Args:
+            content: The main content text
+            max_chars: Maximum total characters (default: 3000 for Ollama safety)
+            max_refs: Maximum number of refs in preamble
+            
+        Returns:
+            Combined preamble + content, truncated to fit max_chars
+        """
+        preamble = self.build_preamble(max_refs=max_refs)
+        
+        if not preamble:
+            # No preamble - just truncate content if needed
+            if len(content) > max_chars:
+                truncate_at = content.rfind(' ', 0, max_chars)
+                if truncate_at > max_chars * 0.8:
+                    return content[:truncate_at]
+                return content[:max_chars]
+            return content
+        
+        # Calculate available space for content
+        available_for_content = max_chars - len(preamble)
+        
+        if available_for_content < 100:
+            # Preamble is too long - shouldn't happen, but handle it
+            # Truncate preamble and give content at least 500 chars
+            available_for_content = 500
+            preamble = preamble[:max_chars - 500]
+        
+        # Truncate content to fit
+        if len(content) > available_for_content:
+            truncate_at = content.rfind(' ', 0, available_for_content)
+            if truncate_at > available_for_content * 0.8:
+                content = content[:truncate_at]
+            else:
+                content = content[:available_for_content]
+        
+        return preamble + content
 
 
 @dataclass
@@ -329,15 +373,14 @@ def build_conversation_texts(
     content_chunks = chunk_text(content_text)
     
     # Apply contextual preamble enrichment if metadata provided
-    preamble = metadata.build_preamble() if metadata else ""
-    
-    if preamble:
+    # Uses smart truncation to ensure total size fits model context
+    if metadata:
         if analysis_text:
-            analysis_text = preamble + analysis_text
+            analysis_text = metadata.prepend_to_text(analysis_text)
         if summary_text:
-            summary_text = preamble + summary_text
+            summary_text = metadata.prepend_to_text(summary_text)
         for chunk in content_chunks:
-            chunk.text = preamble + chunk.text
+            chunk.text = metadata.prepend_to_text(chunk.text)
 
     return ConversationTexts(
         analysis_text=analysis_text.strip() if analysis_text and analysis_text.strip() else None,

--- a/src/ohtv/analysis/embeddings/text_builders.py
+++ b/src/ohtv/analysis/embeddings/text_builders.py
@@ -127,9 +127,13 @@ class ConversationMetadata:
 
 @dataclass
 class ConversationTexts:
-    """All text components for a conversation's embeddings."""
-    analysis_text: str | None = None
-    summary_text: str | None = None
+    """All text components for a conversation's embeddings.
+    
+    All fields are lists of TextChunk to support splitting long content
+    into multiple overlapping chunks while preserving all data.
+    """
+    analysis_chunks: list["TextChunk"] = field(default_factory=list)
+    summary_chunks: list["TextChunk"] = field(default_factory=list)
     content_chunks: list["TextChunk"] = field(default_factory=list)
 
 
@@ -403,37 +407,70 @@ def build_conversation_texts(
     analysis_text = build_analysis_text(analysis) if analysis else None
     summary_text = build_summary_text(events, refs)
     content_text = build_content_text(events)
-    content_chunks = chunk_text(content_text)
+    initial_content_chunks = chunk_text(content_text)
     
-    # Apply contextual preamble enrichment if metadata provided
-    # Uses smart splitting to ensure content fits model context without data loss
-    if metadata:
-        # Analysis text - take first piece (analysis is usually concise)
-        if analysis_text:
-            pieces = metadata.prepend_to_text(analysis_text)
-            analysis_text = pieces[0] if pieces else None
+    def _text_to_chunks(text: str | None, metadata: ConversationMetadata | None) -> list[TextChunk]:
+        """Convert text to chunks, applying preamble and splitting if needed."""
+        if not text or not text.strip():
+            return []
         
-        # Summary text - take first piece (summary should fit)
-        if summary_text:
-            pieces = metadata.prepend_to_text(summary_text)
-            summary_text = pieces[0] if pieces else None
+        if metadata:
+            pieces = metadata.prepend_to_text(text)
+        else:
+            # No metadata - still need to respect max size for Ollama
+            max_chars = 3000
+            if len(text) <= max_chars:
+                pieces = [text]
+            else:
+                # Simple split without preamble
+                pieces = []
+                start = 0
+                overlap = 200
+                while start < len(text):
+                    end = min(start + max_chars, len(text))
+                    if end < len(text):
+                        break_at = text.rfind(' ', start, end)
+                        if break_at > start + max_chars * 0.7:
+                            end = break_at
+                    pieces.append(text[start:end])
+                    if end >= len(text):
+                        break
+                    start = end - overlap
         
-        # Content chunks - may expand into more chunks
-        new_content_chunks = []
-        chunk_index = 0
-        for chunk in content_chunks:
-            pieces = metadata.prepend_to_text(chunk.text)
-            for piece in pieces:
-                new_content_chunks.append(TextChunk(
-                    text=piece,
+        return [
+            TextChunk(
+                text=piece.strip(),
+                chunk_index=i,
+                estimated_tokens=int(len(piece.split()) * 1.3),
+            )
+            for i, piece in enumerate(pieces)
+            if piece.strip()
+        ]
+    
+    # Build chunks for all text types
+    analysis_chunks = _text_to_chunks(analysis_text, metadata)
+    summary_chunks = _text_to_chunks(summary_text, metadata)
+    
+    # Content chunks - process each initial chunk through preamble/splitting
+    content_chunks = []
+    chunk_index = 0
+    for initial_chunk in initial_content_chunks:
+        if metadata:
+            pieces = metadata.prepend_to_text(initial_chunk.text)
+        else:
+            pieces = [initial_chunk.text]
+        
+        for piece in pieces:
+            if piece.strip():
+                content_chunks.append(TextChunk(
+                    text=piece.strip(),
                     chunk_index=chunk_index,
                     estimated_tokens=int(len(piece.split()) * 1.3),
                 ))
                 chunk_index += 1
-        content_chunks = new_content_chunks
 
     return ConversationTexts(
-        analysis_text=analysis_text.strip() if analysis_text and analysis_text.strip() else None,
-        summary_text=summary_text.strip() if summary_text and summary_text.strip() else None,
+        analysis_chunks=analysis_chunks,
+        summary_chunks=summary_chunks,
         content_chunks=content_chunks,
     )

--- a/src/ohtv/analysis/embeddings/text_builders.py
+++ b/src/ohtv/analysis/embeddings/text_builders.py
@@ -47,11 +47,11 @@ class ConversationMetadata:
             return "\n".join(parts) + "\n---\n"
         return ""
     
-    def prepend_to_text(self, content: str, max_chars: int = 3000, max_refs: int = 7) -> str:
-        """Prepend preamble to content, truncating content to fit max_chars.
+    def prepend_to_text(self, content: str, max_chars: int = 3000, max_refs: int = 7) -> list[str]:
+        """Prepend preamble to content, splitting into multiple chunks if needed.
         
-        This ensures the combined text (preamble + content) doesn't exceed
-        the model's context window, while preserving the full preamble.
+        This ensures no data is lost - if content is too long to fit with the
+        preamble, it's split into overlapping chunks, each with the preamble.
         
         Args:
             content: The main content text
@@ -59,37 +59,70 @@ class ConversationMetadata:
             max_refs: Maximum number of refs in preamble
             
         Returns:
-            Combined preamble + content, truncated to fit max_chars
+            List of strings, each with preamble + content portion, fitting max_chars
         """
         preamble = self.build_preamble(max_refs=max_refs)
         
         if not preamble:
-            # No preamble - just truncate content if needed
-            if len(content) > max_chars:
-                truncate_at = content.rfind(' ', 0, max_chars)
-                if truncate_at > max_chars * 0.8:
-                    return content[:truncate_at]
-                return content[:max_chars]
-            return content
+            # No preamble - just split content if needed
+            if len(content) <= max_chars:
+                return [content]
+            return self._split_content(content, max_chars)
         
         # Calculate available space for content
         available_for_content = max_chars - len(preamble)
         
         if available_for_content < 100:
             # Preamble is too long - shouldn't happen, but handle it
-            # Truncate preamble and give content at least 500 chars
             available_for_content = 500
             preamble = preamble[:max_chars - 500]
         
-        # Truncate content to fit
-        if len(content) > available_for_content:
-            truncate_at = content.rfind(' ', 0, available_for_content)
-            if truncate_at > available_for_content * 0.8:
-                content = content[:truncate_at]
-            else:
-                content = content[:available_for_content]
+        # If content fits, return single chunk
+        if len(content) <= available_for_content:
+            return [preamble + content]
         
-        return preamble + content
+        # Split content into pieces that fit, with overlap
+        content_pieces = self._split_content(content, available_for_content)
+        return [preamble + piece for piece in content_pieces]
+    
+    def _split_content(self, content: str, max_chars: int, overlap: int = 200) -> list[str]:
+        """Split content into overlapping pieces that fit max_chars.
+        
+        Args:
+            content: Text to split
+            max_chars: Maximum chars per piece
+            overlap: Character overlap between pieces
+            
+        Returns:
+            List of content pieces
+        """
+        if len(content) <= max_chars:
+            return [content]
+        
+        pieces = []
+        start = 0
+        
+        while start < len(content):
+            end = start + max_chars
+            
+            if end >= len(content):
+                # Last piece
+                pieces.append(content[start:])
+                break
+            
+            # Try to break at word boundary
+            break_at = content.rfind(' ', start, end)
+            if break_at > start + max_chars * 0.7:
+                end = break_at
+            
+            pieces.append(content[start:end])
+            
+            # Next piece starts with overlap
+            start = end - overlap
+            if start < 0:
+                start = 0
+        
+        return pieces
 
 
 @dataclass
@@ -373,14 +406,31 @@ def build_conversation_texts(
     content_chunks = chunk_text(content_text)
     
     # Apply contextual preamble enrichment if metadata provided
-    # Uses smart truncation to ensure total size fits model context
+    # Uses smart splitting to ensure content fits model context without data loss
     if metadata:
+        # Analysis text - take first piece (analysis is usually concise)
         if analysis_text:
-            analysis_text = metadata.prepend_to_text(analysis_text)
+            pieces = metadata.prepend_to_text(analysis_text)
+            analysis_text = pieces[0] if pieces else None
+        
+        # Summary text - take first piece (summary should fit)
         if summary_text:
-            summary_text = metadata.prepend_to_text(summary_text)
+            pieces = metadata.prepend_to_text(summary_text)
+            summary_text = pieces[0] if pieces else None
+        
+        # Content chunks - may expand into more chunks
+        new_content_chunks = []
+        chunk_index = 0
         for chunk in content_chunks:
-            chunk.text = metadata.prepend_to_text(chunk.text)
+            pieces = metadata.prepend_to_text(chunk.text)
+            for piece in pieces:
+                new_content_chunks.append(TextChunk(
+                    text=piece,
+                    chunk_index=chunk_index,
+                    estimated_tokens=int(len(piece.split()) * 1.3),
+                ))
+                chunk_index += 1
+        content_chunks = new_content_chunks
 
     return ConversationTexts(
         analysis_text=analysis_text.strip() if analysis_text and analysis_text.strip() else None,

--- a/src/ohtv/analysis/embeddings/text_builders.py
+++ b/src/ohtv/analysis/embeddings/text_builders.py
@@ -1,9 +1,51 @@
 """Text building functions for each embedding type.
 
 Converts conversation data into text suitable for embedding.
+Supports contextual chunk enrichment (Anthropic's "contextual retrieval" technique).
 """
 
 from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class ConversationMetadata:
+    """Metadata for contextual chunk enrichment.
+    
+    Used to prepend context to chunks before embedding, improving
+    retrieval accuracy (Anthropic's "contextual retrieval" technique).
+    """
+    conversation_id: str
+    created_at: datetime | None = None
+    summary: str | None = None
+    ref_fqns: list[str] = field(default_factory=list)  # e.g., ["jpshackelford/ohtv#23"]
+    
+    def build_preamble(self, max_refs: int = 7) -> str:
+        """Build a contextual preamble for chunk enrichment.
+        
+        Args:
+            max_refs: Maximum number of refs to include (default: 7)
+            
+        Returns:
+            Formatted preamble string with date, summary, and refs
+        """
+        parts = []
+        
+        if self.created_at:
+            parts.append(f"Date: {self.created_at.strftime('%Y-%m-%d')}")
+        
+        if self.summary:
+            # Truncate summary if too long
+            summary = self.summary[:200] + "..." if len(self.summary) > 200 else self.summary
+            parts.append(f"Summary: {summary}")
+        
+        if self.ref_fqns:
+            limited_refs = self.ref_fqns[:max_refs]
+            parts.append(f"Related: {', '.join(limited_refs)}")
+        
+        if parts:
+            return "\n".join(parts) + "\n---\n"
+        return ""
 
 
 @dataclass
@@ -266,6 +308,7 @@ def build_conversation_texts(
     events: list[dict],
     analysis: dict | None = None,
     refs: list[dict] | None = None,
+    metadata: ConversationMetadata | None = None,
 ) -> ConversationTexts:
     """Build all text components for a conversation's embeddings.
 
@@ -273,9 +316,10 @@ def build_conversation_texts(
         events: List of conversation events
         analysis: Cached analysis dict (from gen objs)
         refs: List of git refs from database
+        metadata: Optional metadata for contextual preamble enrichment
 
     Returns:
-        ConversationTexts with all components
+        ConversationTexts with all components (with preambles if metadata provided)
     """
     from .chunking import chunk_text
 
@@ -283,6 +327,17 @@ def build_conversation_texts(
     summary_text = build_summary_text(events, refs)
     content_text = build_content_text(events)
     content_chunks = chunk_text(content_text)
+    
+    # Apply contextual preamble enrichment if metadata provided
+    preamble = metadata.build_preamble() if metadata else ""
+    
+    if preamble:
+        if analysis_text:
+            analysis_text = preamble + analysis_text
+        if summary_text:
+            summary_text = preamble + summary_text
+        for chunk in content_chunks:
+            chunk.text = preamble + chunk.text
 
     return ConversationTexts(
         analysis_text=analysis_text.strip() if analysis_text and analysis_text.strip() else None,

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -415,14 +415,17 @@ class RAGAnswerer:
             )
         
         # Build context text with richer metadata for LLM
+        # Sort by score descending so most relevant sources come first
+        sorted_chunks = sorted(context_chunks, key=lambda c: c.score, reverse=True)
+        
         context_parts = []
-        for i, chunk in enumerate(context_chunks, 1):
-            # Header with title and date
+        for i, chunk in enumerate(sorted_chunks, 1):
+            # Header with title, date, and relevance score
             header = f"[Source {i}: {chunk.title}"
             if chunk.created_at:
                 age = self._format_age(chunk.created_at)
                 header += f" ({age})"
-            header += "]"
+            header += f" - relevance: {chunk.score:.0%}]"
             context_parts.append(header)
             
             # Summary (if available)

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -2,15 +2,16 @@
 
 Provides a clean API for:
 1. Retrieving relevant context from embeddings
-2. Building prompts with context
+2. Building prompts with context including refs for disambiguation
 3. Generating answers using an LLM
 4. Temporal filtering based on question intent
+5. Citation output with conversation URLs, dates, and summaries
 """
 
 import logging
 import os
-from dataclasses import dataclass
-from datetime import datetime, timezone
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
 
 import litellm
 
@@ -21,16 +22,68 @@ log = logging.getLogger("ohtv")
 
 DEFAULT_LLM_MODEL = "openai/gpt-4o-mini"
 
-DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant that answers questions about software development conversations and coding sessions. 
+# Cloud conversations have 14-day retention
+CLOUD_RETENTION_DAYS = 14
 
-You have been provided with context from relevant conversation history. Use this context to answer the user's question accurately and concisely.
+DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant that answers questions about software development conversations and coding sessions.
+
+You have been provided with context from relevant conversation history. Each source includes:
+- Title and date
+- Summary (when available)
+- Related refs (PRs, issues, repos) - use these to disambiguate references like "#42"
 
 Guidelines:
 - Base your answer on the provided context
-- If the context doesn't contain enough information, say so
-- Reference specific conversations when relevant
+- When citing information, reference the specific conversation by title (e.g., "In the conversation 'Configure MCP secrets' from 3 days ago...")
+- Use the provided refs to accurately cite PRs/issues (e.g., "jpshackelford/ohtv#42" not just "#42")
+- If multiple conversations are relevant, mention them
+- If the context doesn't contain enough information, say so clearly
 - Be concise but thorough
 - Use markdown formatting for code snippets"""
+
+
+@dataclass
+class RefInfo:
+    """A reference (PR/issue) associated with a conversation."""
+    ref_type: str  # "pr" or "issue"
+    url: str
+    fqn: str  # e.g., "owner/repo#123"
+    display_name: str  # e.g., "repo #123"
+    link_type: str  # "read" or "write"
+
+
+@dataclass 
+class RepoInfo:
+    """A repository associated with a conversation."""
+    url: str
+    fqn: str  # e.g., "owner/repo"
+    short_name: str
+    link_type: str  # "read" or "write"
+
+
+@dataclass
+class ConversationSource:
+    """Full source information for a conversation."""
+    conversation_id: str
+    title: str
+    summary: str | None = None
+    source: str = "local"  # "local" or "cloud"
+    cloud_url: str | None = None
+    created_at: datetime | None = None
+    repos: list[RepoInfo] = field(default_factory=list)
+    prs: list[RefInfo] = field(default_factory=list)
+    issues: list[RefInfo] = field(default_factory=list)
+    
+    def is_cloud_url_valid(self) -> bool:
+        """Check if cloud URL is valid (within 14-day retention)."""
+        if self.source != "cloud" or not self.created_at:
+            return False
+        now = datetime.now(timezone.utc)
+        if self.created_at.tzinfo is None:
+            created = self.created_at.replace(tzinfo=timezone.utc)
+        else:
+            created = self.created_at
+        return (now - created).days <= CLOUD_RETENTION_DAYS
 
 
 @dataclass
@@ -41,6 +94,19 @@ class ContextChunk:
     embed_type: str
     source_text: str
     score: float
+    # New fields for citations
+    summary: str | None = None
+    cloud_url: str | None = None
+    created_at: datetime | None = None
+    conv_source: str = "local"  # "local" or "cloud"
+    source: ConversationSource | None = None
+    
+    @property
+    def display_url(self) -> str | None:
+        """Get URL to display (only if cloud and within 14-day retention)."""
+        if self.source and self.source.is_cloud_url_valid():
+            return self.cloud_url
+        return None
 
 
 @dataclass
@@ -54,6 +120,10 @@ class RAGAnswer:
     model: str
     temporal_filter_applied: bool = False
     date_range: tuple[datetime | None, datetime | None] | None = None
+    # Aggregated refs from all source conversations
+    related_repos: list[RepoInfo] | None = None
+    related_prs: list[RefInfo] | None = None
+    related_issues: list[RefInfo] | None = None
 
 
 class RAGAnswerer:
@@ -62,6 +132,11 @@ class RAGAnswerer:
     Uses embeddings to find relevant context from conversations,
     then generates an answer using an LLM. Supports automatic
     temporal filtering based on question intent.
+    
+    Enhanced with:
+    - Full source metadata (dates, summaries, cloud URLs)
+    - Related refs (PRs, issues, repos) for disambiguation
+    - Aggregated "See Also" refs from all source conversations
     """
     
     def __init__(
@@ -71,6 +146,10 @@ class RAGAnswerer:
         model: str | None = None,
         system_prompt: str | None = None,
         enable_temporal_filter: bool = True,
+        link_store=None,
+        ref_store=None,
+        repo_store=None,
+        cloud_base_url: str | None = None,
     ):
         """Initialize RAG answerer.
         
@@ -80,12 +159,22 @@ class RAGAnswerer:
             model: LLM model for generation (default: LLM_MODEL env var or gpt-4o-mini)
             system_prompt: Custom system prompt (default: built-in prompt)
             enable_temporal_filter: Enable automatic temporal filtering from questions
+            link_store: LinkStore for conversation-ref relationships (optional)
+            ref_store: ReferenceStore for ref details (optional)
+            repo_store: RepoStore for repository details (optional)
+            cloud_base_url: Base URL for cloud conversations (default: env or app.all-hands.dev)
         """
         self.embed_store = embed_store
         self.conv_store = conv_store
         self.model = model or os.environ.get("LLM_MODEL", DEFAULT_LLM_MODEL)
         self.system_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
         self.enable_temporal_filter = enable_temporal_filter
+        self.link_store = link_store
+        self.ref_store = ref_store
+        self.repo_store = repo_store
+        self.cloud_base_url = cloud_base_url or os.environ.get(
+            "OHTV_CLOUD_API_URL", "https://app.all-hands.dev"
+        )
     
     def answer_question(
         self,
@@ -159,6 +248,23 @@ class RAGAnswerer:
         
         source_ids = {c.conversation_id for c in context_chunks}
         
+        # Aggregate refs from all source conversations
+        all_repos: dict[str, RepoInfo] = {}
+        all_prs: dict[str, RefInfo] = {}
+        all_issues: dict[str, RefInfo] = {}
+        
+        for chunk in context_chunks:
+            if chunk.source:
+                for repo in chunk.source.repos:
+                    if repo.url not in all_repos:
+                        all_repos[repo.url] = repo
+                for pr in chunk.source.prs:
+                    if pr.url not in all_prs:
+                        all_prs[pr.url] = pr
+                for issue in chunk.source.issues:
+                    if issue.url not in all_issues:
+                        all_issues[issue.url] = issue
+        
         return RAGAnswer(
             answer=answer,
             context_chunks=context_chunks,
@@ -168,6 +274,9 @@ class RAGAnswerer:
             model=self.model,
             temporal_filter_applied=temporal_applied,
             date_range=(start_date, end_date) if temporal_applied else None,
+            related_repos=list(all_repos.values()) if all_repos else None,
+            related_prs=list(all_prs.values()) if all_prs else None,
+            related_issues=list(all_issues.values()) if all_issues else None,
         )
     
     def _retrieve_context(
@@ -178,7 +287,7 @@ class RAGAnswerer:
         start_date: datetime | None = None,
         end_date: datetime | None = None,
     ) -> list[ContextChunk]:
-        """Retrieve relevant context chunks for a question."""
+        """Retrieve relevant context chunks for a question with full metadata."""
         from ohtv.analysis.embeddings import get_embedding
         
         # Embed the question
@@ -194,11 +303,18 @@ class RAGAnswerer:
             end_date=end_date,
         )
         
-        # Convert to ContextChunk with conversation titles
+        # Convert to ContextChunk with full metadata
         chunks = []
         for r in results:
             conv = self.conv_store.get(r.conversation_id)
             title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
+            created_at = conv.created_at if conv else None
+            summary = conv.summary if conv else None
+            conv_source = conv.source if conv else "local"
+            
+            # Get source info with refs
+            source = self._get_conversation_source(r.conversation_id)
+            cloud_url = self._get_cloud_url(r.conversation_id)
             
             chunks.append(ContextChunk(
                 conversation_id=r.conversation_id,
@@ -206,16 +322,83 @@ class RAGAnswerer:
                 embed_type=r.embed_type,
                 source_text=r.source_text,
                 score=r.score,
+                summary=summary,
+                cloud_url=cloud_url,
+                created_at=created_at,
+                conv_source=conv_source or "local",
+                source=source,
             ))
         
         return chunks
+    
+    def _get_cloud_url(self, conversation_id: str) -> str:
+        """Generate the cloud URL for a conversation."""
+        return f"{self.cloud_base_url}/conversations/{conversation_id}"
+    
+    def _get_conversation_source(self, conversation_id: str) -> ConversationSource | None:
+        """Get full source information including refs for a conversation."""
+        if not all([self.link_store, self.ref_store, self.repo_store]):
+            return None
+        
+        try:
+            # Get conversation metadata
+            conv = self.conv_store.get(conversation_id)
+            title = conv.title if conv and conv.title else f"Conversation {conversation_id[:8]}"
+            created_at = conv.created_at if conv else None
+            summary = conv.summary if conv else None
+            conv_source = conv.source if conv else "local"
+            
+            # Get repos
+            repos = []
+            for repo_id, link_type in self.link_store.get_repos_for_conversation(conversation_id):
+                repo = self.repo_store.get_by_id(repo_id)
+                if repo:
+                    repos.append(RepoInfo(
+                        url=repo.canonical_url,
+                        fqn=repo.fqn,
+                        short_name=repo.short_name,
+                        link_type=link_type.value,
+                    ))
+            
+            # Get PRs and issues
+            prs = []
+            issues = []
+            for ref_id, link_type in self.link_store.get_refs_for_conversation(conversation_id):
+                ref = self.ref_store.get_by_id(ref_id)
+                if ref:
+                    ref_info = RefInfo(
+                        ref_type=ref.ref_type.value,
+                        url=ref.url,
+                        fqn=ref.fqn,
+                        display_name=ref.display_name,
+                        link_type=link_type.value,
+                    )
+                    if ref.ref_type.value == "pull_request":
+                        prs.append(ref_info)
+                    else:
+                        issues.append(ref_info)
+            
+            return ConversationSource(
+                conversation_id=conversation_id,
+                title=title,
+                summary=summary,
+                source=conv_source or "local",
+                cloud_url=self._get_cloud_url(conversation_id),
+                created_at=created_at,
+                repos=repos,
+                prs=prs,
+                issues=issues,
+            )
+        except Exception as e:
+            log.debug("Error getting source info for %s: %s", conversation_id, e)
+            return None
     
     def _generate_answer(
         self,
         question: str,
         context_chunks: list[ContextChunk],
     ) -> str:
-        """Generate an answer using the LLM."""
+        """Generate an answer using the LLM with rich context."""
         api_key = os.environ.get("LLM_API_KEY")
         api_base = os.environ.get("LLM_BASE_URL")
         
@@ -225,10 +408,34 @@ class RAGAnswerer:
                 "This is required for answer generation."
             )
         
-        # Build context text
+        # Build context text with richer metadata for LLM
         context_parts = []
         for i, chunk in enumerate(context_chunks, 1):
-            context_parts.append(f"[Source {i}: {chunk.title} ({chunk.embed_type})]")
+            # Header with title and date
+            header = f"[Source {i}: {chunk.title}"
+            if chunk.created_at:
+                age = self._format_age(chunk.created_at)
+                header += f" ({age})"
+            header += "]"
+            context_parts.append(header)
+            
+            # Summary (if available)
+            if chunk.summary:
+                context_parts.append(f"Summary: {chunk.summary}")
+            
+            # Related refs for disambiguation
+            if chunk.source:
+                ref_fqns = []
+                for pr in chunk.source.prs[:3]:  # Limit to avoid bloat
+                    ref_fqns.append(f"PR {pr.fqn}")
+                for issue in chunk.source.issues[:3]:
+                    ref_fqns.append(f"Issue {issue.fqn}")
+                for repo in chunk.source.repos[:2]:
+                    ref_fqns.append(f"Repo {repo.fqn}")
+                if ref_fqns:
+                    context_parts.append(f"Related: {', '.join(ref_fqns)}")
+            
+            # Content
             context_parts.append(chunk.source_text)
             context_parts.append("")
         
@@ -254,3 +461,23 @@ Please provide a helpful answer based on the context above."""
             return response.choices[0].message.content
         except Exception as e:
             raise RuntimeError(f"LLM API call failed: {e}") from e
+    
+    def _format_age(self, dt: datetime) -> str:
+        """Format datetime as relative age (e.g., '3 days ago')."""
+        now = datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = now - dt
+        
+        if delta.days == 0:
+            return "today"
+        elif delta.days == 1:
+            return "yesterday"
+        elif delta.days < 7:
+            return f"{delta.days} days ago"
+        elif delta.days < 30:
+            weeks = delta.days // 7
+            return f"{weeks} week{'s' if weeks > 1 else ''} ago"
+        else:
+            months = delta.days // 30
+            return f"{months} month{'s' if months > 1 else ''} ago"

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -436,88 +436,105 @@ class RAGAnswerer:
         Returns:
             Tuple of (answer, context_tokens, total_input_tokens, cost)
         """
-        # Build context text with richer metadata for LLM
-        # Sort by score descending so most relevant sources come first
-        sorted_chunks = sorted(context_chunks, key=lambda c: c.score, reverse=True)
+        context_text = self._build_context_text(context_chunks)
+        user_prompt = self._build_user_prompt(question, context_text)
+        context_tokens = self._estimate_tokens(context_text)
         
-        context_parts = []
-        for i, chunk in enumerate(sorted_chunks, 1):
-            # Header with title, date, and relevance score
-            header = f"[Source {i}: {chunk.title}"
-            if chunk.created_at:
-                age = self._format_age(chunk.created_at)
-                header += f" ({age})"
-            header += f" - relevance: {chunk.score:.0%}]"
-            context_parts.append(header)
-            
-            # Summary (if available)
-            if chunk.summary:
-                context_parts.append(f"Summary: {chunk.summary}")
-            
-            # Related refs for disambiguation
-            if chunk.source:
-                ref_fqns = []
-                for pr in chunk.source.prs[:3]:  # Limit to avoid bloat
-                    ref_fqns.append(f"PR {pr.fqn}")
-                for issue in chunk.source.issues[:3]:
-                    ref_fqns.append(f"Issue {issue.fqn}")
-                for repo in chunk.source.repos[:2]:
-                    ref_fqns.append(f"Repo {repo.fqn}")
-                if ref_fqns:
-                    context_parts.append(f"Related: {', '.join(ref_fqns)}")
-            
-            # Content
-            context_parts.append(chunk.source_text)
-            context_parts.append("")
-        
-        context_text = "\n".join(context_parts)
-        
-        user_prompt = f"""Context from conversation history:
-{context_text}
-
-Question: {question}
-
-Please provide a helpful answer based on the context above."""
-        
-        # Build messages using openhands-sdk Message format
         messages = [
             Message(role="system", content=self.system_prompt),
             Message(role="user", content=user_prompt),
         ]
         
-        # Estimate context tokens (approximate using litellm's token counter)
         try:
-            context_tokens = litellm.token_counter(model=self.model, text=context_text)
-        except Exception:
-            # Fallback: rough estimate of ~4 chars per token
-            context_tokens = len(context_text) // 4
-        
-        try:
-            # Use openhands-sdk LLM for completion
             response = self.llm.completion(messages)
-            
-            # Get metrics from response
-            metrics = response.metrics
-            total_tokens = 0
-            cost = 0.0
-            if metrics:
-                if metrics.accumulated_token_usage:
-                    usage = metrics.accumulated_token_usage
-                    total_tokens = usage.prompt_tokens + usage.completion_tokens
-                cost = metrics.accumulated_cost or 0.0
-            
-            # Extract text from message content (which is a list of TextContent/ImageContent)
-            answer_text = ""
-            if response.message.content:
-                text_parts = [
-                    part.text for part in response.message.content
-                    if hasattr(part, 'text') and part.text
-                ]
-                answer_text = "".join(text_parts)
-            
+            answer_text = self._extract_answer_text(response)
+            total_tokens, cost = self._extract_response_metrics(response)
             return answer_text, context_tokens, total_tokens, cost
         except Exception as e:
             raise RuntimeError(f"LLM API call failed: {e}") from e
+    
+    def _build_context_text(self, context_chunks: list[ContextChunk]) -> str:
+        """Build formatted context text from chunks for LLM prompt."""
+        sorted_chunks = sorted(context_chunks, key=lambda c: c.score, reverse=True)
+        
+        context_parts = []
+        for i, chunk in enumerate(sorted_chunks, 1):
+            context_parts.append(self._format_chunk_header(chunk, i))
+            
+            if chunk.summary:
+                context_parts.append(f"Summary: {chunk.summary}")
+            
+            refs_line = self._format_chunk_refs(chunk)
+            if refs_line:
+                context_parts.append(refs_line)
+            
+            context_parts.append(chunk.source_text)
+            context_parts.append("")
+        
+        return "\n".join(context_parts)
+    
+    def _format_chunk_header(self, chunk: ContextChunk, index: int) -> str:
+        """Format the header line for a context chunk."""
+        header = f"[Source {index}: {chunk.title}"
+        if chunk.created_at:
+            header += f" ({self._format_age(chunk.created_at)})"
+        header += f" - relevance: {chunk.score:.0%}]"
+        return header
+    
+    def _format_chunk_refs(self, chunk: ContextChunk) -> str | None:
+        """Format related refs for a chunk, or None if no refs."""
+        if not chunk.source:
+            return None
+        
+        ref_fqns = []
+        for pr in chunk.source.prs[:3]:
+            ref_fqns.append(f"PR {pr.fqn}")
+        for issue in chunk.source.issues[:3]:
+            ref_fqns.append(f"Issue {issue.fqn}")
+        for repo in chunk.source.repos[:2]:
+            ref_fqns.append(f"Repo {repo.fqn}")
+        
+        return f"Related: {', '.join(ref_fqns)}" if ref_fqns else None
+    
+    def _build_user_prompt(self, question: str, context_text: str) -> str:
+        """Build the user prompt with context and question."""
+        return f"""Context from conversation history:
+{context_text}
+
+Question: {question}
+
+Please provide a helpful answer based on the context above."""
+    
+    def _estimate_tokens(self, text: str) -> int:
+        """Estimate token count for text."""
+        try:
+            return litellm.token_counter(model=self.model, text=text)
+        except Exception:
+            return len(text) // 4
+    
+    def _extract_answer_text(self, response) -> str:
+        """Extract answer text from LLM response."""
+        if not response.message.content:
+            return ""
+        text_parts = [
+            part.text for part in response.message.content
+            if hasattr(part, 'text') and part.text
+        ]
+        return "".join(text_parts)
+    
+    def _extract_response_metrics(self, response) -> tuple[int, float]:
+        """Extract total tokens and cost from LLM response."""
+        metrics = response.metrics
+        if not metrics:
+            return 0, 0.0
+        
+        total_tokens = 0
+        if metrics.accumulated_token_usage:
+            usage = metrics.accumulated_token_usage
+            total_tokens = usage.prompt_tokens + usage.completion_tokens
+        
+        cost = metrics.accumulated_cost or 0.0
+        return total_tokens, cost
     
     def _format_age(self, dt: datetime) -> str:
         """Format datetime as relative age (e.g., '3 days ago')."""

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -125,9 +125,10 @@ class RAGAnswer:
     related_repos: list[RepoInfo] | None = None
     related_prs: list[RefInfo] | None = None
     related_issues: list[RefInfo] | None = None
-    # Token counts
+    # Token counts and cost
     context_tokens: int = 0
     total_tokens: int = 0  # Context + question + system prompt
+    cost: float = 0.0  # Estimated cost in USD
 
 
 class RAGAnswerer:
@@ -247,7 +248,7 @@ class RAGAnswerer:
         
         # Generate answer
         gen_start = time.perf_counter()
-        answer, context_tokens, total_tokens = self._generate_answer(question, context_chunks)
+        answer, context_tokens, total_tokens, cost = self._generate_answer(question, context_chunks)
         gen_time = time.perf_counter() - gen_start
         
         source_ids = {c.conversation_id for c in context_chunks}
@@ -283,6 +284,7 @@ class RAGAnswerer:
             related_issues=list(all_issues.values()) if all_issues else None,
             context_tokens=context_tokens,
             total_tokens=total_tokens,
+            cost=cost,
         )
     
     def _retrieve_context(
@@ -408,11 +410,11 @@ class RAGAnswerer:
         self,
         question: str,
         context_chunks: list[ContextChunk],
-    ) -> tuple[str, int, int]:
+    ) -> tuple[str, int, int, float]:
         """Generate an answer using the LLM with rich context.
         
         Returns:
-            Tuple of (answer, context_tokens, total_input_tokens)
+            Tuple of (answer, context_tokens, total_input_tokens, cost)
         """
         api_key = os.environ.get("LLM_API_KEY")
         api_base = os.environ.get("LLM_BASE_URL")
@@ -487,7 +489,16 @@ Please provide a helpful answer based on the context above."""
                 api_key=api_key,
                 api_base=api_base,
             )
-            return response.choices[0].message.content, context_tokens, total_tokens
+            
+            # Calculate cost using litellm's completion_cost
+            cost = 0.0
+            try:
+                cost = litellm.completion_cost(completion_response=response)
+            except Exception:
+                # Fallback: rough estimate if model not in litellm's pricing
+                pass
+            
+            return response.choices[0].message.content, context_tokens, total_tokens, cost
         except Exception as e:
             raise RuntimeError(f"LLM API call failed: {e}") from e
     

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone, timedelta
 import litellm
 from pydantic import SecretStr
 
+# Suppress openhands-sdk banner before import
+os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.message import Message
 

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -14,6 +14,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 
 import litellm
+from pydantic import SecretStr
+
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.message import Message
 
 # Suppress LiteLLM info messages that spam output during batch operations
 litellm.suppress_debug_info = True
@@ -179,6 +183,19 @@ class RAGAnswerer:
         self.repo_store = repo_store
         self.cloud_base_url = cloud_base_url or os.environ.get(
             "OHTV_CLOUD_API_URL", "https://app.all-hands.dev"
+        )
+        
+        # Initialize LLM using openhands-sdk
+        api_key = os.environ.get("LLM_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "LLM_API_KEY environment variable not set. "
+                "This is required for answer generation."
+            )
+        self.llm = LLM(
+            model=self.model,
+            api_key=SecretStr(api_key),
+            base_url=os.environ.get("LLM_BASE_URL"),
         )
     
     def answer_question(
@@ -416,15 +433,6 @@ class RAGAnswerer:
         Returns:
             Tuple of (answer, context_tokens, total_input_tokens, cost)
         """
-        api_key = os.environ.get("LLM_API_KEY")
-        api_base = os.environ.get("LLM_BASE_URL")
-        
-        if not api_key:
-            raise RuntimeError(
-                "LLM_API_KEY environment variable not set. "
-                "This is required for answer generation."
-            )
-        
         # Build context text with richer metadata for LLM
         # Sort by score descending so most relevant sources come first
         sorted_chunks = sorted(context_chunks, key=lambda c: c.score, reverse=True)
@@ -468,37 +476,29 @@ Question: {question}
 
 Please provide a helpful answer based on the context above."""
         
+        # Build messages using openhands-sdk Message format
         messages = [
-            {"role": "system", "content": self.system_prompt},
-            {"role": "user", "content": user_prompt},
+            Message(role="system", content=self.system_prompt),
+            Message(role="user", content=user_prompt),
         ]
         
-        # Estimate token counts (approximate using litellm's token counter)
+        # Estimate context tokens (approximate using litellm's token counter)
         try:
             context_tokens = litellm.token_counter(model=self.model, text=context_text)
-            total_tokens = litellm.token_counter(model=self.model, messages=messages)
         except Exception:
             # Fallback: rough estimate of ~4 chars per token
             context_tokens = len(context_text) // 4
-            total_tokens = (len(self.system_prompt) + len(user_prompt)) // 4
         
         try:
-            response = litellm.completion(
-                model=self.model,
-                messages=messages,
-                api_key=api_key,
-                api_base=api_base,
-            )
+            # Use openhands-sdk LLM for completion
+            response = self.llm.completion(messages)
             
-            # Calculate cost using litellm's completion_cost
-            cost = 0.0
-            try:
-                cost = litellm.completion_cost(completion_response=response)
-            except Exception:
-                # Fallback: rough estimate if model not in litellm's pricing
-                pass
+            # Get metrics from response
+            metrics = response.metrics
+            total_tokens = metrics.accumulated_token_usage if metrics else 0
+            cost = metrics.accumulated_cost if metrics else 0.0
             
-            return response.choices[0].message.content, context_tokens, total_tokens, cost
+            return response.message.content, context_tokens, total_tokens, cost
         except Exception as e:
             raise RuntimeError(f"LLM API call failed: {e}") from e
     

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -405,10 +405,11 @@ class RAGAnswerer:
                         display_name=ref.display_name,
                         link_type=link_type.value,
                     )
-                    if ref.ref_type.value == "pull_request":
+                    if ref.ref_type.value == "pr":
                         prs.append(ref_info)
-                    else:
+                    elif ref.ref_type.value == "issue":
                         issues.append(ref_info)
+                    # Skip branches and other ref types for now
             
             return ConversationSource(
                 conversation_id=conversation_id,

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -505,7 +505,16 @@ Please provide a helpful answer based on the context above."""
                     total_tokens = usage.prompt_tokens + usage.completion_tokens
                 cost = metrics.accumulated_cost or 0.0
             
-            return response.message.content, context_tokens, total_tokens, cost
+            # Extract text from message content (which is a list of TextContent/ImageContent)
+            answer_text = ""
+            if response.message.content:
+                text_parts = [
+                    part.text for part in response.message.content
+                    if hasattr(part, 'text') and part.text
+                ]
+                answer_text = "".join(text_parts)
+            
+            return answer_text, context_tokens, total_tokens, cost
         except Exception as e:
             raise RuntimeError(f"LLM API call failed: {e}") from e
     

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -497,8 +497,13 @@ Please provide a helpful answer based on the context above."""
             
             # Get metrics from response
             metrics = response.metrics
-            total_tokens = metrics.accumulated_token_usage if metrics else 0
-            cost = metrics.accumulated_cost if metrics else 0.0
+            total_tokens = 0
+            cost = 0.0
+            if metrics:
+                if metrics.accumulated_token_usage:
+                    usage = metrics.accumulated_token_usage
+                    total_tokens = usage.prompt_tokens + usage.completion_tokens
+                cost = metrics.accumulated_cost or 0.0
             
             return response.message.content, context_tokens, total_tokens, cost
         except Exception as e:

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -125,6 +125,9 @@ class RAGAnswer:
     related_repos: list[RepoInfo] | None = None
     related_prs: list[RefInfo] | None = None
     related_issues: list[RefInfo] | None = None
+    # Token counts
+    context_tokens: int = 0
+    total_tokens: int = 0  # Context + question + system prompt
 
 
 class RAGAnswerer:
@@ -244,7 +247,7 @@ class RAGAnswerer:
         
         # Generate answer
         gen_start = time.perf_counter()
-        answer = self._generate_answer(question, context_chunks)
+        answer, context_tokens, total_tokens = self._generate_answer(question, context_chunks)
         gen_time = time.perf_counter() - gen_start
         
         source_ids = {c.conversation_id for c in context_chunks}
@@ -278,6 +281,8 @@ class RAGAnswerer:
             related_repos=list(all_repos.values()) if all_repos else None,
             related_prs=list(all_prs.values()) if all_prs else None,
             related_issues=list(all_issues.values()) if all_issues else None,
+            context_tokens=context_tokens,
+            total_tokens=total_tokens,
         )
     
     def _retrieve_context(
@@ -403,8 +408,12 @@ class RAGAnswerer:
         self,
         question: str,
         context_chunks: list[ContextChunk],
-    ) -> str:
-        """Generate an answer using the LLM with rich context."""
+    ) -> tuple[str, int, int]:
+        """Generate an answer using the LLM with rich context.
+        
+        Returns:
+            Tuple of (answer, context_tokens, total_input_tokens)
+        """
         api_key = os.environ.get("LLM_API_KEY")
         api_base = os.environ.get("LLM_BASE_URL")
         
@@ -457,17 +466,28 @@ Question: {question}
 
 Please provide a helpful answer based on the context above."""
         
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        
+        # Estimate token counts (approximate using litellm's token counter)
+        try:
+            context_tokens = litellm.token_counter(model=self.model, text=context_text)
+            total_tokens = litellm.token_counter(model=self.model, messages=messages)
+        except Exception:
+            # Fallback: rough estimate of ~4 chars per token
+            context_tokens = len(context_text) // 4
+            total_tokens = (len(self.system_prompt) + len(user_prompt)) // 4
+        
         try:
             response = litellm.completion(
                 model=self.model,
-                messages=[
-                    {"role": "system", "content": self.system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
+                messages=messages,
                 api_key=api_key,
                 api_base=api_base,
             )
-            return response.choices[0].message.content
+            return response.choices[0].message.content, context_tokens, total_tokens
         except Exception as e:
             raise RuntimeError(f"LLM API call failed: {e}") from e
     

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -94,6 +94,7 @@ class ContextChunk:
     embed_type: str
     source_text: str
     score: float
+    chunk_index: int = 0  # For ordering chunks within a conversation
     # New fields for citations
     summary: str | None = None
     cloud_url: str | None = None
@@ -322,12 +323,17 @@ class RAGAnswerer:
                 embed_type=r.embed_type,
                 source_text=r.source_text,
                 score=r.score,
+                chunk_index=r.chunk_index,
                 summary=summary,
                 cloud_url=cloud_url,
                 created_at=created_at,
                 conv_source=conv_source or "local",
                 source=source,
             ))
+        
+        # Sort chunks: group by conversation, then by embed_type, then by chunk_index
+        # This ensures the LLM sees coherent context from each conversation
+        chunks.sort(key=lambda c: (c.conversation_id, c.embed_type, c.chunk_index))
         
         return chunks
     

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1861,6 +1861,8 @@ def ask(
             f"Generation: {result.generation_time_seconds:.2f}s",
             f"Model: {result.model}",
         ]
+        if result.total_tokens > 0:
+            timing_parts.append(f"Tokens: {result.total_tokens:,}")
         if result.temporal_filter_applied:
             timing_parts.append("📅 auto-filtered")
         console.print(f"\n[dim]{' | '.join(timing_parts)}[/dim]")

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -602,19 +602,20 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         
         all_convs = conv_store.list_all()
         
-        # Find conversations without embeddings that have local directories
+        # Find conversations without embeddings that have local content
         needs_embedding = []
-        no_local_dir = 0
+        no_local_content = 0
         already_embedded = 0
         
         for conv in all_convs:
-            # Skip if no local directory
+            # Skip if no local directory or no events file
             if not conv.location:
-                no_local_dir += 1
+                no_local_content += 1
                 continue
             conv_dir = Path(conv.location)
-            if not conv_dir.exists():
-                no_local_dir += 1
+            events_file = conv_dir / "events.json"
+            if not events_file.exists():
+                no_local_content += 1
                 continue
             
             if embed_store.has_embedding(conv.id):
@@ -625,16 +626,16 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         
         if not needs_embedding:
             if not quiet:
-                if no_local_dir > 0:
-                    console.print(f"  [dim]All local conversations have embeddings ({no_local_dir} cloud-only skipped)[/dim]")
+                if no_local_content > 0:
+                    console.print(f"  [dim]All local conversations have embeddings ({no_local_content} without content skipped)[/dim]")
                 else:
                     console.print("  [dim]All conversations have embeddings[/dim]")
             return
         
         if not quiet:
             msg = f"  Embedding {len(needs_embedding)} conversation(s)..."
-            if no_local_dir > 0:
-                msg += f" ({no_local_dir} cloud-only skipped)"
+            if no_local_content > 0:
+                msg += f" ({no_local_content} without content skipped)"
             console.print(msg)
         
         try:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -624,6 +624,11 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
                 
             needs_embedding.append(conv)
         
+        log.info(
+            "Embedding check: total=%d, already_embedded=%d, no_content=%d, needs_embedding=%d",
+            len(all_convs), already_embedded, no_local_content, len(needs_embedding)
+        )
+        
         if not needs_embedding:
             if not quiet:
                 if no_local_content > 0:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1826,27 +1826,36 @@ def ask(
         # Sort by date descending (newest first), None dates at the end
         source_infos.sort(key=lambda x: x["created_at"] or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
         
+        # Build borderless table for sources
+        table = Table(show_header=False, box=None, padding=(0, 1), expand=True)
+        table.add_column("Date", style="dim", no_wrap=True, width=10)
+        table.add_column("ID", style="cyan", no_wrap=True, width=10)
+        table.add_column("Type", no_wrap=True, width=7)
+        table.add_column("Chunks", no_wrap=True, width=10)
+        table.add_column("Summary", ratio=1)  # Flexible width, will wrap
+        
         for info in source_infos:
-            # Date first
             date_str = info["created_at"].strftime("%Y-%m-%d") if info["created_at"] else "unknown"
-            
-            # Conversation ID with source type
             source_type = "cloud" if info["conv_source"] == "cloud" else "local"
+            chunk_count = f"{info['chunk_count']} chunk{'s' if info['chunk_count'] > 1 else ''}"
             
-            # Chunk count
-            chunk_count = f"({info['chunk_count']} chunk{'s' if info['chunk_count'] > 1 else ''})"
-            
-            console.print(f"• [dim]{date_str}[/dim] [cyan][{info['conv_id'][:8]}][/cyan] [{source_type}] {chunk_count}")
-            
-            # Show summary if available
+            # Build summary with optional URL
+            summary_parts = []
             if info["summary"]:
-                summary = info["summary"][:100] + "..." if len(info["summary"]) > 100 else info["summary"]
-                console.print(f"  [dim]{summary}[/dim]")
+                summary_parts.append(f"[dim]{info['summary']}[/dim]")
+            if info["display_url"]:
+                summary_parts.append(f"[link={info['display_url']}]{info['display_url']}[/link]")
+            summary_text = "\n".join(summary_parts) if summary_parts else "[dim]—[/dim]"
             
-            # Show cloud URL if valid (within retention)
-            display_url = info["display_url"]
-            if display_url:
-                console.print(f"  [link={display_url}]{display_url}[/link]")
+            table.add_row(
+                date_str,
+                f"[{info['conv_id'][:8]}]",
+                f"[{source_type}]",
+                chunk_count,
+                summary_text,
+            )
+        
+        console.print(table)
         
         # Show "See Also" section with related refs
         has_related = any([

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -605,7 +605,7 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         # Find conversations without embeddings
         needs_embedding = []
         for conv in all_convs:
-            if not embed_store.has_embeddings(conv.id):
+            if not embed_store.has_embedding(conv.id):
                 needs_embedding.append(conv)
         
         if not needs_embedding:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -620,17 +620,25 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
             from pathlib import Path
             from ohtv.analysis.embeddings import embed_conversation_full
             
+            embedded_count = 0
             for conv in needs_embedding:
                 conv_dir = Path(conv.location)
                 try:
-                    embed_conversation_full(conv_dir, conn)
-                    if verbose:
-                        console.print(f"    [dim]Embedded {conv.id[:8]}[/dim]")
+                    stats = embed_conversation_full(conv_dir, conn)
+                    if stats.embeddings_created > 0:
+                        embedded_count += 1
+                        if verbose:
+                            console.print(f"    [dim]Embedded {conv.id[:8]} ({stats.embeddings_created} embeddings)[/dim]")
+                    elif verbose:
+                        console.print(f"    [dim]Skipped {conv.id[:8]} (no content)[/dim]")
                 except Exception as e:
                     if verbose:
                         console.print(f"    [red]Error embedding {conv.id}:[/red] {e}")
             
             conn.commit()
+            
+            if verbose and embedded_count < len(needs_embedding):
+                console.print(f"  [dim]Actually embedded: {embedded_count}/{len(needs_embedding)}[/dim]")
             
         except ImportError as e:
             if verbose:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1835,7 +1835,7 @@ def ask(
         table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
         table.add_column("Date", style="dim", no_wrap=True, width=10)
         table.add_column("ID", style="cyan", no_wrap=True, width=8)
-        table.add_column("Sim", no_wrap=True, width=16)  # e.g., "0.823-0.671 22ch"
+        table.add_column("Stats", no_wrap=True, width=11)  # "22 chunks\n0.703-0.671"
         table.add_column("Summary", width=CLOUD_URL_WIDTH, overflow="fold")
         
         for i, info in enumerate(source_infos):
@@ -1844,9 +1844,10 @@ def ask(
             # Handle both dashed (with -) and undashed conversation IDs, always show 8 chars
             conv_id = raw_conv_id.replace("-", "")[:8] if raw_conv_id else "--------"
             
-            # Format similarity as range (high-low) or single value, with chunk count
+            # Format stats: chunk count on first line, similarity on second
             score_min, score_max = info["score_min"], info["score_max"]
             chunk_count = info["chunk_count"]
+            chunk_label = f"{chunk_count} chunk" if chunk_count == 1 else f"{chunk_count} chunks"
             if chunk_count == 1 or abs(score_max - score_min) < 0.005:
                 sim_score = f"{score_max:.3f}"
             else:
@@ -1858,8 +1859,7 @@ def ask(
                 sim_style = "yellow"
             else:
                 sim_style = "dim"
-            # Combine similarity and chunk count
-            sim_text = f"[{sim_style}]{sim_score}[/{sim_style}] [dim]{chunk_count}ch[/dim]"
+            stats_text = f"[dim]{chunk_label}[/dim]\n[{sim_style}]{sim_score}[/{sim_style}]"
             
             # Build summary with optional URL on separate line
             summary_parts = []
@@ -1878,7 +1878,7 @@ def ask(
             table.add_row(
                 date_str,
                 conv_id,
-                sim_text,
+                stats_text,
                 summary_text,
             )
         

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1835,7 +1835,7 @@ def ask(
         table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
         table.add_column("Date", style="dim", no_wrap=True, width=10)
         table.add_column("ID", style="cyan", no_wrap=True, width=8)
-        table.add_column("Conf", no_wrap=True, width=11)  # e.g., "0.82-0.91"
+        table.add_column("Sim", no_wrap=True, width=16)  # e.g., "0.823-0.671 22ch"
         table.add_column("Summary", width=CLOUD_URL_WIDTH, overflow="fold")
         
         for i, info in enumerate(source_infos):
@@ -1844,20 +1844,22 @@ def ask(
             # Handle both dashed (with -) and undashed conversation IDs, always show 8 chars
             conv_id = raw_conv_id.replace("-", "")[:8] if raw_conv_id else "--------"
             
-            # Format confidence as range or single value
+            # Format similarity as range (high-low) or single value, with chunk count
             score_min, score_max = info["score_min"], info["score_max"]
-            if info["chunk_count"] == 1 or abs(score_max - score_min) < 0.01:
-                confidence = f"{score_max:.2f}"
+            chunk_count = info["chunk_count"]
+            if chunk_count == 1 or abs(score_max - score_min) < 0.005:
+                sim_score = f"{score_max:.3f}"
             else:
-                confidence = f"{score_min:.2f}-{score_max:.2f}"
+                sim_score = f"{score_max:.3f}-{score_min:.3f}"  # High to low
             # Color based on max score: green (>0.8), yellow (0.6-0.8), dim (<0.6)
             if score_max >= 0.8:
-                conf_style = "green"
+                sim_style = "green"
             elif score_max >= 0.6:
-                conf_style = "yellow"
+                sim_style = "yellow"
             else:
-                conf_style = "dim"
-            confidence_text = f"[{conf_style}]{confidence}[/{conf_style}]"
+                sim_style = "dim"
+            # Combine similarity and chunk count
+            sim_text = f"[{sim_style}]{sim_score}[/{sim_style}] [dim]{chunk_count}ch[/dim]"
             
             # Build summary with optional URL on separate line
             summary_parts = []
@@ -1876,7 +1878,7 @@ def ask(
             table.add_row(
                 date_str,
                 conv_id,
-                confidence_text,
+                sim_text,
                 summary_text,
             )
         

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1874,19 +1874,34 @@ def ask(
             console.print()
             console.print("[bold]See Also:[/bold]")
             
+            def ref_sort_key(ref):
+                """Sort by repo name, then by ID number descending."""
+                fqn = ref.fqn
+                if "#" in fqn:
+                    repo_part, num_part = fqn.rsplit("#", 1)
+                    try:
+                        num = int(num_part)
+                    except ValueError:
+                        num = 0
+                    return (repo_part.lower(), -num)  # Negative for descending
+                return (fqn.lower(), 0)
+            
             if result.related_prs:
                 console.print("  [bold]Pull Requests:[/bold]")
-                for pr in result.related_prs:
+                sorted_prs = sorted(result.related_prs, key=ref_sort_key)
+                for pr in sorted_prs:
                     console.print(f"  • [link={pr.url}]{pr.fqn}[/link]")
             
             if result.related_issues:
                 console.print("  [bold]Issues:[/bold]")
-                for issue in result.related_issues:
+                sorted_issues = sorted(result.related_issues, key=ref_sort_key)
+                for issue in sorted_issues:
                     console.print(f"  • [link={issue.url}]{issue.fqn}[/link]")
             
             if result.related_repos:
                 console.print("  [bold]Repositories:[/bold]")
-                for repo in result.related_repos:
+                sorted_repos = sorted(result.related_repos, key=lambda r: r.fqn.lower())
+                for repo in sorted_repos:
                     console.print(f"  • [link={repo.url}]{repo.fqn}[/link]")
         
         # Show timing info

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5612,8 +5612,8 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
         # Reset rate limiter state from any previous operations
         reset_rate_limiter()
         
-        # Start the writer thread with the main connection
-        writer = EmbeddingWriter(conn, batch_size=20)
+        # Start the writer thread (it creates its own DB connection)
+        writer = EmbeddingWriter(batch_size=20)
         writer.start()
         
         def _embed_one(conv, conv_dir) -> tuple[EmbeddingStats | None, str | None]:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5607,7 +5607,10 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
             return _last_rate_str[0]
         
         # Import the new batched embedding function
-        from ohtv.analysis.embeddings import generate_embeddings_only, EmbeddingBatch, EmbeddingWriter
+        from ohtv.analysis.embeddings import generate_embeddings_only, EmbeddingBatch, EmbeddingWriter, reset_rate_limiter
+        
+        # Reset rate limiter state from any previous operations
+        reset_rate_limiter()
         
         # Start the writer thread with the main connection
         writer = EmbeddingWriter(conn, batch_size=20)

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -602,30 +602,52 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         
         all_convs = conv_store.list_all()
         
-        # Find conversations without embeddings
+        # Find conversations without embeddings that have local directories
         needs_embedding = []
+        no_local_dir = 0
+        already_embedded = 0
+        
         for conv in all_convs:
-            if not embed_store.has_embedding(conv.id):
-                needs_embedding.append(conv)
+            # Skip if no local directory
+            if not conv.location:
+                no_local_dir += 1
+                continue
+            conv_dir = Path(conv.location)
+            if not conv_dir.exists():
+                no_local_dir += 1
+                continue
+            
+            if embed_store.has_embedding(conv.id):
+                already_embedded += 1
+                continue
+                
+            needs_embedding.append(conv)
         
         if not needs_embedding:
             if not quiet:
-                console.print("  [dim]All conversations have embeddings[/dim]")
+                if no_local_dir > 0:
+                    console.print(f"  [dim]All local conversations have embeddings ({no_local_dir} cloud-only skipped)[/dim]")
+                else:
+                    console.print("  [dim]All conversations have embeddings[/dim]")
             return
         
         if not quiet:
-            console.print(f"  Embedding {len(needs_embedding)} conversation(s)...")
+            msg = f"  Embedding {len(needs_embedding)} conversation(s)..."
+            if no_local_dir > 0:
+                msg += f" ({no_local_dir} cloud-only skipped)"
+            console.print(msg)
         
         try:
             from pathlib import Path
             from ohtv.analysis.embeddings import embed_conversation_full
             
             embedded_count = 0
-            skipped_count = 0
+            skipped_no_content = 0
             error_count = 0
             
             for conv in needs_embedding:
-                conv_dir = Path(conv.location)
+                conv_dir = Path(conv.location)  # Already verified exists above
+                
                 try:
                     stats = embed_conversation_full(conv_dir, conn)
                     if stats.embeddings_created > 0:
@@ -633,7 +655,7 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
                         if verbose:
                             console.print(f"    [dim]Embedded {conv.id[:8]} ({stats.embeddings_created} embeddings)[/dim]")
                     else:
-                        skipped_count += 1
+                        skipped_no_content += 1
                         if verbose:
                             console.print(f"    [dim]Skipped {conv.id[:8]} (no content)[/dim]")
                 except Exception as e:
@@ -646,8 +668,13 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
             conn.commit()
             
             # Always show summary if there were issues
-            if skipped_count > 0 or error_count > 0:
-                console.print(f"  [dim]Results: {embedded_count} embedded, {skipped_count} skipped (no content), {error_count} errors[/dim]")
+            if skipped_no_content > 0 or error_count > 0:
+                parts = [f"{embedded_count} embedded"]
+                if skipped_no_content > 0:
+                    parts.append(f"{skipped_no_content} skipped (no content)")
+                if error_count > 0:
+                    parts.append(f"{error_count} errors")
+                console.print(f"  [dim]Results: {', '.join(parts)}[/dim]")
             
         except Exception as e:
             # Catch ALL exceptions including import errors

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -585,6 +585,7 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
     """Generate embeddings for conversations that need them."""
     import os
     from ohtv.db import get_connection
+    from pathlib import Path
     from ohtv.db.stores import ConversationStore, EmbeddingStore
     
     # Check if embedding is configured
@@ -644,7 +645,6 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
             console.print(msg)
         
         try:
-            from pathlib import Path
             from ohtv.analysis.embeddings import embed_conversation_full
             
             embedded_count = 0

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1868,7 +1868,9 @@ def ask(
             else:
                 summary_parts.append("[dim]—[/dim]")
             if info["display_url"]:
-                summary_parts.append(f"[dim][link={info['display_url']}]{info['display_url']}[/link][/dim]")
+                # No styling on URL - keeps Terminal.app auto-detection working
+                # OSC 8 link markup for modern terminals (iTerm2, Windows Terminal, etc)
+                summary_parts.append(f"[link={info['display_url']}]{info['display_url']}[/link]")
             summary_text = "\n".join(summary_parts)
             
             # Add blank row between entries (except before first)

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5397,6 +5397,7 @@ def db_index_cache(verbose: bool) -> None:
     
     Scans all conversation directories for objective_analysis.json files
     and imports their metadata into the database for fast cache lookup.
+    Also syncs the goal/summary from cached analysis to the conversations table.
     
     This enables the summary command to quickly determine which conversations
     need analysis without reading event files.
@@ -5406,6 +5407,7 @@ def db_index_cache(verbose: bool) -> None:
     from ohtv.db import get_connection, migrate
     from ohtv.db.stores import AnalysisCacheStore, ConversationStore
     from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry, AnalysisSkipEntry
+    from ohtv.analysis.cache import load_analysis
     
     config = Config.from_env()
     
@@ -5423,6 +5425,7 @@ def db_index_cache(verbose: bool) -> None:
         
         indexed = 0
         skipped = 0
+        summaries_updated = 0
         errors = 0
         
         with Progress(
@@ -5478,6 +5481,14 @@ def db_index_cache(verbose: bool) -> None:
                         )
                         cache_store.upsert_cache(entry)
                         indexed += 1
+                    
+                    # Sync summary/goal from cached analysis to conversations table
+                    analysis = load_analysis(conv_dir)
+                    if analysis:
+                        goal = analysis.get("goal")
+                        if goal and goal != conv.summary:
+                            conv_store.update_summary(conv.id, goal)
+                            summaries_updated += 1
                         
                 except (json.JSONDecodeError, KeyError) as e:
                     errors += 1
@@ -5491,11 +5502,13 @@ def db_index_cache(verbose: bool) -> None:
     # Display results
     if indexed > 0:
         console.print(f"[green]✓[/green] Indexed {indexed} cached analysis entries")
+    if summaries_updated > 0:
+        console.print(f"[green]✓[/green] Updated {summaries_updated} conversation summaries")
     if skipped > 0:
         console.print(f"[dim]{skipped} skip markers indexed[/dim]")
     if errors > 0:
         console.print(f"[yellow]![/yellow] {errors} error(s) reading cache files")
-    if indexed == 0 and skipped == 0 and errors == 0:
+    if indexed == 0 and skipped == 0 and summaries_updated == 0 and errors == 0:
         console.print("[dim]No cache files found to index.[/dim]")
 
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1827,11 +1827,13 @@ def ask(
         source_infos.sort(key=lambda x: x["created_at"] or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
         
         # Build borderless table for sources
-        table = Table(show_header=False, box=None, padding=(0, 1), expand=True)
+        # Fix summary width to match cloud URL length (72 chars) for consistent wrapping
+        CLOUD_URL_WIDTH = 72  # len("https://app.all-hands.dev/conversations/{32-char-id}")
+        table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
         table.add_column("Date", style="dim", no_wrap=True, width=10)
         table.add_column("ID", style="cyan", no_wrap=True, width=8)
         table.add_column("Chunks", style="dim", no_wrap=True, width=5)
-        table.add_column("Summary", ratio=1)  # Flexible width, will wrap
+        table.add_column("Summary", width=CLOUD_URL_WIDTH, overflow="fold")
         
         for i, info in enumerate(source_infos):
             date_str = info["created_at"].strftime("%Y-%m-%d") if info["created_at"] else "unknown"

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1802,30 +1802,49 @@ def ask(
         console.print(f"\n[dim]─────────────────────────────────────────────────[/dim]")
         console.print(f"[bold]Sources ({len(result.source_conversation_ids)} conversations):[/bold]")
         
-        # Collect unique chunks per conversation for display
-        seen_convs = set()
+        # Group chunks by conversation and count them
+        conv_chunks: dict[str, list] = {}
         for chunk in result.context_chunks:
-            if chunk.conversation_id in seen_convs:
-                continue
-            seen_convs.add(chunk.conversation_id)
+            if chunk.conversation_id not in conv_chunks:
+                conv_chunks[chunk.conversation_id] = []
+            conv_chunks[chunk.conversation_id].append(chunk)
+        
+        # Build source info list and sort by date (newest first)
+        source_infos = []
+        for conv_id, chunks in conv_chunks.items():
+            first_chunk = chunks[0]
+            source_infos.append({
+                "conv_id": conv_id,
+                "created_at": first_chunk.created_at,
+                "summary": first_chunk.summary,
+                "cloud_url": first_chunk.cloud_url if first_chunk.conv_source == "cloud" else None,
+                "display_url": first_chunk.display_url,
+                "conv_source": first_chunk.conv_source,
+                "chunk_count": len(chunks),
+            })
+        
+        # Sort by date descending (newest first), None dates at the end
+        source_infos.sort(key=lambda x: x["created_at"] or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+        
+        for info in source_infos:
+            # Date first
+            date_str = info["created_at"].strftime("%Y-%m-%d") if info["created_at"] else "unknown"
             
-            # Format title with date
-            title = chunk.title or "(no title)"
-            short_title = title[:50] + "..." if len(title) > 50 else title
+            # Conversation ID with source type
+            source_type = "cloud" if info["conv_source"] == "cloud" else "local"
             
-            date_str = ""
-            if chunk.created_at:
-                date_str = f" ({chunk.created_at.strftime('%Y-%m-%d')})"
+            # Chunk count
+            chunk_count = f"({info['chunk_count']} chunk{'s' if info['chunk_count'] > 1 else ''})"
             
-            console.print(f"• [cyan][{chunk.conversation_id[:8]}][/cyan] {short_title}{date_str}")
+            console.print(f"• [dim]{date_str}[/dim] [cyan][{info['conv_id'][:8]}][/cyan] [{source_type}] {chunk_count}")
             
             # Show summary if available
-            if chunk.summary:
-                summary = chunk.summary[:100] + "..." if len(chunk.summary) > 100 else chunk.summary
+            if info["summary"]:
+                summary = info["summary"][:100] + "..." if len(info["summary"]) > 100 else info["summary"]
                 console.print(f"  [dim]{summary}[/dim]")
             
-            # Show cloud URL if valid (within 14-day retention)
-            display_url = chunk.display_url
+            # Show cloud URL if valid (within retention)
+            display_url = info["display_url"]
             if display_url:
                 console.print(f"  [link={display_url}]{display_url}[/link]")
         

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5526,7 +5526,7 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
                 return (conv, conv_dir, tokens, num_embeddings)
             
             # Use more workers for estimate since it's just file I/O
-            max_workers = min(16, len(to_embed))
+            max_workers = min(20, len(to_embed))
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = {executor.submit(_estimate_one, conv): conv for conv in to_embed}
                 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5512,24 +5512,40 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
                 current="calculating tokens..."
             )
             
-            for conv in to_embed:
-                short_id = conv.id[:12]
-                progress.update(task, current=short_id)
-                
+            # Parallelize estimation - it's I/O bound (reading files)
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+            
+            def _estimate_one(conv):
+                """Estimate tokens for a single conversation."""
                 conv_dir = Path(conv.location)
                 if not conv_dir.exists():
-                    progress.advance(task)
-                    continue
-                
+                    return None
                 tokens, num_embeddings = estimate_conversation_tokens(conv_dir)
                 if tokens == 0:
-                    progress.advance(task)
-                    continue
+                    return None
+                return (conv, conv_dir, tokens, num_embeddings)
+            
+            # Use more workers for estimate since it's just file I/O
+            max_workers = min(16, len(to_embed))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {executor.submit(_estimate_one, conv): conv for conv in to_embed}
                 
-                total_tokens += tokens
-                total_embeddings += num_embeddings
-                valid_convs.append((conv, conv_dir, tokens, num_embeddings))
-                progress.advance(task)
+                for future in as_completed(futures):
+                    conv = futures[future]
+                    short_id = conv.id[:12]
+                    progress.update(task, current=short_id)
+                    
+                    try:
+                        result = future.result()
+                        if result:
+                            conv, conv_dir, tokens, num_embeddings = result
+                            total_tokens += tokens
+                            total_embeddings += num_embeddings
+                            valid_convs.append((conv, conv_dir, tokens, num_embeddings))
+                    except Exception as e:
+                        log.debug("Error estimating %s: %s", short_id, e)
+                    
+                    progress.advance(task)
         
         if not valid_convs:
             console.print("[dim]No conversations with content to embed.[/dim]")

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -5561,6 +5561,9 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
                 return
         
         # Build embeddings with progress bar (parallel processing)
+        # Uses a single-writer pattern to avoid SQLite locking issues:
+        # - Multiple worker threads generate embeddings (API calls)
+        # - A single writer thread batches and commits to the database
         embedded = 0
         skipped = 0
         errors = 0
@@ -5603,47 +5606,43 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
                 _last_rate_str[0] = f"{rate:.0f}/min"
             return _last_rate_str[0]
         
+        # Import the new batched embedding function
+        from ohtv.analysis.embeddings import generate_embeddings_only, EmbeddingBatch, EmbeddingWriter
+        
+        # Start the writer thread with the main connection
+        writer = EmbeddingWriter(conn, batch_size=20)
+        writer.start()
+        
         def _embed_one(conv, conv_dir) -> tuple[EmbeddingStats | None, str | None]:
-            """Embed a single conversation. Returns (stats, error_msg)."""
-            max_retries = 5
-            retry_delay = 0.5  # seconds
+            """Generate embeddings for a single conversation (no DB writes).
             
-            # Each thread gets its own connection (SQLite connections aren't thread-safe)
-            with get_connection() as thread_conn:
-                for attempt in range(max_retries):
-                    try:
-                        stats = embed_conversation_full(
-                            conv_dir,
-                            thread_conn,
-                            model=model,
-                            skip_existing=not force,
-                        )
-                        
-                        log.debug("Embedded %s: %d embeddings created", conv.id[:12], stats.embeddings_created)
-                        
-                        # Also update FTS for keyword search
-                        if stats.embeddings_created > 0:
-                            events = load_events(conv_dir)
-                            if events:
-                                summary = build_summary_text(events)
-                                if summary:
-                                    thread_embed_store = EmbeddingStore(thread_conn)
-                                    thread_embed_store.upsert_fts(conv.id, summary)
-                        
-                        thread_conn.commit()
-                        log.debug("Committed %s", conv.id[:12])
-                        return stats, None
-                    except sqlite3.OperationalError as e:
-                        log.debug("SQLite error on %s (attempt %d): %s", conv.id[:12], attempt + 1, e)
-                        if "database is locked" in str(e) and attempt < max_retries - 1:
-                            time.sleep(retry_delay * (attempt + 1))  # exponential backoff
-                            continue
-                        return None, str(e)
-                    except Exception as e:
-                        log.debug("Error on %s: %s", conv.id[:12], e)
-                        return None, str(e)
-            
-            return None, "database is locked (max retries exceeded)"
+            Returns (stats, error_msg). The batch is submitted to the writer queue.
+            """
+            # Use a read-only connection for checking existing embeddings
+            with get_connection() as read_conn:
+                try:
+                    batch = generate_embeddings_only(
+                        conv_dir,
+                        read_conn,
+                        model=model,
+                        skip_existing=not force,
+                    )
+                    
+                    if batch.error:
+                        return None, batch.error
+                    
+                    # Submit batch to writer (non-blocking)
+                    writer.submit(batch)
+                    
+                    log.debug("Generated %d embeddings for %s", 
+                              batch.stats.embeddings_created if batch.stats else 0, 
+                              conv.id[:12])
+                    
+                    return batch.stats, None
+                    
+                except Exception as e:
+                    log.debug("Error on %s: %s", conv.id[:12], e)
+                    return None, str(e)
         
         interrupted = False
         
@@ -5734,6 +5733,11 @@ def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
             interrupted = True
             console.print("\n[yellow]Interrupted! Partial results saved.[/yellow]")
             console.print("[dim]  Some embeddings may be incomplete. Re-run to complete remaining.[/dim]")
+        finally:
+            # Stop the writer thread and flush any pending batches
+            writer.stop(timeout=30.0)
+            writer_stats = writer.get_stats()
+            log.info("Writer stats: %s", writer_stats)
         
         # Log deduplicated errors to file
         for err_msg, count in error_counts.items():

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1476,9 +1476,10 @@ def ask(
       ohtv ask "recent issues" --no-temporal             # Disable auto-filter
     """
     from ohtv.db import get_connection, get_db_path, migrate
-    from ohtv.db.stores import ConversationStore, EmbeddingStore
+    from ohtv.db.stores import ConversationStore, EmbeddingStore, LinkStore, ReferenceStore, RepoStore
     from ohtv.analysis.rag import RAGAnswerer
     from ohtv.filters import parse_date_filter
+    from ohtv.config import Config
     
     _init_logging(verbose=verbose)
     db_path = get_db_path()
@@ -1504,11 +1505,26 @@ def ask(
             console.print("[dim]Use YYYY-MM-DD format[/dim]")
             raise SystemExit(1)
     
+    # Get cloud base URL from config
+    config = Config.from_env()
+    cloud_base_url = config.cloud_api_url
+    
     with get_connection() as conn:
         migrate(conn)
         
         embed_store = EmbeddingStore(conn)
         conv_store = ConversationStore(conn)
+        
+        # Initialize ref stores for enhanced citations (gracefully handle if not available)
+        link_store = None
+        ref_store = None
+        repo_store = None
+        try:
+            link_store = LinkStore(conn)
+            ref_store = ReferenceStore(conn)
+            repo_store = RepoStore(conn)
+        except Exception:
+            pass  # Stores not available, citations will be basic
         
         # Check if we have embeddings
         embed_count = embed_store.count()
@@ -1526,6 +1542,10 @@ def ask(
             embed_store, conv_store, 
             model=model, 
             enable_temporal_filter=enable_temporal,
+            link_store=link_store,
+            ref_store=ref_store,
+            repo_store=repo_store,
+            cloud_base_url=cloud_base_url,
         )
         
         try:
@@ -1578,14 +1598,62 @@ def ask(
         console.print(f"\n[bold]Answer:[/bold]\n")
         console.print(result.answer)
         
-        # Show sources
+        # Show sources with enhanced citations
         console.print(f"\n[dim]─────────────────────────────────────────────────[/dim]")
-        console.print(f"[dim]Sources ({len(result.source_conversation_ids)} conversations):[/dim]")
-        for conv_id in result.source_conversation_ids:
-            conv = conv_store.get(conv_id)
-            title = conv.title if conv and conv.title else "(no title)"
+        console.print(f"[bold]Sources ({len(result.source_conversation_ids)} conversations):[/bold]")
+        
+        # Collect unique chunks per conversation for display
+        seen_convs = set()
+        for chunk in result.context_chunks:
+            if chunk.conversation_id in seen_convs:
+                continue
+            seen_convs.add(chunk.conversation_id)
+            
+            # Format title with date
+            title = chunk.title or "(no title)"
             short_title = title[:50] + "..." if len(title) > 50 else title
-            console.print(f"[dim]  • [{conv_id[:8]}] {short_title}[/dim]")
+            
+            date_str = ""
+            if chunk.created_at:
+                date_str = f" ({chunk.created_at.strftime('%Y-%m-%d')})"
+            
+            console.print(f"• [cyan][{chunk.conversation_id[:8]}][/cyan] {short_title}{date_str}")
+            
+            # Show summary if available
+            if chunk.summary:
+                summary = chunk.summary[:100] + "..." if len(chunk.summary) > 100 else chunk.summary
+                console.print(f"  [dim]{summary}[/dim]")
+            
+            # Show cloud URL if valid (within 14-day retention)
+            display_url = chunk.display_url
+            if display_url:
+                console.print(f"  [link={display_url}]{display_url}[/link]")
+        
+        # Show "See Also" section with related refs
+        has_related = any([
+            result.related_prs,
+            result.related_issues,
+            result.related_repos
+        ])
+        
+        if has_related:
+            console.print()
+            console.print("[bold]See Also:[/bold]")
+            
+            if result.related_prs:
+                console.print("  [bold]Pull Requests:[/bold]")
+                for pr in result.related_prs:
+                    console.print(f"  • [link={pr.url}]{pr.fqn}[/link]")
+            
+            if result.related_issues:
+                console.print("  [bold]Issues:[/bold]")
+                for issue in result.related_issues:
+                    console.print(f"  • [link={issue.url}]{issue.fqn}[/link]")
+            
+            if result.related_repos:
+                console.print("  [bold]Repositories:[/bold]")
+                for repo in result.related_repos:
+                    console.print(f"  • [link={repo.url}]{repo.fqn}[/link]")
         
         # Show timing info
         timing_parts = [

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1829,28 +1829,34 @@ def ask(
         # Build borderless table for sources
         table = Table(show_header=False, box=None, padding=(0, 1), expand=True)
         table.add_column("Date", style="dim", no_wrap=True, width=10)
-        table.add_column("ID", style="cyan", no_wrap=True, width=10)
-        table.add_column("Type", no_wrap=True, width=7)
-        table.add_column("Chunks", no_wrap=True, width=10)
+        table.add_column("ID", style="cyan", no_wrap=True, width=8)
+        table.add_column("Chunks", style="dim", no_wrap=True, width=5)
         table.add_column("Summary", ratio=1)  # Flexible width, will wrap
         
-        for info in source_infos:
+        for i, info in enumerate(source_infos):
             date_str = info["created_at"].strftime("%Y-%m-%d") if info["created_at"] else "unknown"
-            source_type = "cloud" if info["conv_source"] == "cloud" else "local"
-            chunk_count = f"{info['chunk_count']} chunk{'s' if info['chunk_count'] > 1 else ''}"
+            raw_conv_id = info["conv_id"] or ""
+            # Handle both dashed (with -) and undashed conversation IDs, always show 8 chars
+            conv_id = raw_conv_id.replace("-", "")[:8] if raw_conv_id else "--------"
+            chunk_count = f"{info['chunk_count']}ch"
             
-            # Build summary with optional URL
+            # Build summary with optional URL on separate line
             summary_parts = []
             if info["summary"]:
-                summary_parts.append(f"[dim]{info['summary']}[/dim]")
+                summary_parts.append(info["summary"])
+            else:
+                summary_parts.append("[dim]—[/dim]")
             if info["display_url"]:
-                summary_parts.append(f"[link={info['display_url']}]{info['display_url']}[/link]")
-            summary_text = "\n".join(summary_parts) if summary_parts else "[dim]—[/dim]"
+                summary_parts.append(f"[dim][link={info['display_url']}]{info['display_url']}[/link][/dim]")
+            summary_text = "\n".join(summary_parts)
+            
+            # Add blank row between entries (except before first)
+            if i > 0:
+                table.add_row("", "", "", "")
             
             table.add_row(
                 date_str,
-                f"[{info['conv_id'][:8]}]",
-                f"[{source_type}]",
+                conv_id,
                 chunk_count,
                 summary_text,
             )

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -244,6 +244,8 @@ def main() -> None:
 @click.option("--status", "-s", is_flag=True, help="Show sync status")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output for cron jobs")
 @click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@click.option("--no-llm", is_flag=True, help="Skip LLM-powered analysis (summaries won't be generated)")
+@click.option("--no-embed", is_flag=True, help="Skip embedding generation")
 def sync(
     force: bool,
     since: datetime | None,
@@ -252,14 +254,18 @@ def sync(
     status: bool,
     quiet: bool,
     verbose: bool,
+    no_llm: bool,
+    no_embed: bool,
 ) -> None:
     """Sync cloud conversations to local storage.
     
     Use -n/--max-new to limit the number of NEW conversations synced.
     Updates to existing conversations are always synced (no limit).
     
-    After syncing, automatically indexes conversations and runs all
-    processing stages (refs, actions, branch_context, push_pr_links).
+    After syncing, automatically:
+    - Indexes conversations and runs processing stages
+    - Generates LLM analysis and extracts summaries (unless --no-llm)
+    - Generates embeddings for RAG search (unless --no-embed)
     
     Combining --force with -n resets local storage to only the N most
     recent conversations (destructive operation, requires confirmation).
@@ -289,7 +295,7 @@ def sync(
         
         # Always run processing stages after sync (unless dry-run)
         if not dry_run:
-            _run_post_sync_processing(quiet, verbose)
+            _run_post_sync_processing(quiet, verbose, no_llm, no_embed)
             
     except SyncAuthError as e:
         console.print(f"[red]Authentication error:[/red] {e}")
@@ -438,8 +444,15 @@ def _show_config() -> None:
         console.print(f"  [yellow]![/yellow] manifest not found")
 
 
-def _run_post_sync_processing(quiet: bool, verbose: bool) -> None:
-    """Run all processing stages after sync."""
+def _run_post_sync_processing(quiet: bool, verbose: bool, no_llm: bool = False, no_embed: bool = False) -> None:
+    """Run all processing stages after sync.
+    
+    Args:
+        quiet: Minimal output
+        verbose: Show debug output
+        no_llm: Skip LLM-powered analysis (summaries won't be generated)
+        no_embed: Skip embedding generation
+    """
     from ohtv.db import get_connection, migrate, scan_conversations
     from ohtv.db.stages import STAGES
     from ohtv.db.stores import ConversationStore, StageStore
@@ -489,6 +502,142 @@ def _run_post_sync_processing(quiet: bool, verbose: bool) -> None:
     
     if not quiet:
         console.print("[green]✓[/green] Processing complete")
+    
+    # Run LLM analysis to generate summaries (unless --no-llm)
+    if not no_llm:
+        _run_post_sync_llm_analysis(quiet, verbose)
+    
+    # Generate embeddings (unless --no-embed)
+    if not no_embed:
+        _run_post_sync_embeddings(quiet, verbose)
+
+
+def _run_post_sync_llm_analysis(quiet: bool, verbose: bool) -> None:
+    """Run LLM analysis on conversations that need it."""
+    import os
+    from pathlib import Path
+    from ohtv.db import get_connection
+    from ohtv.db.stores import ConversationStore
+    from ohtv.analysis.cache import load_analysis
+    
+    # Check if LLM is configured
+    if not os.environ.get("LLM_API_KEY"):
+        if not quiet:
+            console.print("\n[dim]Skipping LLM analysis (LLM_API_KEY not set)[/dim]")
+        return
+    
+    if not quiet:
+        console.print("\n[bold]Generating LLM analysis...[/bold]")
+    
+    with get_connection() as conn:
+        conv_store = ConversationStore(conn)
+        all_convs = conv_store.list_all()
+        
+        # Find conversations without analysis cache
+        needs_analysis = []
+        for conv in all_convs:
+            conv_dir = Path(conv.location)
+            if not load_analysis(conv_dir):
+                needs_analysis.append(conv)
+        
+        if not needs_analysis:
+            if not quiet:
+                console.print("  [dim]All conversations have analysis cached[/dim]")
+            return
+        
+        if not quiet:
+            console.print(f"  Analyzing {len(needs_analysis)} conversation(s)...")
+        
+        # Import and run the objective analysis generator
+        try:
+            from ohtv.analysis.objectives import generate_objective_analysis
+            from ohtv.analysis.cache import load_events, save_analysis
+            
+            for conv in needs_analysis:
+                conv_dir = Path(conv.location)
+                try:
+                    events = load_events(conv_dir)
+                    if events:
+                        analysis = generate_objective_analysis(events)
+                        if analysis:
+                            save_analysis(conv_dir, analysis)
+                            # Update summary in database
+                            goal = analysis.get("goal")
+                            if goal:
+                                conv_store.update_summary(conv.id, goal)
+                            if verbose:
+                                console.print(f"    [dim]Analyzed {conv.id[:8]}[/dim]")
+                except Exception as e:
+                    if verbose:
+                        console.print(f"    [red]Error analyzing {conv.id}:[/red] {e}")
+            
+            conn.commit()
+            
+        except ImportError as e:
+            if verbose:
+                console.print(f"  [red]Could not import analysis module:[/red] {e}")
+    
+    if not quiet:
+        console.print("[green]✓[/green] LLM analysis complete")
+
+
+def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
+    """Generate embeddings for conversations that need them."""
+    import os
+    from ohtv.db import get_connection
+    from ohtv.db.stores import ConversationStore, EmbeddingStore
+    
+    # Check if embedding is configured
+    if not os.environ.get("LLM_API_KEY"):
+        if not quiet:
+            console.print("\n[dim]Skipping embeddings (LLM_API_KEY not set)[/dim]")
+        return
+    
+    if not quiet:
+        console.print("\n[bold]Generating embeddings...[/bold]")
+    
+    with get_connection() as conn:
+        conv_store = ConversationStore(conn)
+        embed_store = EmbeddingStore(conn)
+        
+        all_convs = conv_store.list_all()
+        
+        # Find conversations without embeddings
+        needs_embedding = []
+        for conv in all_convs:
+            if not embed_store.has_embeddings(conv.id):
+                needs_embedding.append(conv)
+        
+        if not needs_embedding:
+            if not quiet:
+                console.print("  [dim]All conversations have embeddings[/dim]")
+            return
+        
+        if not quiet:
+            console.print(f"  Embedding {len(needs_embedding)} conversation(s)...")
+        
+        try:
+            from pathlib import Path
+            from ohtv.analysis.embeddings import embed_conversation_full
+            
+            for conv in needs_embedding:
+                conv_dir = Path(conv.location)
+                try:
+                    embed_conversation_full(conv_dir, conn)
+                    if verbose:
+                        console.print(f"    [dim]Embedded {conv.id[:8]}[/dim]")
+                except Exception as e:
+                    if verbose:
+                        console.print(f"    [red]Error embedding {conv.id}:[/red] {e}")
+            
+            conn.commit()
+            
+        except ImportError as e:
+            if verbose:
+                console.print(f"  [red]Could not import embedding module:[/red] {e}")
+    
+    if not quiet:
+        console.print("[green]✓[/green] Embedding complete")
 
 
 def _show_status(manager: SyncManager) -> None:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1813,6 +1813,7 @@ def ask(
         source_infos = []
         for conv_id, chunks in conv_chunks.items():
             first_chunk = chunks[0]
+            scores = [c.score for c in chunks]
             source_infos.append({
                 "conv_id": conv_id,
                 "created_at": first_chunk.created_at,
@@ -1821,6 +1822,8 @@ def ask(
                 "display_url": first_chunk.display_url,
                 "conv_source": first_chunk.conv_source,
                 "chunk_count": len(chunks),
+                "score_min": min(scores),
+                "score_max": max(scores),
             })
         
         # Sort by date descending (newest first), None dates at the end
@@ -1832,7 +1835,7 @@ def ask(
         table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
         table.add_column("Date", style="dim", no_wrap=True, width=10)
         table.add_column("ID", style="cyan", no_wrap=True, width=8)
-        table.add_column("Chunks", style="dim", no_wrap=True, width=5)
+        table.add_column("Conf", no_wrap=True, width=11)  # e.g., "0.82-0.91"
         table.add_column("Summary", width=CLOUD_URL_WIDTH, overflow="fold")
         
         for i, info in enumerate(source_infos):
@@ -1840,7 +1843,21 @@ def ask(
             raw_conv_id = info["conv_id"] or ""
             # Handle both dashed (with -) and undashed conversation IDs, always show 8 chars
             conv_id = raw_conv_id.replace("-", "")[:8] if raw_conv_id else "--------"
-            chunk_count = f"{info['chunk_count']}ch"
+            
+            # Format confidence as range or single value
+            score_min, score_max = info["score_min"], info["score_max"]
+            if info["chunk_count"] == 1 or abs(score_max - score_min) < 0.01:
+                confidence = f"{score_max:.2f}"
+            else:
+                confidence = f"{score_min:.2f}-{score_max:.2f}"
+            # Color based on max score: green (>0.8), yellow (0.6-0.8), dim (<0.6)
+            if score_max >= 0.8:
+                conf_style = "green"
+            elif score_max >= 0.6:
+                conf_style = "yellow"
+            else:
+                conf_style = "dim"
+            confidence_text = f"[{conf_style}]{confidence}[/{conf_style}]"
             
             # Build summary with optional URL on separate line
             summary_parts = []
@@ -1859,7 +1876,7 @@ def ask(
             table.add_row(
                 date_str,
                 conv_id,
-                chunk_count,
+                confidence_text,
                 summary_text,
             )
         

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -621,6 +621,9 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
             from ohtv.analysis.embeddings import embed_conversation_full
             
             embedded_count = 0
+            skipped_count = 0
+            error_count = 0
+            
             for conv in needs_embedding:
                 conv_dir = Path(conv.location)
                 try:
@@ -629,20 +632,27 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
                         embedded_count += 1
                         if verbose:
                             console.print(f"    [dim]Embedded {conv.id[:8]} ({stats.embeddings_created} embeddings)[/dim]")
-                    elif verbose:
-                        console.print(f"    [dim]Skipped {conv.id[:8]} (no content)[/dim]")
+                    else:
+                        skipped_count += 1
+                        if verbose:
+                            console.print(f"    [dim]Skipped {conv.id[:8]} (no content)[/dim]")
                 except Exception as e:
+                    error_count += 1
+                    # Always log errors, not just in verbose mode
+                    log.warning("Error embedding %s: %s", conv.id[:8], e)
                     if verbose:
                         console.print(f"    [red]Error embedding {conv.id}:[/red] {e}")
             
             conn.commit()
             
-            if verbose and embedded_count < len(needs_embedding):
-                console.print(f"  [dim]Actually embedded: {embedded_count}/{len(needs_embedding)}[/dim]")
+            # Always show summary if there were issues
+            if skipped_count > 0 or error_count > 0:
+                console.print(f"  [dim]Results: {embedded_count} embedded, {skipped_count} skipped (no content), {error_count} errors[/dim]")
             
-        except ImportError as e:
-            if verbose:
-                console.print(f"  [red]Could not import embedding module:[/red] {e}")
+        except Exception as e:
+            # Catch ALL exceptions including import errors
+            console.print(f"  [red]Embedding failed:[/red] {e}")
+            log.exception("Embedding failed")
     
     if not quiet:
         console.print("[green]✓[/green] Embedding complete")

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -4849,7 +4849,7 @@ def db_init(verbose: bool) -> None:
 
 
 @db.command("process")
-@click.argument("stage", type=click.Choice(["refs", "actions", "branch_context", "push_pr_links", "all"]))
+@click.argument("stage", type=click.Choice(["refs", "actions", "branch_context", "push_pr_links", "summaries", "all"]))
 @click.option("--force", "-f", is_flag=True, help="Reprocess all conversations, ignoring stage completion")
 @click.option("--conversation", "-c", help="Process only this conversation ID")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
@@ -4865,6 +4865,7 @@ def db_process(stage: str, force: bool, conversation: str | None, verbose: bool)
       actions        - Recognize actions (file edits, git ops, PRs, etc.)
       branch_context - Track branches and create branch refs
       push_pr_links  - Correlate git pushes with PRs via branch matching
+      summaries      - Extract summaries from objective analysis cache
       all            - Run all stages in sequence
     """
     from ohtv.db import get_connection, get_db_path, migrate, scan_conversations

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1881,7 +1881,7 @@ def ask(
             f"Model: {result.model}",
         ]
         if result.total_tokens > 0:
-            timing_parts.append(f"Tokens: {result.total_tokens:,}")
+            timing_parts.append(f"Tokens: {result.total_tokens:,} (${result.cost:.4f})")
         if result.temporal_filter_applied:
             timing_parts.append("📅 auto-filtered")
         console.print(f"\n[dim]{' | '.join(timing_parts)}[/dim]")

--- a/src/ohtv/db/migrations/009_add_summary_column.py
+++ b/src/ohtv/db/migrations/009_add_summary_column.py
@@ -1,0 +1,18 @@
+"""Add summary column to conversations table.
+
+Stores conversation summaries in the database for:
+- Fast RAG retrieval (no need to read analysis JSON files)
+- Contextual chunk enrichment in embeddings
+- Display in citation output
+
+The summary is populated during embedding generation or can be
+generated separately via `ohtv db process objective`.
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Add summary column to conversations table."""
+    # Summary text for RAG and contextual embeddings
+    conn.execute("ALTER TABLE conversations ADD COLUMN summary TEXT")

--- a/src/ohtv/db/models/conversation.py
+++ b/src/ohtv/db/models/conversation.py
@@ -19,6 +19,7 @@ class Conversation:
         updated_at: When the conversation was last updated (UTC)
         selected_repository: Repository selected for this conversation
         source: Source identifier ('local', 'cloud', or custom name)
+        summary: Brief summary of conversation goal/objective (for RAG)
     """
     id: str
     location: str
@@ -30,3 +31,4 @@ class Conversation:
     updated_at: datetime | None = None
     selected_repository: str | None = None
     source: str | None = None
+    summary: str | None = None

--- a/src/ohtv/db/stages/__init__.py
+++ b/src/ohtv/db/stages/__init__.py
@@ -8,12 +8,14 @@ Stage ordering:
 2. actions - Recognize actions (file edits, git ops, PRs, etc.)
 3. branch_context - Track branches and create branch refs (requires actions)
 4. push_pr_links - Correlate pushes with PRs (requires actions, branch_context)
+5. summaries - Extract summaries from objective analysis cache
 """
 
 from ohtv.db.stages.actions import process_actions
 from ohtv.db.stages.branch_context import process_branch_context
 from ohtv.db.stages.push_pr_links import process_push_pr_links
 from ohtv.db.stages.refs import process_refs
+from ohtv.db.stages.summaries import process_summaries
 
 # Registry of available stages
 # Order matters for dependencies
@@ -22,6 +24,7 @@ STAGES = {
     "actions": process_actions,
     "branch_context": process_branch_context,
     "push_pr_links": process_push_pr_links,
+    "summaries": process_summaries,
 }
 
 __all__ = [
@@ -30,4 +33,5 @@ __all__ = [
     "process_branch_context",
     "process_push_pr_links",
     "process_refs",
+    "process_summaries",
 ]

--- a/src/ohtv/db/stages/summaries.py
+++ b/src/ohtv/db/stages/summaries.py
@@ -5,81 +5,40 @@ conversations table for use in RAG contextual enrichment.
 """
 
 import logging
+import sqlite3
 from pathlib import Path
 
 from ohtv.analysis.cache import load_analysis
-from ohtv.db.stores import ConversationStore
+from ohtv.db.models import Conversation
+from ohtv.db.stores import ConversationStore, StageStore
 
 log = logging.getLogger("ohtv")
 
+STAGE_NAME = "summaries"
 
-def process_summaries(
-    conn,
-    conv_dirs: list[Path],
-    force: bool = False,
-) -> int:
-    """Extract summaries from analysis cache and store in database.
-    
+
+def process_summaries(conn: sqlite3.Connection, conversation: Conversation) -> None:
+    """Extract summary from analysis cache and store in database.
+
+    Loads the objective analysis from cache (if available) and extracts
+    the goal as a summary for use in RAG contextual enrichment.
+
     Args:
         conn: Database connection
-        conv_dirs: List of conversation directories to process
-        force: If True, reprocess even if summary already exists
-    
-    Returns:
-        Number of summaries extracted
+        conversation: The conversation to process
     """
+    conv_dir = Path(conversation.location)
     conv_store = ConversationStore(conn)
-    extracted = 0
-    
-    for conv_dir in conv_dirs:
-        conv_id = conv_dir.name
-        
-        # Skip if already has summary (unless force)
-        if not force:
-            conv = conv_store.get(conv_id)
-            if conv and conv.summary:
-                continue
-        
-        # Load analysis from cache
-        analysis = load_analysis(conv_dir)
-        if not analysis:
-            continue
-        
+    stage_store = StageStore(conn)
+
+    # Load analysis from cache
+    analysis = load_analysis(conv_dir)
+    if analysis:
         # Extract goal as summary
         goal = analysis.get("goal")
         if goal:
-            if conv_store.update_summary(conv_id, goal):
-                extracted += 1
-                log.debug("Extracted summary for %s: %s", conv_id[:8], goal[:50])
-    
-    return extracted
+            conv_store.update_summary(conversation.id, goal)
+            log.debug("Extracted summary for %s: %s", conversation.id[:8], goal[:50])
 
-
-def extract_summary_for_conversation(
-    conn,
-    conv_dir: Path,
-) -> str | None:
-    """Extract and store summary for a single conversation.
-    
-    Args:
-        conn: Database connection
-        conv_dir: Conversation directory
-    
-    Returns:
-        Extracted summary or None if not available
-    """
-    conv_id = conv_dir.name
-    conv_store = ConversationStore(conn)
-    
-    # Load analysis from cache
-    analysis = load_analysis(conv_dir)
-    if not analysis:
-        return None
-    
-    # Extract goal as summary
-    goal = analysis.get("goal")
-    if goal:
-        conv_store.update_summary(conv_id, goal)
-        return goal
-    
-    return None
+    # Mark stage as complete (even if no summary found - we tried)
+    stage_store.mark_complete(conversation.id, STAGE_NAME, conversation.event_count)

--- a/src/ohtv/db/stages/summaries.py
+++ b/src/ohtv/db/stages/summaries.py
@@ -1,0 +1,85 @@
+"""Summary extraction stage.
+
+Extracts summaries from objective analysis cache and stores them in the
+conversations table for use in RAG contextual enrichment.
+"""
+
+import logging
+from pathlib import Path
+
+from ohtv.analysis.cache import load_analysis
+from ohtv.db.stores import ConversationStore
+
+log = logging.getLogger("ohtv")
+
+
+def process_summaries(
+    conn,
+    conv_dirs: list[Path],
+    force: bool = False,
+) -> int:
+    """Extract summaries from analysis cache and store in database.
+    
+    Args:
+        conn: Database connection
+        conv_dirs: List of conversation directories to process
+        force: If True, reprocess even if summary already exists
+    
+    Returns:
+        Number of summaries extracted
+    """
+    conv_store = ConversationStore(conn)
+    extracted = 0
+    
+    for conv_dir in conv_dirs:
+        conv_id = conv_dir.name
+        
+        # Skip if already has summary (unless force)
+        if not force:
+            conv = conv_store.get(conv_id)
+            if conv and conv.summary:
+                continue
+        
+        # Load analysis from cache
+        analysis = load_analysis(conv_dir)
+        if not analysis:
+            continue
+        
+        # Extract goal as summary
+        goal = analysis.get("goal")
+        if goal:
+            if conv_store.update_summary(conv_id, goal):
+                extracted += 1
+                log.debug("Extracted summary for %s: %s", conv_id[:8], goal[:50])
+    
+    return extracted
+
+
+def extract_summary_for_conversation(
+    conn,
+    conv_dir: Path,
+) -> str | None:
+    """Extract and store summary for a single conversation.
+    
+    Args:
+        conn: Database connection
+        conv_dir: Conversation directory
+    
+    Returns:
+        Extracted summary or None if not available
+    """
+    conv_id = conv_dir.name
+    conv_store = ConversationStore(conn)
+    
+    # Load analysis from cache
+    analysis = load_analysis(conv_dir)
+    if not analysis:
+        return None
+    
+    # Extract goal as summary
+    goal = analysis.get("goal")
+    if goal:
+        conv_store.update_summary(conv_id, goal)
+        return goal
+    
+    return None

--- a/src/ohtv/db/stores/conversation_store.py
+++ b/src/ohtv/db/stores/conversation_store.py
@@ -12,7 +12,7 @@ class ConversationStore:
     # All columns for SELECT queries
     _ALL_COLUMNS = """
         id, location, registered_at, events_mtime, event_count,
-        title, created_at, updated_at, selected_repository, source
+        title, created_at, updated_at, selected_repository, source, summary
     """
     
     def __init__(self, conn: sqlite3.Connection):
@@ -32,6 +32,13 @@ class ConversationStore:
         if row["updated_at"]:
             updated_at = datetime.fromisoformat(row["updated_at"])
         
+        # Handle summary column gracefully - may not exist in older databases
+        summary = None
+        try:
+            summary = row["summary"]
+        except (IndexError, KeyError):
+            pass
+        
         return Conversation(
             id=row["id"],
             location=row["location"],
@@ -43,6 +50,7 @@ class ConversationStore:
             updated_at=updated_at,
             selected_repository=row["selected_repository"],
             source=row["source"],
+            summary=summary,
         )
     
     def upsert(self, conversation: Conversation) -> None:
@@ -60,9 +68,9 @@ class ConversationStore:
             """
             INSERT INTO conversations (
                 id, location, registered_at, events_mtime, event_count,
-                title, created_at, updated_at, selected_repository, source
+                title, created_at, updated_at, selected_repository, source, summary
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 location = excluded.location,
                 events_mtime = excluded.events_mtime,
@@ -71,7 +79,8 @@ class ConversationStore:
                 created_at = excluded.created_at,
                 updated_at = excluded.updated_at,
                 selected_repository = excluded.selected_repository,
-                source = excluded.source
+                source = excluded.source,
+                summary = COALESCE(excluded.summary, conversations.summary)
             """,
             (
                 conversation.id,
@@ -84,6 +93,7 @@ class ConversationStore:
                 updated_at_str,
                 conversation.selected_repository,
                 conversation.source,
+                conversation.summary,
             ),
         )
     
@@ -176,3 +186,33 @@ class ConversationStore:
             "SELECT COUNT(*) FROM conversations WHERE created_at IS NOT NULL"
         )
         return cursor.fetchone()[0]
+    
+    def count_with_summary(self) -> int:
+        """Return count of conversations that have summary populated."""
+        cursor = self.conn.execute(
+            "SELECT COUNT(*) FROM conversations WHERE summary IS NOT NULL"
+        )
+        return cursor.fetchone()[0]
+    
+    def update_summary(self, conversation_id: str, summary: str) -> bool:
+        """Update the summary for a conversation.
+        
+        Args:
+            conversation_id: The conversation ID
+            summary: The summary text to set
+            
+        Returns:
+            True if a row was updated, False if conversation not found
+        """
+        cursor = self.conn.execute(
+            "UPDATE conversations SET summary = ? WHERE id = ?",
+            (summary, conversation_id),
+        )
+        return cursor.rowcount > 0
+    
+    def list_without_summary(self) -> list[Conversation]:
+        """List conversations that don't have a summary yet."""
+        cursor = self.conn.execute(
+            f"SELECT {self._ALL_COLUMNS} FROM conversations WHERE summary IS NULL"
+        )
+        return [self._row_to_conversation(row) for row in cursor.fetchall()]

--- a/tests/unit/analysis/test_embeddings.py
+++ b/tests/unit/analysis/test_embeddings.py
@@ -333,10 +333,10 @@ class TestBuildConversationTexts:
 
         result = build_conversation_texts(events, analysis, refs)
 
-        assert result.analysis_text is not None
-        assert "Test goal" in result.analysis_text
-        assert result.summary_text is not None
-        assert "[USER]: Hello" in result.summary_text
+        assert len(result.analysis_chunks) > 0
+        assert "Test goal" in result.analysis_chunks[0].text
+        assert len(result.summary_chunks) > 0
+        assert "[USER]: Hello" in result.summary_chunks[0].text
 
     def test_handles_no_analysis(self):
         from ohtv.analysis.embeddings import build_conversation_texts
@@ -348,8 +348,8 @@ class TestBuildConversationTexts:
             }
         ]
         result = build_conversation_texts(events, analysis=None, refs=None)
-        assert result.analysis_text is None
-        assert result.summary_text is not None
+        assert len(result.analysis_chunks) == 0
+        assert len(result.summary_chunks) > 0
 
 
 class TestChunkText:
@@ -430,8 +430,8 @@ class TestConversationTexts:
     def test_default_values(self):
         from ohtv.analysis.embeddings import ConversationTexts
         texts = ConversationTexts()
-        assert texts.analysis_text is None
-        assert texts.summary_text is None
+        assert texts.analysis_chunks == []
+        assert texts.summary_chunks == []
         assert texts.content_chunks == []
 
 

--- a/tests/unit/analysis/test_text_builders.py
+++ b/tests/unit/analysis/test_text_builders.py
@@ -1,0 +1,290 @@
+"""Tests for text_builders.py - contextual chunk building and splitting."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from ohtv.analysis.embeddings.text_builders import (
+    ConversationMetadata,
+    MIN_CONTENT_SPACE,
+)
+
+
+class TestConversationMetadataBuildPreamble:
+    """Tests for ConversationMetadata.build_preamble()."""
+
+    def test_empty_metadata_returns_empty_string(self):
+        """Metadata with no fields returns empty preamble."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        assert meta.build_preamble() == ""
+
+    def test_with_date_only(self):
+        """Preamble includes formatted date."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            created_at=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+        )
+        preamble = meta.build_preamble()
+        assert "Date: 2026-04-19" in preamble
+        assert preamble.endswith("---\n")
+
+    def test_with_summary_only(self):
+        """Preamble includes summary."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary="Configure MCP secrets handling",
+        )
+        preamble = meta.build_preamble()
+        assert "Summary: Configure MCP secrets handling" in preamble
+
+    def test_with_refs_only(self):
+        """Preamble includes related refs."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            ref_fqns=["owner/repo#42", "owner/repo#38"],
+        )
+        preamble = meta.build_preamble()
+        assert "Related: owner/repo#42, owner/repo#38" in preamble
+
+    def test_long_summary_truncated(self):
+        """Summaries over 200 chars are truncated with ellipsis."""
+        long_summary = "A" * 250
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary=long_summary,
+        )
+        preamble = meta.build_preamble()
+        # Should be truncated to 200 chars + "..."
+        assert "A" * 200 + "..." in preamble
+        assert "A" * 201 not in preamble
+
+    def test_refs_limited_by_max_refs(self):
+        """Only max_refs refs are included."""
+        refs = [f"owner/repo#{i}" for i in range(10)]
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            ref_fqns=refs,
+        )
+        preamble = meta.build_preamble(max_refs=3)
+        assert "owner/repo#0" in preamble
+        assert "owner/repo#2" in preamble
+        assert "owner/repo#3" not in preamble
+
+    def test_full_preamble_format(self):
+        """Full preamble with all fields has correct format."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            created_at=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+            summary="Configure MCP secrets",
+            ref_fqns=["owner/repo#42"],
+        )
+        preamble = meta.build_preamble()
+        lines = preamble.split("\n")
+        assert lines[0] == "Date: 2026-04-19"
+        assert lines[1] == "Summary: Configure MCP secrets"
+        assert lines[2] == "Related: owner/repo#42"
+        assert lines[3] == "---"
+
+
+class TestConversationMetadataPrependToText:
+    """Tests for ConversationMetadata.prepend_to_text()."""
+
+    def test_short_content_no_preamble(self):
+        """Short content without preamble returns single chunk."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "Short content here"
+        chunks = meta.prepend_to_text(content, max_chars=3000)
+        assert len(chunks) == 1
+        assert chunks[0] == "Short content here"
+
+    def test_short_content_with_preamble(self):
+        """Short content with preamble returns single chunk with preamble prepended."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary="Test summary",
+        )
+        content = "Short content here"
+        chunks = meta.prepend_to_text(content, max_chars=3000)
+        assert len(chunks) == 1
+        assert "Summary: Test summary" in chunks[0]
+        assert "Short content here" in chunks[0]
+
+    def test_long_content_no_preamble_splits(self):
+        """Long content without preamble is split into chunks."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "word " * 1000  # ~5000 chars
+        chunks = meta.prepend_to_text(content, max_chars=500)
+        assert len(chunks) > 1
+        # All chunks should fit within max_chars
+        for chunk in chunks:
+            assert len(chunk) <= 500
+
+    def test_long_content_with_preamble_splits_with_preamble_each(self):
+        """Long content with preamble splits, and each chunk has preamble."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary="Test summary",
+        )
+        content = "word " * 1000  # ~5000 chars
+        chunks = meta.prepend_to_text(content, max_chars=500)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert "Summary: Test summary" in chunk
+            assert len(chunk) <= 500
+
+    def test_empty_content(self):
+        """Empty content returns empty list or list with preamble only."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary="Test",
+        )
+        chunks = meta.prepend_to_text("", max_chars=3000)
+        assert len(chunks) == 1
+        assert "Summary: Test" in chunks[0]
+
+    def test_whitespace_only_content(self):
+        """Whitespace-only content handled gracefully."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        chunks = meta.prepend_to_text("   ", max_chars=3000)
+        assert len(chunks) == 1
+        assert chunks[0] == "   "
+
+    def test_content_exactly_at_limit(self):
+        """Content exactly at max_chars limit returns single chunk."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "x" * 500
+        chunks = meta.prepend_to_text(content, max_chars=500)
+        assert len(chunks) == 1
+        assert chunks[0] == content
+
+    def test_preamble_plus_content_at_limit(self):
+        """Preamble + content at limit returns single chunk."""
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary="X",  # Minimal summary
+        )
+        preamble = meta.build_preamble()
+        content_len = 500 - len(preamble)
+        content = "x" * content_len
+        chunks = meta.prepend_to_text(content, max_chars=500)
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 500
+
+    def test_very_long_preamble_truncated(self):
+        """Very long preamble is truncated to allow MIN_CONTENT_SPACE for content."""
+        # Create a preamble that would exceed max_chars
+        long_refs = [f"owner/really-long-repository-name#{i:04d}" for i in range(100)]
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            created_at=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
+            summary="A" * 200,
+            ref_fqns=long_refs,
+        )
+        content = "Important content that must be preserved"
+        chunks = meta.prepend_to_text(content, max_chars=500, max_refs=100)
+        # Content should still appear
+        assert any("Important content" in chunk for chunk in chunks)
+
+
+class TestConversationMetadataSplitContent:
+    """Tests for ConversationMetadata._split_content()."""
+
+    def test_short_content_no_split(self):
+        """Content shorter than max_chars returns single piece."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        pieces = meta._split_content("short text", max_chars=100)
+        assert len(pieces) == 1
+        assert pieces[0] == "short text"
+
+    def test_split_creates_two_chunks(self):
+        """Content requiring 2 chunks is split correctly."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "a" * 150
+        pieces = meta._split_content(content, max_chars=100, overlap=20)
+        assert len(pieces) == 2
+        # First chunk is at max
+        assert len(pieces[0]) == 100
+        # Second chunk includes overlap
+        assert pieces[1].startswith("a" * 20)
+
+    def test_split_creates_multiple_chunks(self):
+        """Long content creates 3+ chunks."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "word " * 200  # ~1000 chars
+        pieces = meta._split_content(content, max_chars=300, overlap=50)
+        assert len(pieces) >= 3
+
+    def test_overlap_applied_correctly(self):
+        """Overlap ensures continuity between chunks."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "The quick brown fox jumps over the lazy dog. " * 10
+        pieces = meta._split_content(content, max_chars=100, overlap=30)
+        
+        # Check that end of chunk N overlaps with start of chunk N+1
+        for i in range(len(pieces) - 1):
+            # Last 30 chars of piece[i] should appear at start of piece[i+1]
+            # (approximately, due to word boundary logic)
+            end_of_current = pieces[i][-30:]
+            # The next piece should contain content that was in current piece
+            # This is an approximation test since word boundaries may shift things
+            assert len(pieces[i]) <= 100
+
+    def test_word_boundary_splitting(self):
+        """Split prefers breaking at word boundaries."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "word " * 50  # Many words
+        pieces = meta._split_content(content, max_chars=23, overlap=5)
+        # Each piece should not end mid-word (unless no space found)
+        for piece in pieces[:-1]:  # Last piece may be shorter
+            # Should end with a word or be exactly at limit
+            assert piece.endswith(" ") or len(piece) <= 23
+
+    def test_overlap_larger_than_content_handled(self):
+        """Gracefully handles edge case where overlap >= content length."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        content = "short"
+        pieces = meta._split_content(content, max_chars=10, overlap=20)
+        assert len(pieces) == 1
+        assert pieces[0] == "short"
+
+    def test_no_infinite_loop_on_edge_cases(self):
+        """Ensure no infinite loop with pathological inputs."""
+        meta = ConversationMetadata(conversation_id="abc123")
+        # Very small max_chars
+        content = "This is some content"
+        pieces = meta._split_content(content, max_chars=5, overlap=2)
+        # Should terminate and produce output
+        assert len(pieces) > 0
+        # Combined pieces should cover the content
+        combined = "".join(pieces)
+        assert "This" in combined
+
+
+class TestMinContentSpaceConstant:
+    """Tests verifying MIN_CONTENT_SPACE is used correctly."""
+
+    def test_constant_value(self):
+        """MIN_CONTENT_SPACE has expected value."""
+        assert MIN_CONTENT_SPACE == 100
+
+    def test_used_in_prepend_logic(self):
+        """MIN_CONTENT_SPACE is respected in prepend_to_text."""
+        # Create metadata with preamble that leaves < MIN_CONTENT_SPACE
+        meta = ConversationMetadata(
+            conversation_id="abc123",
+            summary="A" * 200,
+            ref_fqns=["owner/repo#" + str(i) for i in range(10)],
+        )
+        preamble = meta.build_preamble()
+        # Set max_chars so that available = max_chars - preamble < MIN_CONTENT_SPACE
+        # This should trigger the truncation logic
+        max_chars = len(preamble) + 50  # Only 50 chars left for content
+        
+        content = "Important content"
+        chunks = meta.prepend_to_text(content, max_chars=max_chars)
+        
+        # Should still produce output with content
+        assert len(chunks) >= 1
+        # Content should be present somewhere
+        full_text = "".join(chunks)
+        assert "Important content" in full_text


### PR DESCRIPTION
## Problem

When using `ohtv ask`, the RAG system finds relevant conversations but provides poor citations:

- **No clickable URLs** to cloud conversations  
- **No conversation dates** (making it hard to know if info is current)
- **No summaries** in citations (just truncated IDs)
- **Ambiguous references** - the LLM might say "#42" without context about which repo
- **No "See Also" section** aggregating related PRs/issues/repos from source conversations

**Example before this PR:**
```
Sources (2 conversations):
  • [4403c7fb] Configure MCP secrets handling...
```

## Solution

This PR enhances the RAG citation system comprehensively:

1. **Richer LLM context** - Feed the LLM more metadata (dates, summaries, fully-qualified refs) so it can cite sources naturally and accurately
2. **Better retrieval** - Prepend contextual preambles to chunks before embedding (Anthropic's ["contextual retrieval"](https://www.anthropic.com/news/contextual-retrieval) technique)
3. **Enhanced CLI output** - Display dates, summaries, cloud URLs, and a "See Also" section
4. **Automatic pipeline** - `ohtv sync` now generates summaries and embeddings automatically
5. **Robust parallel processing** - Single-writer pattern eliminates SQLite locking; global rate limiter coordinates backoff across threads

## What's New

### 1. Improved Citation Output

```
Sources (2 conversations):
• [4403c7fb] Configure MCP secrets handling (2026-04-19)
  User wanted to configure MCP secrets handling for the plugin system.
  https://app.all-hands.dev/conversations/4403c7fb01ac40b0b4a6fc727314c7c2

See Also:
  Pull Requests:
  • jpshackelford/ohtv #42
  Issues:
  • jpshackelford/ohtv #38
```

### 2. Better LLM Responses

The LLM now receives:
- Conversation dates (enables "In the conversation from 3 days ago...")
- Summaries (helps LLM understand each source at a glance)  
- Fully-qualified refs (`jpshackelford/ohtv#42` instead of just `#42`)

### 3. Smarter Retrieval

Content chunks are now embedded with contextual preambles:
```
Date: 2026-04-19
Summary: Configure MCP secrets handling
Related: PR jpshackelford/ohtv#23, Issue jpshackelford/ohtv#42
---
[actual chunk content]
```

This improves retrieval when queries reference specific dates, PRs, or issues.

### 4. Automatic Pipeline

`ohtv sync` now automatically keeps everything up to date:
- Indexes conversations and runs processing stages
- Generates LLM analysis and extracts summaries
- Generates embeddings with contextual preambles

New options to control this:
- `--no-llm` - Skip LLM analysis (saves API costs)
- `--no-embed` - Skip embedding generation

### 5. Robust Parallel Processing

**Single-writer pattern for SQLite:**
- Multiple worker threads generate embeddings (parallel API calls)
- A single writer thread batches and commits to the database
- Eliminates "database is locked" errors under high concurrency

**Global rate limiter:**
- When any thread hits rate limits (429) or server errors (500-599), all threads back off together
- Exponential backoff with jitter (1s, 2s, 4s... up to 30s max)
- Max 5 retries before giving up
- Automatic reset on success
- Prevents thundering herd problem with Ollama and cloud APIs

## How to Test

```bash
# Just sync - everything happens automatically
ohtv sync

# Or with options to skip expensive operations
ohtv sync --no-llm    # Skip LLM analysis
ohtv sync --no-embed  # Skip embeddings

# Ask questions and observe enhanced citations
ohtv ask "help me find the PR discussion about mcp configuration"
ohtv ask "what did we discuss about authentication last week?"

# Test embedding with many conversations (rate limiter in action)
ohtv db embed --force
```

**What to look for:**
- Citations show conversation dates and summaries
- Cloud URLs appear for recent conversations (within 14-day retention)
- "See Also" section shows related PRs, issues, and repos
- LLM uses natural date references ("In the conversation from 3 days ago...")
- No SQLite locking errors during embedding
- Graceful handling of rate limits / 500 errors with Ollama

## For Existing Users

For existing databases, run sync once to backfill summaries and embeddings:

```bash
ohtv sync
```

This will:
1. Generate LLM analysis for conversations without it
2. Extract summaries into the database
3. Generate embeddings with contextual preambles

If you want to regenerate embeddings for conversations that already have them (to add contextual preambles):
```bash
ohtv db embed --force
```

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Contextual preambles in embeddings | Improves retrieval accuracy for date/ref-specific queries (per Anthropic research) |
| Summary stored in `conversations` table | Fast retrieval without reading JSON files; enables display and embedding enrichment |
| 14-day retention check for cloud URLs | Avoids displaying broken links for expired conversations |
| Refs limited to 5-7 in preambles | Prevents embedding bloat while maintaining relevance |
| Auto-generate during sync | Users don't need to remember a multi-step pipeline |
| Single-writer for embeddings | Eliminates SQLite locking while keeping parallel API calls |
| Global rate limiter | Coordinates backoff across all threads, prevents thundering herd |

## Architecture

```
                                ┌─────────────────────┐
                                │    ohtv sync        │
                                └──────────┬──────────┘
                                           │
                        ┌──────────────────┼──────────────────┐
                        │                  │                  │
                        ▼                  ▼                  ▼
                 ┌──────────┐      ┌──────────────┐    ┌────────────┐
                 │ Download │      │ LLM Analysis │    │ Embeddings │
                 │  Convos  │      │  (summaries) │    │            │
                 └──────────┘      └──────────────┘    └──────┬─────┘
                                                              │
                                          ┌───────────────────┼───────────────────┐
                                          │                   │                   │
                                          ▼                   ▼                   ▼
                                   ┌────────────┐      ┌────────────┐      ┌────────────┐
                                   │  Worker 1  │      │  Worker 2  │      │  Worker N  │
                                   │ (API call) │      │ (API call) │      │ (API call) │
                                   └─────┬──────┘      └─────┬──────┘      └─────┬──────┘
                                         │                   │                   │
                                         │    ┌──────────────┴──────────────┐    │
                                         │    │    GlobalRateLimiter        │    │
                                         │    │  (coordinates backoff)      │    │
                                         │    └──────────────┬──────────────┘    │
                                         │                   │                   │
                                         ▼                   ▼                   ▼
                                   ┌─────────────────────────────────────────────────┐
                                   │              Write Queue                        │
                                   └─────────────────────────┬───────────────────────┘
                                                             │
                                                             ▼
                                                   ┌─────────────────┐
                                                   │ EmbeddingWriter │
                                                   │  (single thread)│
                                                   │ batched commits │
                                                   └────────┬────────┘
                                                            │
                                                            ▼
                                                   ┌─────────────────┐
                                                   │    SQLite DB    │
                                                   └─────────────────┘
```

## Database Migration

**Migration 009** adds a `summary` column to the `conversations` table. This runs automatically on first use.

## Files Changed

- `src/ohtv/analysis/rag.py` - Enhanced `RAGAnswerer` with ref stores, rich context, and new dataclasses
- `src/ohtv/analysis/embeddings/text_builders.py` - `ConversationMetadata` for contextual preambles
- `src/ohtv/analysis/embeddings/client.py` - `GlobalRateLimiter` for coordinated backoff
- `src/ohtv/analysis/embeddings/operations.py` - `EmbeddingWriter` for batched DB writes, `generate_embeddings_only()` for parallel generation
- `src/ohtv/cli.py` - Enhanced sync with `--no-llm`/`--no-embed`, single-writer embed pattern
- `src/ohtv/db/stages/summaries.py` - New processing stage for summary extraction
- `docs/DESIGN_RAG_CITATIONS.md` - Design documentation

Closes #32

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._