### PR TITLE
Add --explain flag to ask command for RAG retrieval debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ ohtv search "fix authentication bugs"
 # Ask questions about your conversations (RAG)
 ohtv ask "how did we fix the auth bug?"
 
+# Debug RAG retrieval quality
+ohtv ask "api changes" --explain            # Show retrieval breakdown + answer
+ohtv ask "api changes" --explain-only       # Retrieval only (no LLM_API_KEY needed)
+
 # Deep investigation with agent mode
 ohtv ask "explain the auth fix in detail" --agent
 
@@ -1125,6 +1129,15 @@ ohtv ask "explain the auth fix in detail" --agent
 
 # Investigation with more steps for complex questions
 ohtv ask "what went wrong with the deployment?" --agent --max-steps 10
+
+# Debug retrieval quality (show which conversations match)
+ohtv ask "api changes" --explain
+
+# Retrieval debugging only (no LLM answer, no LLM_API_KEY needed)
+ohtv ask "api changes" --explain-only
+
+# Combine with date filters
+ohtv ask "what did we work on yesterday?" --explain --since 7d
 ```
 
 **Example Output:**
@@ -1157,11 +1170,67 @@ Search: 0.15s | Generation: 2.34s | Model: openai/gpt-4o-mini
 | `-s, --min-score N` | Minimum similarity score 0-1 (default: 0.3) |
 | `-m, --model MODEL` | LLM model for answer generation |
 | `--show-context` | Show retrieved context chunks |
+| `--explain` | Show retrieval breakdown before answer (see below) |
+| `--explain-only` | Show retrieval breakdown only, skip LLM answer (no `LLM_API_KEY` needed) |
 | `--agent` | Enable multi-turn investigation mode (see below) |
 | `--max-steps N` | Maximum investigation steps with `--agent` (default: 5) |
+| `-S, --since DATE` | Filter by date (YYYY-MM-DD or relative like `7d`, `2w`) |
+| `-U, --until DATE` | Filter by date (YYYY-MM-DD) |
+| `--no-temporal` | Disable automatic temporal extraction from question |
 | `-v, --verbose` | Show debug output |
 
 **Note:** Requires embeddings. Run `ohtv db embed` first.
+
+#### Retrieval Debugging (`--explain`)
+
+The `--explain` flag shows a per-conversation breakdown of retrieved chunks before the LLM answer, helping diagnose RAG retrieval quality.
+
+```bash
+$ ohtv ask "how do embeddings work?" --explain
+
+Query: how do embeddings work?
+Retrieved 50 chunks from 19 conversations
+📅 Auto-filtered: 2024-04-15 to 2024-04-22
+
+b3af77ff (2024-04-22) "Clarify RAG implementation..."
+  analysis    2 chunks   0.723-0.718
+  summary     1 chunk    0.695
+  content     5 chunks   0.701-0.668
+
+76230e77 (2024-04-21) "Fix embedding functionality..."
+  analysis    1 chunk    0.712
+  content    22 chunks   0.698-0.667
+
+238de50e (2024-04-21) "Draft GitHub issue for..."
+  summary     1 chunk    0.682
+  ...
+
+Search time: 0.23s
+
+Generating answer...
+[Answer follows]
+```
+
+The breakdown shows:
+- **Chunks grouped by conversation** - Each conversation displays its ID (truncated), date, and title
+- **Embed types** - `analysis` (goal/outcomes), `summary` (user messages/refs), `content` (file contents)
+- **Chunk counts** - How many chunks matched from each type
+- **Score ranges** - Similarity scores (higher = better match, 0-1 scale)
+- **Conversations sorted by best score** - Most relevant conversations first
+- **Temporal filter info** - Shows if auto or explicit date filtering was applied
+
+**Use `--explain-only` for retrieval-only debugging:**
+
+```bash
+# Skip LLM answer, just see retrieval (no LLM_API_KEY needed)
+$ ohtv ask "api changes" --explain-only
+```
+
+This is useful for:
+- **Diagnosing retrieval quality** - Are the right conversations being found?
+- **Tuning chunking parameters** - Is content over-fragmented?
+- **Identifying noisy conversations** - Some may flood results with low-quality matches
+- **Comparing embedding types** - Which types work best for different query types?
 
 #### Investigation Mode (`--agent`)
 

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -149,6 +149,114 @@ class RAGAnswer:
     cost: float = 0.0  # Estimated cost in USD
 
 
+# --- Shared helper functions for RAGRetriever and RAGAnswerer ---
+
+
+def _get_cloud_url(cloud_base_url: str, conversation_id: str) -> str:
+    """Generate the cloud URL for a conversation."""
+    return f"{cloud_base_url}/conversations/{conversation_id}"
+
+
+def _get_conversation_source(
+    conversation_id: str,
+    conv_store,
+    link_store,
+    ref_store,
+    repo_store,
+    cloud_base_url: str,
+) -> ConversationSource | None:
+    """Get full source information including refs for a conversation."""
+    if not all([link_store, ref_store, repo_store]):
+        return None
+
+    try:
+        conv = conv_store.get(conversation_id)
+        title = conv.title if conv and conv.title else f"Conversation {conversation_id[:8]}"
+        created_at = conv.created_at if conv else None
+        summary = conv.summary if conv else None
+        conv_source = conv.source if conv else "local"
+
+        repos = []
+        for repo_id, link_type in link_store.get_repos_for_conversation(conversation_id):
+            repo = repo_store.get_by_id(repo_id)
+            if repo:
+                repos.append(RepoInfo(
+                    url=repo.canonical_url,
+                    fqn=repo.fqn,
+                    short_name=repo.short_name,
+                    link_type=link_type.value,
+                ))
+
+        prs = []
+        issues = []
+        for ref_id, link_type in link_store.get_refs_for_conversation(conversation_id):
+            ref = ref_store.get_by_id(ref_id)
+            if ref:
+                ref_info = RefInfo(
+                    ref_type=ref.ref_type.value,
+                    url=ref.url,
+                    fqn=ref.fqn,
+                    display_name=ref.display_name,
+                    link_type=link_type.value,
+                )
+                if ref.ref_type.value == "pr":
+                    prs.append(ref_info)
+                elif ref.ref_type.value == "issue":
+                    issues.append(ref_info)
+
+        return ConversationSource(
+            conversation_id=conversation_id,
+            title=title,
+            summary=summary,
+            source=conv_source or "local",
+            cloud_url=_get_cloud_url(cloud_base_url, conversation_id),
+            created_at=created_at,
+            repos=repos,
+            prs=prs,
+            issues=issues,
+        )
+    except Exception as e:
+        log.debug("Error getting source info for %s: %s", conversation_id, e)
+        return None
+
+
+def _results_to_context_chunks(
+    results,
+    conv_store,
+    link_store,
+    ref_store,
+    repo_store,
+    cloud_base_url: str,
+) -> list[ContextChunk]:
+    """Convert embedding search results to ContextChunk objects with full metadata."""
+    chunks = []
+    for r in results:
+        conv = conv_store.get(r.conversation_id)
+        title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
+        created_at = conv.created_at if conv else None
+        summary = conv.summary if conv else None
+        conv_source = conv.source if conv else "local"
+        source = _get_conversation_source(
+            r.conversation_id, conv_store, link_store, ref_store, repo_store, cloud_base_url
+        )
+        cloud_url = _get_cloud_url(cloud_base_url, r.conversation_id)
+
+        chunks.append(ContextChunk(
+            conversation_id=r.conversation_id,
+            title=title,
+            embed_type=r.embed_type,
+            source_text=r.source_text,
+            score=r.score,
+            chunk_index=r.chunk_index,
+            summary=summary,
+            cloud_url=cloud_url,
+            created_at=created_at,
+            conv_source=conv_source or "local",
+            source=source,
+        ))
+    return chunks
+
+
 class RAGRetriever:
     """Retrieves relevant context without LLM generation.
 
@@ -230,7 +338,10 @@ class RAGRetriever:
             end_date=end_date,
         )
 
-        context_chunks = self._results_to_context_chunks(results)
+        context_chunks = _results_to_context_chunks(
+            results, self.conv_store, self.link_store, self.ref_store,
+            self.repo_store, self.cloud_base_url
+        )
 
         search_time = time.perf_counter() - start_time
 
@@ -246,7 +357,10 @@ class RAGRetriever:
                     start_date=None,
                     end_date=None,
                 )
-                context_chunks = self._results_to_context_chunks(results)
+                context_chunks = _results_to_context_chunks(
+                    results, self.conv_store, self.link_store, self.ref_store,
+                    self.repo_store, self.cloud_base_url
+                )
                 search_time += time.perf_counter() - start_time
                 if context_chunks:
                     temporal_applied = False
@@ -265,90 +379,6 @@ class RAGRetriever:
             temporal_filter_applied=temporal_applied,
             date_range=(start_date, end_date) if temporal_applied else None,
         )
-
-    def _results_to_context_chunks(self, results) -> list[ContextChunk]:
-        """Convert embedding search results to ContextChunk objects with full metadata."""
-        chunks = []
-        for r in results:
-            conv = self.conv_store.get(r.conversation_id)
-            title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
-            created_at = conv.created_at if conv else None
-            summary = conv.summary if conv else None
-            conv_source = conv.source if conv else "local"
-            source = self._get_conversation_source(r.conversation_id)
-            cloud_url = self._get_cloud_url(r.conversation_id)
-
-            chunks.append(ContextChunk(
-                conversation_id=r.conversation_id,
-                title=title,
-                embed_type=r.embed_type,
-                source_text=r.source_text,
-                score=r.score,
-                chunk_index=r.chunk_index,
-                summary=summary,
-                cloud_url=cloud_url,
-                created_at=created_at,
-                conv_source=conv_source or "local",
-                source=source,
-            ))
-        return chunks
-
-    def _get_cloud_url(self, conversation_id: str) -> str:
-        return f"{self.cloud_base_url}/conversations/{conversation_id}"
-
-    def _get_conversation_source(self, conversation_id: str) -> ConversationSource | None:
-        if not all([self.link_store, self.ref_store, self.repo_store]):
-            return None
-
-        try:
-            conv = self.conv_store.get(conversation_id)
-            title = conv.title if conv and conv.title else f"Conversation {conversation_id[:8]}"
-            created_at = conv.created_at if conv else None
-            summary = conv.summary if conv else None
-            conv_source = conv.source if conv else "local"
-
-            repos = []
-            for repo_id, link_type in self.link_store.get_repos_for_conversation(conversation_id):
-                repo = self.repo_store.get_by_id(repo_id)
-                if repo:
-                    repos.append(RepoInfo(
-                        url=repo.canonical_url,
-                        fqn=repo.fqn,
-                        short_name=repo.short_name,
-                        link_type=link_type.value,
-                    ))
-
-            prs = []
-            issues = []
-            for ref_id, link_type in self.link_store.get_refs_for_conversation(conversation_id):
-                ref = self.ref_store.get_by_id(ref_id)
-                if ref:
-                    ref_info = RefInfo(
-                        ref_type=ref.ref_type.value,
-                        url=ref.url,
-                        fqn=ref.fqn,
-                        display_name=ref.display_name,
-                        link_type=link_type.value,
-                    )
-                    if ref.ref_type.value == "pr":
-                        prs.append(ref_info)
-                    elif ref.ref_type.value == "issue":
-                        issues.append(ref_info)
-
-            return ConversationSource(
-                conversation_id=conversation_id,
-                title=title,
-                summary=summary,
-                source=conv_source or "local",
-                cloud_url=self._get_cloud_url(conversation_id),
-                created_at=created_at,
-                repos=repos,
-                prs=prs,
-                issues=issues,
-            )
-        except Exception as e:
-            log.debug("Error getting source info for %s: %s", conversation_id, e)
-            return None
 
 
 class RAGAnswerer:
@@ -530,12 +560,10 @@ class RAGAnswerer:
     ) -> list[ContextChunk]:
         """Retrieve relevant context chunks for a question with full metadata."""
         from ohtv.analysis.embeddings import get_embedding
-        
-        # Embed the question
+
         query_result = get_embedding(question)
         query_embedding = query_result.embedding
-        
-        # Search for relevant context with optional date filter
+
         results = self.embed_store.get_context_for_rag(
             query_embedding,
             max_chunks=max_chunks,
@@ -543,103 +571,18 @@ class RAGAnswerer:
             start_date=start_date,
             end_date=end_date,
         )
-        
-        # Convert to ContextChunk with full metadata
-        chunks = []
-        for r in results:
-            conv = self.conv_store.get(r.conversation_id)
-            title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
-            created_at = conv.created_at if conv else None
-            summary = conv.summary if conv else None
-            conv_source = conv.source if conv else "local"
-            
-            # Get source info with refs
-            source = self._get_conversation_source(r.conversation_id)
-            cloud_url = self._get_cloud_url(r.conversation_id)
-            
-            chunks.append(ContextChunk(
-                conversation_id=r.conversation_id,
-                title=title,
-                embed_type=r.embed_type,
-                source_text=r.source_text,
-                score=r.score,
-                chunk_index=r.chunk_index,
-                summary=summary,
-                cloud_url=cloud_url,
-                created_at=created_at,
-                conv_source=conv_source or "local",
-                source=source,
-            ))
-        
+
+        chunks = _results_to_context_chunks(
+            results, self.conv_store, self.link_store, self.ref_store,
+            self.repo_store, self.cloud_base_url
+        )
+
         # Sort chunks: group by conversation, then by embed_type, then by chunk_index
         # This ensures the LLM sees coherent context from each conversation
         chunks.sort(key=lambda c: (c.conversation_id, c.embed_type, c.chunk_index))
-        
+
         return chunks
-    
-    def _get_cloud_url(self, conversation_id: str) -> str:
-        """Generate the cloud URL for a conversation."""
-        return f"{self.cloud_base_url}/conversations/{conversation_id}"
-    
-    def _get_conversation_source(self, conversation_id: str) -> ConversationSource | None:
-        """Get full source information including refs for a conversation."""
-        if not all([self.link_store, self.ref_store, self.repo_store]):
-            return None
-        
-        try:
-            # Get conversation metadata
-            conv = self.conv_store.get(conversation_id)
-            title = conv.title if conv and conv.title else f"Conversation {conversation_id[:8]}"
-            created_at = conv.created_at if conv else None
-            summary = conv.summary if conv else None
-            conv_source = conv.source if conv else "local"
-            
-            # Get repos
-            repos = []
-            for repo_id, link_type in self.link_store.get_repos_for_conversation(conversation_id):
-                repo = self.repo_store.get_by_id(repo_id)
-                if repo:
-                    repos.append(RepoInfo(
-                        url=repo.canonical_url,
-                        fqn=repo.fqn,
-                        short_name=repo.short_name,
-                        link_type=link_type.value,
-                    ))
-            
-            # Get PRs and issues
-            prs = []
-            issues = []
-            for ref_id, link_type in self.link_store.get_refs_for_conversation(conversation_id):
-                ref = self.ref_store.get_by_id(ref_id)
-                if ref:
-                    ref_info = RefInfo(
-                        ref_type=ref.ref_type.value,
-                        url=ref.url,
-                        fqn=ref.fqn,
-                        display_name=ref.display_name,
-                        link_type=link_type.value,
-                    )
-                    if ref.ref_type.value == "pr":
-                        prs.append(ref_info)
-                    elif ref.ref_type.value == "issue":
-                        issues.append(ref_info)
-                    # Skip branches and other ref types for now
-            
-            return ConversationSource(
-                conversation_id=conversation_id,
-                title=title,
-                summary=summary,
-                source=conv_source or "local",
-                cloud_url=self._get_cloud_url(conversation_id),
-                created_at=created_at,
-                repos=repos,
-                prs=prs,
-                issues=issues,
-            )
-        except Exception as e:
-            log.debug("Error getting source info for %s: %s", conversation_id, e)
-            return None
-    
+
     def _generate_answer(
         self,
         question: str,

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -119,6 +119,16 @@ class ContextChunk:
 
 
 @dataclass
+class RAGRetrievalResult:
+    """Result of retrieval-only (no LLM generation)."""
+    context_chunks: list[ContextChunk]
+    source_conversation_ids: set[str]
+    search_time_seconds: float
+    temporal_filter_applied: bool = False
+    date_range: tuple[datetime | None, datetime | None] | None = None
+
+
+@dataclass
 class RAGAnswer:
     """Result of a RAG query."""
     answer: str
@@ -137,6 +147,227 @@ class RAGAnswer:
     context_tokens: int = 0
     total_tokens: int = 0  # Context + question + system prompt
     cost: float = 0.0  # Estimated cost in USD
+
+
+class RAGRetriever:
+    """Retrieves relevant context without LLM generation.
+
+    For retrieval-only operations (debugging, explain mode) that
+    don't need LLM_API_KEY.
+    """
+
+    def __init__(
+        self,
+        embed_store,
+        conv_store,
+        enable_temporal_filter: bool = True,
+        link_store=None,
+        ref_store=None,
+        repo_store=None,
+        cloud_base_url: str | None = None,
+    ):
+        self.embed_store = embed_store
+        self.conv_store = conv_store
+        self.enable_temporal_filter = enable_temporal_filter
+        self.link_store = link_store
+        self.ref_store = ref_store
+        self.repo_store = repo_store
+        self.cloud_base_url = cloud_base_url or os.environ.get(
+            "OHTV_CLOUD_API_URL", "https://app.all-hands.dev"
+        )
+
+    def retrieve(
+        self,
+        question: str,
+        max_context_chunks: int = 5,
+        min_score: float = 0.3,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> RAGRetrievalResult:
+        """Retrieve relevant context chunks without LLM generation.
+
+        Args:
+            question: The question/query for retrieval
+            max_context_chunks: Maximum number of context chunks to retrieve
+            min_score: Minimum similarity score for context (0-1)
+            start_date: Only include conversations from this date
+            end_date: Only include conversations until this date
+
+        Returns:
+            RAGRetrievalResult with retrieved chunks and metadata
+        """
+        import time
+        from ohtv.analysis.embeddings import get_embedding
+
+        # Extract temporal filter if enabled and no explicit dates provided
+        temporal_applied = False
+        search_query = question
+
+        if self.enable_temporal_filter and start_date is None and end_date is None:
+            from ohtv.analysis.temporal import extract_temporal_filter
+            temporal = extract_temporal_filter(question)
+            if temporal.has_temporal_intent:
+                start_date = temporal.start_date
+                end_date = temporal.end_date
+                search_query = temporal.cleaned_query
+                temporal_applied = True
+                log.debug(
+                    "Temporal filter extracted: %s to %s, query: %s",
+                    start_date, end_date, search_query
+                )
+
+        # Retrieve context
+        start_time = time.perf_counter()
+
+        query_result = get_embedding(search_query)
+        query_embedding = query_result.embedding
+
+        results = self.embed_store.get_context_for_rag(
+            query_embedding,
+            max_chunks=max_context_chunks,
+            min_score=min_score,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        # Convert to ContextChunk with full metadata
+        context_chunks = []
+        for r in results:
+            conv = self.conv_store.get(r.conversation_id)
+            title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
+            created_at = conv.created_at if conv else None
+            summary = conv.summary if conv else None
+            conv_source = conv.source if conv else "local"
+
+            # Get source info with refs
+            source = self._get_conversation_source(r.conversation_id)
+            cloud_url = self._get_cloud_url(r.conversation_id)
+
+            context_chunks.append(ContextChunk(
+                conversation_id=r.conversation_id,
+                title=title,
+                embed_type=r.embed_type,
+                source_text=r.source_text,
+                score=r.score,
+                chunk_index=r.chunk_index,
+                summary=summary,
+                cloud_url=cloud_url,
+                created_at=created_at,
+                conv_source=conv_source or "local",
+                source=source,
+            ))
+
+        search_time = time.perf_counter() - start_time
+
+        if not context_chunks:
+            # If temporal filter found nothing, try without filter
+            if temporal_applied:
+                log.debug("No results with temporal filter, retrying without filter")
+                start_time = time.perf_counter()
+                results = self.embed_store.get_context_for_rag(
+                    query_embedding,
+                    max_chunks=max_context_chunks,
+                    min_score=min_score,
+                    start_date=None,
+                    end_date=None,
+                )
+                for r in results:
+                    conv = self.conv_store.get(r.conversation_id)
+                    title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
+                    created_at = conv.created_at if conv else None
+                    summary = conv.summary if conv else None
+                    conv_source = conv.source if conv else "local"
+                    source = self._get_conversation_source(r.conversation_id)
+                    cloud_url = self._get_cloud_url(r.conversation_id)
+
+                    context_chunks.append(ContextChunk(
+                        conversation_id=r.conversation_id,
+                        title=title,
+                        embed_type=r.embed_type,
+                        source_text=r.source_text,
+                        score=r.score,
+                        chunk_index=r.chunk_index,
+                        summary=summary,
+                        cloud_url=cloud_url,
+                        created_at=created_at,
+                        conv_source=conv_source or "local",
+                        source=source,
+                    ))
+                search_time += time.perf_counter() - start_time
+                if context_chunks:
+                    temporal_applied = False
+                    start_date = None
+                    end_date = None
+
+        # Sort chunks: group by conversation, then by embed_type, then by chunk_index
+        context_chunks.sort(key=lambda c: (c.conversation_id, c.embed_type, c.chunk_index))
+
+        source_ids = {c.conversation_id for c in context_chunks}
+
+        return RAGRetrievalResult(
+            context_chunks=context_chunks,
+            source_conversation_ids=source_ids,
+            search_time_seconds=search_time,
+            temporal_filter_applied=temporal_applied,
+            date_range=(start_date, end_date) if temporal_applied else None,
+        )
+
+    def _get_cloud_url(self, conversation_id: str) -> str:
+        return f"{self.cloud_base_url}/conversations/{conversation_id}"
+
+    def _get_conversation_source(self, conversation_id: str) -> ConversationSource | None:
+        if not all([self.link_store, self.ref_store, self.repo_store]):
+            return None
+
+        try:
+            conv = self.conv_store.get(conversation_id)
+            title = conv.title if conv and conv.title else f"Conversation {conversation_id[:8]}"
+            created_at = conv.created_at if conv else None
+            summary = conv.summary if conv else None
+            conv_source = conv.source if conv else "local"
+
+            repos = []
+            for repo_id, link_type in self.link_store.get_repos_for_conversation(conversation_id):
+                repo = self.repo_store.get_by_id(repo_id)
+                if repo:
+                    repos.append(RepoInfo(
+                        url=repo.canonical_url,
+                        fqn=repo.fqn,
+                        short_name=repo.short_name,
+                        link_type=link_type.value,
+                    ))
+
+            prs = []
+            issues = []
+            for ref_id, link_type in self.link_store.get_refs_for_conversation(conversation_id):
+                ref = self.ref_store.get_by_id(ref_id)
+                if ref:
+                    ref_info = RefInfo(
+                        ref_type=ref.ref_type.value,
+                        url=ref.url,
+                        fqn=ref.fqn,
+                        display_name=ref.display_name,
+                        link_type=link_type.value,
+                    )
+                    if ref.ref_type.value == "pr":
+                        prs.append(ref_info)
+                    elif ref.ref_type.value == "issue":
+                        issues.append(ref_info)
+
+            return ConversationSource(
+                conversation_id=conversation_id,
+                title=title,
+                summary=summary,
+                source=conv_source or "local",
+                cloud_url=self._get_cloud_url(conversation_id),
+                created_at=created_at,
+                repos=repos,
+                prs=prs,
+                issues=issues,
+            )
+        except Exception as e:
+            log.debug("Error getting source info for %s: %s", conversation_id, e)
+            return None
 
 
 class RAGAnswerer:

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -230,32 +230,7 @@ class RAGRetriever:
             end_date=end_date,
         )
 
-        # Convert to ContextChunk with full metadata
-        context_chunks = []
-        for r in results:
-            conv = self.conv_store.get(r.conversation_id)
-            title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
-            created_at = conv.created_at if conv else None
-            summary = conv.summary if conv else None
-            conv_source = conv.source if conv else "local"
-
-            # Get source info with refs
-            source = self._get_conversation_source(r.conversation_id)
-            cloud_url = self._get_cloud_url(r.conversation_id)
-
-            context_chunks.append(ContextChunk(
-                conversation_id=r.conversation_id,
-                title=title,
-                embed_type=r.embed_type,
-                source_text=r.source_text,
-                score=r.score,
-                chunk_index=r.chunk_index,
-                summary=summary,
-                cloud_url=cloud_url,
-                created_at=created_at,
-                conv_source=conv_source or "local",
-                source=source,
-            ))
+        context_chunks = self._results_to_context_chunks(results)
 
         search_time = time.perf_counter() - start_time
 
@@ -271,28 +246,7 @@ class RAGRetriever:
                     start_date=None,
                     end_date=None,
                 )
-                for r in results:
-                    conv = self.conv_store.get(r.conversation_id)
-                    title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
-                    created_at = conv.created_at if conv else None
-                    summary = conv.summary if conv else None
-                    conv_source = conv.source if conv else "local"
-                    source = self._get_conversation_source(r.conversation_id)
-                    cloud_url = self._get_cloud_url(r.conversation_id)
-
-                    context_chunks.append(ContextChunk(
-                        conversation_id=r.conversation_id,
-                        title=title,
-                        embed_type=r.embed_type,
-                        source_text=r.source_text,
-                        score=r.score,
-                        chunk_index=r.chunk_index,
-                        summary=summary,
-                        cloud_url=cloud_url,
-                        created_at=created_at,
-                        conv_source=conv_source or "local",
-                        source=source,
-                    ))
+                context_chunks = self._results_to_context_chunks(results)
                 search_time += time.perf_counter() - start_time
                 if context_chunks:
                     temporal_applied = False
@@ -311,6 +265,33 @@ class RAGRetriever:
             temporal_filter_applied=temporal_applied,
             date_range=(start_date, end_date) if temporal_applied else None,
         )
+
+    def _results_to_context_chunks(self, results) -> list[ContextChunk]:
+        """Convert embedding search results to ContextChunk objects with full metadata."""
+        chunks = []
+        for r in results:
+            conv = self.conv_store.get(r.conversation_id)
+            title = conv.title if conv and conv.title else f"Conversation {r.conversation_id[:8]}"
+            created_at = conv.created_at if conv else None
+            summary = conv.summary if conv else None
+            conv_source = conv.source if conv else "local"
+            source = self._get_conversation_source(r.conversation_id)
+            cloud_url = self._get_cloud_url(r.conversation_id)
+
+            chunks.append(ContextChunk(
+                conversation_id=r.conversation_id,
+                title=title,
+                embed_type=r.embed_type,
+                source_text=r.source_text,
+                score=r.score,
+                chunk_index=r.chunk_index,
+                summary=summary,
+                cloud_url=cloud_url,
+                created_at=created_at,
+                conv_source=conv_source or "local",
+                source=source,
+            ))
+        return chunks
 
     def _get_cloud_url(self, conversation_id: str) -> str:
         return f"{self.cloud_base_url}/conversations/{conversation_id}"

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -2541,6 +2541,125 @@ def _print_search_json(
     print(json.dumps(output, indent=2))
 
 
+def _display_retrieval_breakdown(
+    question: str,
+    chunks: list,
+    search_time: float,
+    temporal_applied: bool,
+    date_range: tuple | None,
+    explicit_start: datetime | None,
+    explicit_end: datetime | None,
+) -> None:
+    """Display RAG retrieval breakdown grouped by conversation and embed type.
+
+    Shows per-conversation breakdown with chunk counts and score ranges for each
+    embedding type (analysis, summary, content). Helps diagnose retrieval quality.
+    """
+    from collections import defaultdict
+
+    if not chunks:
+        console.print("[yellow]No relevant context found.[/yellow]")
+        return
+
+    # Count unique conversations
+    conv_ids = {c.conversation_id for c in chunks}
+
+    console.print(f"\n[bold]Query:[/bold] {question}")
+    console.print(f"[dim]Retrieved {len(chunks)} chunks from {len(conv_ids)} conversations[/dim]")
+
+    # Show temporal filter info
+    if temporal_applied and date_range:
+        start, end = date_range
+        if start and end:
+            console.print(f"[dim]📅 Auto-filtered: {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}[/dim]")
+        elif start:
+            console.print(f"[dim]📅 Auto-filtered: from {start.strftime('%Y-%m-%d')}[/dim]")
+        elif end:
+            console.print(f"[dim]📅 Auto-filtered: until {end.strftime('%Y-%m-%d')}[/dim]")
+    elif explicit_start or explicit_end:
+        if explicit_start and explicit_end:
+            console.print(f"[dim]📅 Explicit filter: {explicit_start.strftime('%Y-%m-%d')} to {explicit_end.strftime('%Y-%m-%d')}[/dim]")
+        elif explicit_start:
+            console.print(f"[dim]📅 Explicit filter: from {explicit_start.strftime('%Y-%m-%d')}[/dim]")
+        elif explicit_end:
+            console.print(f"[dim]📅 Explicit filter: until {explicit_end.strftime('%Y-%m-%d')}[/dim]")
+
+    console.print()
+
+    # Group chunks by conversation_id, then by embed_type
+    conv_chunks: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+    conv_metadata: dict[str, dict] = {}
+
+    for chunk in chunks:
+        conv_id = chunk.conversation_id
+        conv_chunks[conv_id][chunk.embed_type].append(chunk)
+
+        # Store metadata from first chunk of each conversation
+        if conv_id not in conv_metadata:
+            conv_metadata[conv_id] = {
+                "title": chunk.title,
+                "created_at": chunk.created_at,
+                "summary": chunk.summary,
+            }
+
+    # Sort conversations by max score (highest first)
+    def conv_max_score(conv_id: str) -> float:
+        all_conv_chunks = []
+        for embed_chunks in conv_chunks[conv_id].values():
+            all_conv_chunks.extend(embed_chunks)
+        return max(c.score for c in all_conv_chunks) if all_conv_chunks else 0.0
+
+    sorted_conv_ids = sorted(conv_chunks.keys(), key=conv_max_score, reverse=True)
+
+    # Define embed type order and colors
+    embed_type_order = ["analysis", "summary", "content"]
+    embed_type_colors = {
+        "analysis": "green",
+        "summary": "yellow",
+        "content": "dim",
+    }
+
+    for conv_id in sorted_conv_ids:
+        metadata = conv_metadata[conv_id]
+        date_str = metadata["created_at"].strftime("%Y-%m-%d") if metadata["created_at"] else "unknown"
+        conv_id_short = conv_id.replace("-", "")[:8]
+        title = metadata["title"] or "Untitled"
+
+        # Truncate title to fit nicely
+        max_title_len = 50
+        if len(title) > max_title_len:
+            title = title[:max_title_len-3] + "..."
+
+        console.print(f"[cyan]{conv_id_short}[/cyan] ({date_str}) [dim]\"{title}\"[/dim]")
+
+        # Show breakdown by embed type
+        types_by_conv = conv_chunks[conv_id]
+        for embed_type in embed_type_order:
+            if embed_type not in types_by_conv:
+                continue
+
+            type_chunks = types_by_conv[embed_type]
+            scores = [c.score for c in type_chunks]
+            chunk_count = len(type_chunks)
+            color = embed_type_colors.get(embed_type, "white")
+
+            # Format chunk count
+            chunk_label = f"{chunk_count} chunk" if chunk_count == 1 else f"{chunk_count} chunks"
+
+            # Format score range
+            if chunk_count == 1:
+                score_str = f"{scores[0]:.3f}"
+            else:
+                score_str = f"{max(scores):.3f}-{min(scores):.3f}"
+
+            console.print(f"  [{color}]{embed_type:10}[/{color}] {chunk_label:10}  {score_str}")
+
+        console.print()
+
+    # Show timing
+    console.print(f"[dim]Search time: {search_time:.2f}s[/dim]")
+
+
 @main.command("ask")
 @click.argument("question")
 @click.option("--context", "-c", default=5, help="Number of context chunks to use (default: 5)")
@@ -2550,6 +2669,8 @@ def _print_search_json(
 @click.option("--since", type=str, help="Only search conversations from this date (YYYY-MM-DD or relative: 7d, 2w, 1m)")
 @click.option("--until", type=str, help="Only search conversations until this date (YYYY-MM-DD)")
 @click.option("--no-temporal", is_flag=True, help="Disable automatic temporal filtering from question")
+@click.option("--explain", is_flag=True, help="Show RAG retrieval breakdown by conversation and embed type")
+@click.option("--explain-only", is_flag=True, help="Show retrieval breakdown without generating an LLM answer")
 @click.option("--agent", is_flag=True, help="Enable multi-turn investigation mode")
 @click.option("--max-steps", type=int, default=5, help="Max investigation steps (with --agent)")
 @click.option("--verbose", "-v", is_flag=True, help="Show debug output")
@@ -2562,6 +2683,8 @@ def ask(
     since: str | None,
     until: str | None,
     no_temporal: bool,
+    explain: bool,
+    explain_only: bool,
     agent: bool,
     max_steps: int,
     verbose: bool,
@@ -2579,6 +2702,11 @@ def ask(
     examine specific conversations and search for additional context to
     provide a more thorough answer.
     
+    With --explain, shows a per-conversation retrieval breakdown before the
+    answer, helping diagnose RAG retrieval quality. With --explain-only,
+    shows the breakdown without generating an LLM answer (useful for pure
+    retrieval debugging without token cost).
+    
     \b
     Before asking, build embeddings with:
       ohtv db embed
@@ -2591,12 +2719,14 @@ def ask(
       ohtv ask "summarize deployment work" --since 7d    # Last 7 days
       ohtv ask "show me API changes" --since 2026-04-01 --until 2026-04-15
       ohtv ask "recent issues" --no-temporal             # Disable auto-filter
+      ohtv ask "api changes" --explain                   # Show retrieval breakdown
+      ohtv ask "api changes" --explain-only              # Retrieval only, skip LLM
       ohtv ask "explain the auth fix in detail" --agent  # Multi-turn investigation
       ohtv ask "what PRs were created?" --agent --max-steps 10  # More investigation steps
     """
     from ohtv.db import get_connection, get_db_path, migrate
     from ohtv.db.stores import ConversationStore, EmbeddingStore, LinkStore, ReferenceStore, RepoStore
-    from ohtv.analysis.rag import RAGAnswerer
+    from ohtv.analysis.rag import RAGAnswerer, RAGRetriever
     from ohtv.filters import parse_date_filter
     from ohtv.config import Config
     
@@ -2654,9 +2784,47 @@ def ask(
         
         console.print("[dim]Searching for relevant context...[/dim]")
         
-        # Use RAGAnswerer for context retrieval and answer generation
         # Disable temporal filter if explicit dates provided or --no-temporal flag
         enable_temporal = not no_temporal and start_date is None and end_date is None
+        
+        # --explain-only mode: retrieval only, no LLM answer
+        if explain_only:
+            retriever = RAGRetriever(
+                embed_store, conv_store,
+                enable_temporal_filter=enable_temporal,
+                link_store=link_store,
+                ref_store=ref_store,
+                repo_store=repo_store,
+                cloud_base_url=cloud_base_url,
+            )
+            
+            try:
+                retrieval_result = retriever.retrieve(
+                    question,
+                    max_context_chunks=context,
+                    min_score=min_score,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+            except ValueError as e:
+                console.print(f"[yellow]{e}[/yellow]")
+                console.print("[dim]Try lowering --min-score or building more embeddings.[/dim]")
+                raise SystemExit(1)
+            
+            if not retrieval_result.context_chunks:
+                console.print("[yellow]No relevant context found.[/yellow]")
+                raise SystemExit(1)
+            
+            _display_retrieval_breakdown(
+                question, retrieval_result.context_chunks,
+                retrieval_result.search_time_seconds,
+                retrieval_result.temporal_filter_applied,
+                retrieval_result.date_range,
+                start_date, end_date,
+            )
+            return  # Exit early, no LLM answer
+        
+        # Use RAGAnswerer for context retrieval and answer generation
         answerer = RAGAnswerer(
             embed_store, conv_store, 
             model=model, 
@@ -2683,6 +2851,17 @@ def ask(
             console.print(f"[red]Error:[/red] {e}")
             console.print("[dim]Make sure LLM_API_KEY is set.[/dim]")
             raise SystemExit(1)
+        
+        # Show retrieval breakdown if --explain
+        if explain:
+            _display_retrieval_breakdown(
+                question, result.context_chunks,
+                result.search_time_seconds,
+                result.temporal_filter_applied,
+                result.date_range,
+                start_date, end_date,
+            )
+            console.print()  # Extra spacing before answer
         
         # Agent mode: run multi-turn investigation
         investigation_result = None
@@ -2734,23 +2913,24 @@ def ask(
                 console.print("[dim]Falling back to initial answer.[/dim]")
                 investigation_result = None
         
-        # Show temporal filter info if applied
-        if result.temporal_filter_applied and result.date_range:
-            start, end = result.date_range
-            if start and end:
-                console.print(f"[dim]📅 Filtering to: {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}[/dim]")
-            elif start:
-                console.print(f"[dim]📅 Filtering to: from {start.strftime('%Y-%m-%d')}[/dim]")
-            elif end:
-                console.print(f"[dim]📅 Filtering to: until {end.strftime('%Y-%m-%d')}[/dim]")
-        elif start_date or end_date:
-            # Explicit date filter was provided
-            if start_date and end_date:
-                console.print(f"[dim]📅 Explicit filter: {start_date.strftime('%Y-%m-%d')} to {end_date.strftime('%Y-%m-%d')}[/dim]")
-            elif start_date:
-                console.print(f"[dim]📅 Explicit filter: from {start_date.strftime('%Y-%m-%d')}[/dim]")
-            elif end_date:
-                console.print(f"[dim]📅 Explicit filter: until {end_date.strftime('%Y-%m-%d')}[/dim]")
+        # Show temporal filter info if applied (skip if --explain already showed it)
+        if not explain:
+            if result.temporal_filter_applied and result.date_range:
+                start, end = result.date_range
+                if start and end:
+                    console.print(f"[dim]📅 Filtering to: {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}[/dim]")
+                elif start:
+                    console.print(f"[dim]📅 Filtering to: from {start.strftime('%Y-%m-%d')}[/dim]")
+                elif end:
+                    console.print(f"[dim]📅 Filtering to: until {end.strftime('%Y-%m-%d')}[/dim]")
+            elif start_date or end_date:
+                # Explicit date filter was provided
+                if start_date and end_date:
+                    console.print(f"[dim]📅 Explicit filter: {start_date.strftime('%Y-%m-%d')} to {end_date.strftime('%Y-%m-%d')}[/dim]")
+                elif start_date:
+                    console.print(f"[dim]📅 Explicit filter: from {start_date.strftime('%Y-%m-%d')}[/dim]")
+                elif end_date:
+                    console.print(f"[dim]📅 Explicit filter: until {end_date.strftime('%Y-%m-%d')}[/dim]")
         
         # Show context if requested
         if show_context:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -2701,7 +2701,7 @@ def ask(
     With --agent, enables multi-turn investigation mode where an agent can
     examine specific conversations and search for additional context to
     provide a more thorough answer.
-    
+
     With --explain, shows a per-conversation retrieval breakdown before the
     answer, helping diagnose RAG retrieval quality. With --explain-only,
     shows the breakdown without generating an LLM answer (useful for pure

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -2561,6 +2561,17 @@ def _display_retrieval_breakdown(
         console.print("[yellow]No relevant context found.[/yellow]")
         return
 
+    def format_date_filter(start: datetime | None, end: datetime | None, label: str) -> str | None:
+        """Format date range as a Rich-formatted string, or None if no dates."""
+        if not (start or end):
+            return None
+        if start and end:
+            return f"[dim]📅 {label}: {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}[/dim]"
+        elif start:
+            return f"[dim]📅 {label}: from {start.strftime('%Y-%m-%d')}[/dim]"
+        else:
+            return f"[dim]📅 {label}: until {end.strftime('%Y-%m-%d')}[/dim]"
+
     # Count unique conversations
     conv_ids = {c.conversation_id for c in chunks}
 
@@ -2569,20 +2580,13 @@ def _display_retrieval_breakdown(
 
     # Show temporal filter info
     if temporal_applied and date_range:
-        start, end = date_range
-        if start and end:
-            console.print(f"[dim]📅 Auto-filtered: {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}[/dim]")
-        elif start:
-            console.print(f"[dim]📅 Auto-filtered: from {start.strftime('%Y-%m-%d')}[/dim]")
-        elif end:
-            console.print(f"[dim]📅 Auto-filtered: until {end.strftime('%Y-%m-%d')}[/dim]")
+        filter_msg = format_date_filter(date_range[0], date_range[1], "Auto-filtered")
+        if filter_msg:
+            console.print(filter_msg)
     elif explicit_start or explicit_end:
-        if explicit_start and explicit_end:
-            console.print(f"[dim]📅 Explicit filter: {explicit_start.strftime('%Y-%m-%d')} to {explicit_end.strftime('%Y-%m-%d')}[/dim]")
-        elif explicit_start:
-            console.print(f"[dim]📅 Explicit filter: from {explicit_start.strftime('%Y-%m-%d')}[/dim]")
-        elif explicit_end:
-            console.print(f"[dim]📅 Explicit filter: until {explicit_end.strftime('%Y-%m-%d')}[/dim]")
+        filter_msg = format_date_filter(explicit_start, explicit_end, "Explicit filter")
+        if filter_msg:
+            console.print(filter_msg)
 
     console.print()
 
@@ -2604,10 +2608,8 @@ def _display_retrieval_breakdown(
 
     # Sort conversations by max score (highest first)
     def conv_max_score(conv_id: str) -> float:
-        all_conv_chunks = []
-        for embed_chunks in conv_chunks[conv_id].values():
-            all_conv_chunks.extend(embed_chunks)
-        return max(c.score for c in all_conv_chunks) if all_conv_chunks else 0.0
+        scores = (c.score for embed_chunks in conv_chunks[conv_id].values() for c in embed_chunks)
+        return max(scores, default=0.0)
 
     sorted_conv_ids = sorted(conv_chunks.keys(), key=conv_max_score, reverse=True)
 

--- a/tests/unit/analysis/test_rag_retriever.py
+++ b/tests/unit/analysis/test_rag_retriever.py
@@ -1,0 +1,448 @@
+"""Tests for RAGRetriever and RAGRetrievalResult."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from ohtv.analysis.rag import RAGRetriever, RAGRetrievalResult, ContextChunk
+
+
+class TestRAGRetrievalResult:
+    """Tests for RAGRetrievalResult dataclass."""
+
+    def test_creation_with_defaults(self):
+        """Test creating a result with minimal parameters."""
+        result = RAGRetrievalResult(
+            context_chunks=[],
+            source_conversation_ids=set(),
+            search_time_seconds=0.5,
+        )
+        assert result.context_chunks == []
+        assert result.source_conversation_ids == set()
+        assert result.search_time_seconds == 0.5
+        assert result.temporal_filter_applied is False
+        assert result.date_range is None
+
+    def test_creation_with_temporal_filter(self):
+        """Test creating a result with temporal filter applied."""
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        result = RAGRetrievalResult(
+            context_chunks=[],
+            source_conversation_ids={"abc", "def"},
+            search_time_seconds=1.2,
+            temporal_filter_applied=True,
+            date_range=(start, end),
+        )
+        assert result.temporal_filter_applied is True
+        assert result.date_range == (start, end)
+
+
+class TestRAGRetrieverInit:
+    """Tests for RAGRetriever initialization."""
+
+    def test_init_with_minimal_params(self):
+        """Test initializing with only required stores."""
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        
+        retriever = RAGRetriever(embed_store, conv_store)
+        
+        assert retriever.embed_store is embed_store
+        assert retriever.conv_store is conv_store
+        assert retriever.enable_temporal_filter is True
+        assert retriever.link_store is None
+        assert retriever.ref_store is None
+        assert retriever.repo_store is None
+
+    def test_init_with_all_params(self):
+        """Test initializing with all optional stores."""
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        link_store = MagicMock()
+        ref_store = MagicMock()
+        repo_store = MagicMock()
+        
+        retriever = RAGRetriever(
+            embed_store, conv_store,
+            enable_temporal_filter=False,
+            link_store=link_store,
+            ref_store=ref_store,
+            repo_store=repo_store,
+            cloud_base_url="https://test.example.com",
+        )
+        
+        assert retriever.enable_temporal_filter is False
+        assert retriever.link_store is link_store
+        assert retriever.ref_store is ref_store
+        assert retriever.repo_store is repo_store
+        assert retriever.cloud_base_url == "https://test.example.com"
+
+    def test_default_cloud_url(self):
+        """Test default cloud URL when not provided."""
+        retriever = RAGRetriever(MagicMock(), MagicMock())
+        assert "app.all-hands.dev" in retriever.cloud_base_url
+
+
+class TestRAGRetrieverHelpers:
+    """Tests for RAGRetriever helper methods."""
+
+    def test_get_cloud_url(self):
+        """Test cloud URL generation."""
+        retriever = RAGRetriever(
+            MagicMock(), MagicMock(),
+            cloud_base_url="https://test.example.com"
+        )
+        url = retriever._get_cloud_url("abc123")
+        assert url == "https://test.example.com/conversations/abc123"
+
+    def test_get_conversation_source_without_stores(self):
+        """Test source info is None when stores not provided."""
+        retriever = RAGRetriever(MagicMock(), MagicMock())
+        result = retriever._get_conversation_source("abc123")
+        assert result is None
+
+    def test_get_conversation_source_with_stores(self):
+        """Test source info retrieval with all stores."""
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        link_store = MagicMock()
+        ref_store = MagicMock()
+        repo_store = MagicMock()
+        
+        # Mock conversation
+        mock_conv = MagicMock()
+        mock_conv.title = "Test Conversation"
+        mock_conv.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        mock_conv.summary = "Test summary"
+        mock_conv.source = "cloud"
+        conv_store.get.return_value = mock_conv
+        
+        # Mock links - empty
+        link_store.get_repos_for_conversation.return_value = []
+        link_store.get_refs_for_conversation.return_value = []
+        
+        retriever = RAGRetriever(
+            embed_store, conv_store,
+            link_store=link_store,
+            ref_store=ref_store,
+            repo_store=repo_store,
+        )
+        
+        result = retriever._get_conversation_source("abc123")
+        
+        assert result is not None
+        assert result.conversation_id == "abc123"
+        assert result.title == "Test Conversation"
+        assert result.source == "cloud"
+
+
+class TestRAGRetrieverRetrieve:
+    """Tests for RAGRetriever.retrieve method."""
+
+    @patch("ohtv.analysis.embeddings.get_embedding")
+    def test_retrieve_basic(self, mock_get_embedding):
+        """Test basic retrieval without temporal filter."""
+        # Setup mocks
+        mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
+        
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        
+        # Mock embedding search results
+        mock_result = MagicMock()
+        mock_result.conversation_id = "abc123"
+        mock_result.embed_type = "analysis"
+        mock_result.source_text = "Test content"
+        mock_result.score = 0.85
+        mock_result.chunk_index = 0
+        embed_store.get_context_for_rag.return_value = [mock_result]
+        
+        # Mock conversation
+        mock_conv = MagicMock()
+        mock_conv.title = "Test Conversation"
+        mock_conv.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        mock_conv.summary = None
+        mock_conv.source = "local"
+        conv_store.get.return_value = mock_conv
+        
+        retriever = RAGRetriever(
+            embed_store, conv_store,
+            enable_temporal_filter=False,
+        )
+        
+        result = retriever.retrieve("test query", max_context_chunks=5)
+        
+        assert len(result.context_chunks) == 1
+        assert result.source_conversation_ids == {"abc123"}
+        assert result.temporal_filter_applied is False
+        assert result.context_chunks[0].title == "Test Conversation"
+        assert result.context_chunks[0].score == 0.85
+
+    @patch("ohtv.analysis.embeddings.get_embedding")
+    def test_retrieve_with_no_results(self, mock_get_embedding):
+        """Test retrieval when no results found."""
+        mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
+        
+        embed_store = MagicMock()
+        embed_store.get_context_for_rag.return_value = []
+        
+        retriever = RAGRetriever(
+            embed_store, MagicMock(),
+            enable_temporal_filter=False,
+        )
+        
+        result = retriever.retrieve("test query")
+        
+        assert len(result.context_chunks) == 0
+        assert result.source_conversation_ids == set()
+
+    @patch("ohtv.analysis.temporal.extract_temporal_filter")
+    @patch("ohtv.analysis.embeddings.get_embedding")
+    def test_retrieve_with_temporal_filter(self, mock_get_embedding, mock_extract):
+        """Test retrieval with temporal filter applied."""
+        mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
+        
+        # Mock temporal filter extraction
+        mock_temporal = MagicMock()
+        mock_temporal.has_temporal_intent = True
+        mock_temporal.start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_temporal.end_date = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        mock_temporal.cleaned_query = "what happened"
+        mock_extract.return_value = mock_temporal
+        
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        
+        # Mock embedding search results
+        mock_result = MagicMock()
+        mock_result.conversation_id = "abc123"
+        mock_result.embed_type = "summary"
+        mock_result.source_text = "Content"
+        mock_result.score = 0.75
+        mock_result.chunk_index = 0
+        embed_store.get_context_for_rag.return_value = [mock_result]
+        
+        mock_conv = MagicMock()
+        mock_conv.title = "Test"
+        mock_conv.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        mock_conv.summary = None
+        mock_conv.source = "cloud"
+        conv_store.get.return_value = mock_conv
+        
+        retriever = RAGRetriever(
+            embed_store, conv_store,
+            enable_temporal_filter=True,
+        )
+        
+        result = retriever.retrieve("what happened last month")
+        
+        assert result.temporal_filter_applied is True
+        assert result.date_range == (mock_temporal.start_date, mock_temporal.end_date)
+
+    @patch("ohtv.analysis.embeddings.get_embedding")
+    def test_retrieve_respects_min_score(self, mock_get_embedding):
+        """Test that min_score is passed to the store."""
+        mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
+        
+        embed_store = MagicMock()
+        embed_store.get_context_for_rag.return_value = []
+        
+        retriever = RAGRetriever(
+            embed_store, MagicMock(),
+            enable_temporal_filter=False,
+        )
+        
+        retriever.retrieve("test", min_score=0.6)
+        
+        embed_store.get_context_for_rag.assert_called_once()
+        call_kwargs = embed_store.get_context_for_rag.call_args[1]
+        assert call_kwargs["min_score"] == 0.6
+
+    @patch("ohtv.analysis.embeddings.get_embedding")
+    def test_retrieve_sorts_chunks(self, mock_get_embedding):
+        """Test that chunks are sorted by conversation, type, index."""
+        mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
+        
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        
+        # Create unsorted results
+        results = [
+            MagicMock(
+                conversation_id="def",
+                embed_type="content",
+                source_text="Content 2",
+                score=0.8,
+                chunk_index=0,
+            ),
+            MagicMock(
+                conversation_id="abc",
+                embed_type="analysis",
+                source_text="Analysis",
+                score=0.9,
+                chunk_index=0,
+            ),
+            MagicMock(
+                conversation_id="abc",
+                embed_type="summary",
+                source_text="Summary",
+                score=0.85,
+                chunk_index=0,
+            ),
+        ]
+        embed_store.get_context_for_rag.return_value = results
+        
+        mock_conv = MagicMock()
+        mock_conv.title = "Test"
+        mock_conv.created_at = None
+        mock_conv.summary = None
+        mock_conv.source = "local"
+        conv_store.get.return_value = mock_conv
+        
+        retriever = RAGRetriever(
+            embed_store, conv_store,
+            enable_temporal_filter=False,
+        )
+        
+        result = retriever.retrieve("test")
+        
+        # Should be sorted by conversation_id, then embed_type, then chunk_index
+        assert result.context_chunks[0].conversation_id == "abc"
+        assert result.context_chunks[0].embed_type == "analysis"
+        assert result.context_chunks[1].conversation_id == "abc"
+        assert result.context_chunks[1].embed_type == "summary"
+        assert result.context_chunks[2].conversation_id == "def"
+
+
+class TestDisplayRetrievalBreakdown:
+    """Tests for _display_retrieval_breakdown CLI helper."""
+
+    def test_import(self):
+        """Test that the helper function can be imported from cli module."""
+        # This is mainly a smoke test to ensure the function exists
+        from ohtv.cli import _display_retrieval_breakdown
+        assert callable(_display_retrieval_breakdown)
+
+    def test_empty_chunks(self, capsys):
+        """Test display with no chunks."""
+        from ohtv.cli import _display_retrieval_breakdown
+        
+        _display_retrieval_breakdown(
+            question="test query",
+            chunks=[],
+            search_time=0.5,
+            temporal_applied=False,
+            date_range=None,
+            explicit_start=None,
+            explicit_end=None,
+        )
+        
+        captured = capsys.readouterr()
+        assert "No relevant context found" in captured.out
+
+    def test_with_chunks(self, capsys):
+        """Test display with actual chunks."""
+        from ohtv.cli import _display_retrieval_breakdown
+        
+        # Create mock chunks
+        chunks = [
+            MagicMock(
+                conversation_id="abc123",
+                embed_type="analysis",
+                title="Test Conversation",
+                created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                summary=None,
+                score=0.85,
+            ),
+            MagicMock(
+                conversation_id="abc123",
+                embed_type="summary",
+                title="Test Conversation",
+                created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                summary=None,
+                score=0.72,
+            ),
+        ]
+        
+        _display_retrieval_breakdown(
+            question="test query",
+            chunks=chunks,
+            search_time=0.5,
+            temporal_applied=False,
+            date_range=None,
+            explicit_start=None,
+            explicit_end=None,
+        )
+        
+        captured = capsys.readouterr()
+        assert "Query:" in captured.out
+        assert "test query" in captured.out
+        assert "Retrieved 2 chunks from 1 conversations" in captured.out
+        assert "analysis" in captured.out
+        assert "summary" in captured.out
+        assert "0.85" in captured.out or "0.850" in captured.out
+
+    def test_with_temporal_filter(self, capsys):
+        """Test display shows temporal filter info."""
+        from ohtv.cli import _display_retrieval_breakdown
+        
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 1, 31, tzinfo=timezone.utc)
+        
+        chunks = [
+            MagicMock(
+                conversation_id="abc123",
+                embed_type="analysis",
+                title="Test",
+                created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+                summary=None,
+                score=0.8,
+            ),
+        ]
+        
+        _display_retrieval_breakdown(
+            question="test query",
+            chunks=chunks,
+            search_time=0.5,
+            temporal_applied=True,
+            date_range=(start, end),
+            explicit_start=None,
+            explicit_end=None,
+        )
+        
+        captured = capsys.readouterr()
+        assert "Auto-filtered" in captured.out
+        assert "2024-01-01" in captured.out
+        assert "2024-01-31" in captured.out
+
+    def test_with_explicit_date_filter(self, capsys):
+        """Test display shows explicit date filter info."""
+        from ohtv.cli import _display_retrieval_breakdown
+        
+        explicit_start = datetime(2024, 2, 1, tzinfo=timezone.utc)
+        
+        chunks = [
+            MagicMock(
+                conversation_id="abc123",
+                embed_type="summary",
+                title="Test",
+                created_at=datetime(2024, 2, 15, tzinfo=timezone.utc),
+                summary=None,
+                score=0.7,
+            ),
+        ]
+        
+        _display_retrieval_breakdown(
+            question="test query",
+            chunks=chunks,
+            search_time=0.3,
+            temporal_applied=False,
+            date_range=None,
+            explicit_start=explicit_start,
+            explicit_end=None,
+        )
+        
+        captured = capsys.readouterr()
+        assert "Explicit filter" in captured.out
+        assert "2024-02-01" in captured.out

--- a/tests/unit/analysis/test_rag_retriever.py
+++ b/tests/unit/analysis/test_rag_retriever.py
@@ -84,27 +84,32 @@ class TestRAGRetrieverInit:
         assert "app.all-hands.dev" in retriever.cloud_base_url
 
 
-class TestRAGRetrieverHelpers:
-    """Tests for RAGRetriever helper methods."""
+class TestSharedHelpers:
+    """Tests for module-level helper functions."""
 
     def test_get_cloud_url(self):
         """Test cloud URL generation."""
-        retriever = RAGRetriever(
-            MagicMock(), MagicMock(),
-            cloud_base_url="https://test.example.com"
-        )
-        url = retriever._get_cloud_url("abc123")
+        from ohtv.analysis.rag import _get_cloud_url
+        url = _get_cloud_url("https://test.example.com", "abc123")
         assert url == "https://test.example.com/conversations/abc123"
 
     def test_get_conversation_source_without_stores(self):
         """Test source info is None when stores not provided."""
-        retriever = RAGRetriever(MagicMock(), MagicMock())
-        result = retriever._get_conversation_source("abc123")
+        from ohtv.analysis.rag import _get_conversation_source
+        result = _get_conversation_source(
+            "abc123",
+            conv_store=MagicMock(),
+            link_store=None,
+            ref_store=None,
+            repo_store=None,
+            cloud_base_url="https://test.example.com",
+        )
         assert result is None
 
     def test_get_conversation_source_with_stores(self):
         """Test source info retrieval with all stores."""
-        embed_store = MagicMock()
+        from ohtv.analysis.rag import _get_conversation_source
+        
         conv_store = MagicMock()
         link_store = MagicMock()
         ref_store = MagicMock()
@@ -122,14 +127,14 @@ class TestRAGRetrieverHelpers:
         link_store.get_repos_for_conversation.return_value = []
         link_store.get_refs_for_conversation.return_value = []
         
-        retriever = RAGRetriever(
-            embed_store, conv_store,
+        result = _get_conversation_source(
+            "abc123",
+            conv_store=conv_store,
             link_store=link_store,
             ref_store=ref_store,
             repo_store=repo_store,
+            cloud_base_url="https://test.example.com",
         )
-        
-        result = retriever._get_conversation_source("abc123")
         
         assert result is not None
         assert result.conversation_id == "abc123"


### PR DESCRIPTION
## Summary

Implements #35: Adds `--explain` and `--explain-only` flags to the `ask` command to help diagnose RAG retrieval quality.

## Features

### `--explain` flag

Shows per-conversation retrieval breakdown before the LLM answer:
- Groups chunks by conversation and embed type (analysis, summary, content)
- Shows chunk counts and similarity score ranges for each embed type
- Conversations sorted by best chunk score (highest first)
- Displays temporal filter info (auto or explicit date filtering)

### `--explain-only` flag

Same as `--explain` but skips LLM answer generation:
- Does not require `LLM_API_KEY` (only uses embedding API)
- Useful for pure retrieval debugging without token cost

## Example Output

```
Query: "how do embeddings work?"
Retrieved 50 chunks from 19 conversations
📅 Auto-filtered: 2024-04-15 to 2024-04-22

