### PR TITLE
Fix embedding check in sync flow: use events/ directory not events.json

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -595,6 +595,7 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
     from ohtv.db import get_connection
     from pathlib import Path
     from ohtv.db.stores import ConversationStore, EmbeddingStore
+    from ohtv.filters import normalize_conversation_id
     
     # Check if embedding is configured
     if not os.environ.get("LLM_API_KEY"):
@@ -609,6 +610,9 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         conv_store = ConversationStore(conn)
         embed_store = EmbeddingStore(conn)
         
+        # Build set of already-embedded conversation IDs (normalized for comparison)
+        existing_ids = set(normalize_conversation_id(cid) for cid in embed_store.list_conversation_ids())
+        
         all_convs = conv_store.list_all()
         
         # Find conversations without embeddings that have local content
@@ -617,17 +621,18 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         already_embedded = 0
         
         for conv in all_convs:
-            # Skip if no local directory or no events file
+            # Skip if no local directory or no events directory
             if not conv.location:
                 no_local_content += 1
                 continue
             conv_dir = Path(conv.location)
-            events_file = conv_dir / "events.json"
-            if not events_file.exists():
+            events_dir = conv_dir / "events"
+            if not events_dir.exists() or not events_dir.is_dir():
                 no_local_content += 1
                 continue
             
-            if embed_store.has_embedding(conv.id):
+            # Check using normalized ID (handles dash variations)
+            if normalize_conversation_id(conv.id) in existing_ids:
                 already_embedded += 1
                 continue
                 


### PR DESCRIPTION
## Summary

Fixes a bug in `_run_post_sync_embeddings()` that caused the sync flow to incorrectly report all conversations as having "no content", resulting in misleading output like:

```
All local conversations have embeddings (2084 without content skipped)
```

## The Problem

The embedding sync flow was checking for an `events.json` file that doesn't exist:

```python
events_file = conv_dir / "events.json"  # WRONG!
if not events_file.exists():
    no_local_content += 1
```

Conversations actually store events in an `events/` **directory** containing individual `event-*.json` files (e.g., `event-001.json`, `event-002.json`). Since `events.json` never exists, every conversation was classified as "without content".

This explains why `ohtv sync` reported 2084 conversations without content while `ohtv db embed` correctly found 34 conversations needing embedding.

## Changes

1. **Fixed events check**: Changed from checking `events.json` file to checking `events/` directory existence
2. **Added ID normalization**: Added `normalize_conversation_id()` for consistency with `db_embed` command, which handles conversation ID format differences (with/without dashes)

## Testing

After this fix, the sync flow should correctly identify conversations that need embedding and process them appropriately.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/46247660-87f2-4b06-b060-b006b8f10588)