b3af77ff (2024-04-22) "Clarify RAG implementation..."
  analysis    2 chunks   0.723-0.718
  summary     1 chunk    0.695
  content     5 chunks   0.701-0.668

76230e77 (2024-04-21) "Fix embedding functionality..."
  analysis    1 chunk    0.712
  content    22 chunks   0.698-0.667

Search time: 0.23s
```

## Implementation

### New classes in `analysis/rag.py`:
- `RAGRetrievalResult` - Dataclass for retrieval-only results (no answer)
- `RAGRetriever` - Lightweight retriever that doesn't require LLM initialization

### Shared helper functions (module-level):
- `_get_cloud_url()` - Generate cloud URL for a conversation
- `_get_conversation_source()` - Get full source info including refs
- `_results_to_context_chunks()` - Convert search results to ContextChunk objects

### CLI changes in `cli.py`:
- Added `--explain` and `--explain-only` options to `ask` command
- New `_display_retrieval_breakdown()` helper for formatted output
- New `format_date_filter()` helper for date range display

## Review Decisions

During code review, several refactoring suggestions were addressed:

1. **Code duplication eliminated** (commits 1fe05cc, eede49a): Extracted shared logic between `RAGRetriever` and `RAGAnswerer` into module-level helper functions
2. **Date formatting extracted** (commit a853532): Created `format_date_filter()` helper to DRY up auto vs explicit filter formatting
3. **Max score optimized** (commit a853532): Changed `conv_max_score()` to use generator expression instead of building temporary list
4. **Docstring formatting improved** (commit 1fe05cc): Added blank line for better topic separation

## Test Coverage

- **18 new unit tests** in `tests/unit/analysis/test_rag_retriever.py`:
  - `TestRAGRetrievalResult`: 2 tests (creation with defaults, temporal filter)
  - `TestRAGRetrieverInit`: 3 tests (init params, default cloud URL)
  - `TestSharedHelpers`: 3 tests (get_cloud_url, conversation source)
  - `TestRAGRetrieverRetrieve`: 5 tests (basic, no results, temporal, min_score, sorting)
  - `TestDisplayRetrievalBreakdown`: 5 tests (import, empty chunks, with chunks, filters)

- **Manual testing** verified:
  - Basic `--explain-only` functionality
  - `--explain` with LLM answer generation
  - Integration with `--context`, `--since`, date filters
  - No results handling
  - Both flags together (`--explain-only` takes precedence)

- **All 1183 tests pass**

## Usage Examples

```bash
# Show retrieval breakdown + answer
ohtv ask "api changes" --explain

# Retrieval only, skip LLM (no LLM_API_KEY needed)
ohtv ask "api changes" --explain-only

# Combine with other options
ohtv ask "api changes" --explain --context 20 --since 7d
```

---
This PR was created by an AI assistant (OpenHands) on behalf of the user.

Closes #35
