### PR TITLE
Add embedding configuration wizard (ohtv config-embed)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "openhands-sdk>=1.16.1",
     "pyyaml>=6.0",
     "rich>=13.0",
+    "tomli_w>=1.0",
 ]
 
 [project.scripts]

--- a/src/ohtv/analysis/embeddings/client.py
+++ b/src/ohtv/analysis/embeddings/client.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 
 import litellm
 
+from ohtv.analysis.embeddings.config import get_effective_embedding_model
+
 # Suppress LiteLLM info messages that spam output during batch operations
 litellm.suppress_debug_info = True
 
@@ -123,18 +125,6 @@ def reset_rate_limiter() -> None:
 
 DEFAULT_EMBEDDING_MODEL = "openai/text-embedding-3-small"
 
-
-def _get_configured_model() -> str | None:
-    """Get embedding model from config file if set.
-    
-    Returns None if not configured, allowing fallback to default.
-    """
-    try:
-        from ohtv.analysis.embeddings.config import get_effective_embedding_model
-        return get_effective_embedding_model()
-    except ImportError:
-        return None
-
 # Known model dimensions
 KNOWN_DIMENSIONS: dict[str, int] = {
     "openai/text-embedding-3-small": 1536,
@@ -181,17 +171,7 @@ def get_embedding_model() -> str:
     2. embedding_model in config file (~/.ohtv/config.toml)
     3. Default (openai/text-embedding-3-small)
     """
-    # Environment variable takes highest priority
-    env_model = os.environ.get("EMBEDDING_MODEL")
-    if env_model:
-        return env_model
-    
-    # Check config file
-    config_model = _get_configured_model()
-    if config_model:
-        return config_model
-    
-    return DEFAULT_EMBEDDING_MODEL
+    return get_effective_embedding_model() or DEFAULT_EMBEDDING_MODEL
 
 
 def get_embedding_dimension(model: str | None = None) -> int:

--- a/src/ohtv/analysis/embeddings/client.py
+++ b/src/ohtv/analysis/embeddings/client.py
@@ -123,6 +123,18 @@ def reset_rate_limiter() -> None:
 
 DEFAULT_EMBEDDING_MODEL = "openai/text-embedding-3-small"
 
+
+def _get_configured_model() -> str | None:
+    """Get embedding model from config file if set.
+    
+    Returns None if not configured, allowing fallback to default.
+    """
+    try:
+        from ohtv.analysis.embeddings.config import get_effective_embedding_model
+        return get_effective_embedding_model()
+    except ImportError:
+        return None
+
 # Known model dimensions
 KNOWN_DIMENSIONS: dict[str, int] = {
     "openai/text-embedding-3-small": 1536,
@@ -162,8 +174,24 @@ class EmbeddingResult:
 
 
 def get_embedding_model() -> str:
-    """Get the configured embedding model."""
-    return os.environ.get("EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL)
+    """Get the configured embedding model.
+    
+    Priority:
+    1. EMBEDDING_MODEL environment variable
+    2. embedding_model in config file (~/.ohtv/config.toml)
+    3. Default (openai/text-embedding-3-small)
+    """
+    # Environment variable takes highest priority
+    env_model = os.environ.get("EMBEDDING_MODEL")
+    if env_model:
+        return env_model
+    
+    # Check config file
+    config_model = _get_configured_model()
+    if config_model:
+        return config_model
+    
+    return DEFAULT_EMBEDDING_MODEL
 
 
 def get_embedding_dimension(model: str | None = None) -> int:

--- a/src/ohtv/analysis/embeddings/config.py
+++ b/src/ohtv/analysis/embeddings/config.py
@@ -16,6 +16,14 @@ import urllib.error
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+import tomli_w
 
 log = logging.getLogger("ohtv")
 
@@ -58,6 +66,20 @@ RECOMMENDED_OLLAMA_MODELS = [
     "all-minilm",  # Smallest/fastest, 384 dims
     "bge-m3",  # Multilingual, 1024 dims
 ]
+
+
+def _load_config() -> dict[str, Any]:
+    """Load config file as dict, return {} if missing/invalid."""
+    from ohtv.config import get_config_file_path
+    
+    config_path = get_config_file_path()
+    if not config_path.exists():
+        return {}
+    try:
+        with open(config_path, "rb") as f:
+            return tomllib.load(f)
+    except Exception:
+        return {}
 
 
 def get_ollama_host() -> str:
@@ -104,12 +126,12 @@ def detect_ollama() -> OllamaStatus:
             available_models=[],
             error=f"Cannot connect to Ollama at {host}: {e.reason}",
         )
-    except Exception as e:
+    except (json.JSONDecodeError, KeyError, TimeoutError) as e:
         return OllamaStatus(
             is_running=False,
             host=host,
             available_models=[],
-            error=str(e),
+            error=f"Failed to detect Ollama: {e}",
         )
 
 
@@ -226,33 +248,21 @@ def get_current_config() -> EmbeddingConfig:
             )
     
     # Check config file
-    from ohtv.config import get_config_file_path
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-    
-    config_path = get_config_file_path()
-    if config_path.exists():
-        try:
-            with open(config_path, "rb") as f:
-                file_config = tomllib.load(f)
-            file_model = file_config.get("embedding_model")
-            if file_model:
-                if file_model.startswith("ollama/"):
-                    return EmbeddingConfig(
-                        provider=EmbeddingProvider.OLLAMA,
-                        model=file_model,
-                        source="file",
-                    )
-                else:
-                    return EmbeddingConfig(
-                        provider=EmbeddingProvider.LITELLM,
-                        model=file_model,
-                        source="file",
-                    )
-        except Exception:
-            pass
+    file_config = _load_config()
+    file_model = file_config.get("embedding_model")
+    if file_model:
+        if file_model.startswith("ollama/"):
+            return EmbeddingConfig(
+                provider=EmbeddingProvider.OLLAMA,
+                model=file_model,
+                source="file",
+            )
+        else:
+            return EmbeddingConfig(
+                provider=EmbeddingProvider.LITELLM,
+                model=file_model,
+                source="file",
+            )
     
     # Check if LLM_API_KEY is set (implies cloud embedding might work)
     if os.environ.get("LLM_API_KEY"):
@@ -305,37 +315,19 @@ def save_embedding_config(model: str, ollama_host: str | None = None) -> None:
     """
     from ohtv.config import get_config_file_path
     
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-    
     config_path = get_config_file_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
     
     # Load existing config
-    existing = {}
-    if config_path.exists():
-        try:
-            with open(config_path, "rb") as f:
-                existing = tomllib.load(f)
-        except Exception:
-            pass
+    existing = _load_config()
     
     # Update embedding config
     existing["embedding_model"] = model
     if ollama_host and ollama_host != "http://localhost:11434":
         existing["ollama_host"] = ollama_host
     
-    # Write back as TOML
-    lines = ["# ohtv configuration", "# See 'ohtv config --help' for available settings", ""]
-    for key, value in sorted(existing.items()):
-        if isinstance(value, str):
-            lines.append(f'{key} = "{value}"')
-        else:
-            lines.append(f"{key} = {value}")
-    lines.append("")
-    config_path.write_text("\n".join(lines))
+    # Write back as TOML using tomli_w for proper escaping
+    config_path.write_bytes(tomli_w.dumps(existing))
 
 
 def get_effective_embedding_model() -> str | None:
@@ -344,28 +336,10 @@ def get_effective_embedding_model() -> str | None:
     Checks env var first, then config file. Returns None if not configured.
     This is the function that should be used by embedding operations.
     """
-    # Environment variable takes precedence
     env_model = os.environ.get("EMBEDDING_MODEL")
     if env_model:
         return env_model
-    
-    # Check config file
-    from ohtv.config import get_config_file_path
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-    
-    config_path = get_config_file_path()
-    if config_path.exists():
-        try:
-            with open(config_path, "rb") as f:
-                file_config = tomllib.load(f)
-            return file_config.get("embedding_model")
-        except Exception:
-            pass
-    
-    return None
+    return _load_config().get("embedding_model")
 
 
 def is_embedding_configured() -> bool:

--- a/src/ohtv/analysis/embeddings/config.py
+++ b/src/ohtv/analysis/embeddings/config.py
@@ -1,0 +1,386 @@
+"""Embedding configuration detection and wizard.
+
+Provides auto-detection of available embedding providers and a wizard
+to help users configure embedding support.
+
+Supports:
+- Cloud providers via LiteLLM (OpenAI, Mistral, etc.) using LLM_API_KEY
+- Local Ollama server for free/offline embeddings
+"""
+
+import json
+import logging
+import os
+import urllib.request
+import urllib.error
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+log = logging.getLogger("ohtv")
+
+
+class EmbeddingProvider(Enum):
+    """Available embedding providers."""
+    OPENAI = "openai"
+    OLLAMA = "ollama"
+    LITELLM = "litellm"  # Generic LiteLLM with custom base URL
+    NONE = "none"
+
+
+@dataclass
+class EmbeddingConfig:
+    """Current embedding configuration."""
+    provider: EmbeddingProvider
+    model: str | None
+    source: str  # "env", "file", "detected", "none"
+    is_working: bool | None = None  # None = not tested
+    error: str | None = None
+    
+    @property
+    def is_configured(self) -> bool:
+        return self.provider != EmbeddingProvider.NONE and self.model is not None
+
+
+@dataclass 
+class OllamaStatus:
+    """Status of local Ollama server."""
+    is_running: bool
+    host: str
+    available_models: list[str]
+    error: str | None = None
+
+
+# Recommended Ollama models for embeddings (in preference order)
+RECOMMENDED_OLLAMA_MODELS = [
+    "nomic-embed-text",  # Good quality, 768 dims, fast
+    "mxbai-embed-large",  # Higher quality, 1024 dims
+    "all-minilm",  # Smallest/fastest, 384 dims
+    "bge-m3",  # Multilingual, 1024 dims
+]
+
+
+def get_ollama_host() -> str:
+    """Get Ollama host URL from env or default."""
+    return os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+
+
+def detect_ollama() -> OllamaStatus:
+    """Detect if Ollama is running and what models are available.
+    
+    Returns:
+        OllamaStatus with connection info and available embedding models
+    """
+    host = get_ollama_host()
+    
+    try:
+        # Check if Ollama is responding
+        req = urllib.request.Request(f"{host}/api/tags", method="GET")
+        with urllib.request.urlopen(req, timeout=5) as response:
+            data = json.loads(response.read().decode("utf-8"))
+        
+        # Extract model names that are embedding models
+        all_models = [m.get("name", "").split(":")[0] for m in data.get("models", [])]
+        
+        # Filter to embedding-capable models
+        embedding_models = [m for m in all_models if m in RECOMMENDED_OLLAMA_MODELS]
+        
+        # Also check for any model with "embed" in the name
+        for m in all_models:
+            if "embed" in m.lower() and m not in embedding_models:
+                embedding_models.append(m)
+        
+        return OllamaStatus(
+            is_running=True,
+            host=host,
+            available_models=embedding_models,
+            error=None,
+        )
+        
+    except urllib.error.URLError as e:
+        return OllamaStatus(
+            is_running=False,
+            host=host,
+            available_models=[],
+            error=f"Cannot connect to Ollama at {host}: {e.reason}",
+        )
+    except Exception as e:
+        return OllamaStatus(
+            is_running=False,
+            host=host,
+            available_models=[],
+            error=str(e),
+        )
+
+
+def test_ollama_embedding(model: str, host: str | None = None) -> tuple[bool, str | None]:
+    """Test if an Ollama model can generate embeddings.
+    
+    Args:
+        model: Model name (without ollama/ prefix)
+        host: Ollama host URL (uses default if None)
+    
+    Returns:
+        Tuple of (success, error_message)
+    """
+    if host is None:
+        host = get_ollama_host()
+    
+    test_text = "Test embedding generation"
+    
+    try:
+        request_data = json.dumps({
+            "model": model,
+            "prompt": test_text,
+        }).encode("utf-8")
+        
+        req = urllib.request.Request(
+            f"{host}/api/embeddings",
+            data=request_data,
+            headers={"Content-Type": "application/json"},
+        )
+        
+        with urllib.request.urlopen(req, timeout=30) as response:
+            result = json.loads(response.read().decode("utf-8"))
+        
+        embedding = result.get("embedding", [])
+        if not embedding:
+            return False, "Model returned empty embedding"
+        
+        return True, None
+        
+    except urllib.error.HTTPError as e:
+        error_body = ""
+        try:
+            error_body = e.read().decode("utf-8")
+        except Exception:
+            pass
+        return False, f"HTTP {e.code}: {error_body or str(e)}"
+    except urllib.error.URLError as e:
+        return False, f"Connection failed: {e.reason}"
+    except Exception as e:
+        return False, str(e)
+
+
+def test_litellm_embedding(model: str) -> tuple[bool, str | None]:
+    """Test if a LiteLLM model can generate embeddings.
+    
+    Args:
+        model: Full model name (e.g., "openai/text-embedding-3-small")
+    
+    Returns:
+        Tuple of (success, error_message)
+    """
+    api_key = os.environ.get("LLM_API_KEY")
+    api_base = os.environ.get("LLM_BASE_URL")
+    
+    if not api_key:
+        return False, "LLM_API_KEY environment variable not set"
+    
+    try:
+        import litellm
+        litellm.suppress_debug_info = True
+        
+        response = litellm.embedding(
+            model=model,
+            input=["Test embedding generation"],
+            api_key=api_key,
+            api_base=api_base,
+        )
+        
+        embedding = response.data[0]["embedding"]
+        if not embedding:
+            return False, "Model returned empty embedding"
+        
+        return True, None
+        
+    except Exception as e:
+        return False, str(e)
+
+
+def get_current_config() -> EmbeddingConfig:
+    """Get the current embedding configuration from env and config file.
+    
+    Checks in order:
+    1. EMBEDDING_MODEL environment variable
+    2. embedding_model in config file
+    3. Detects from LLM_API_KEY if available
+    
+    Returns:
+        EmbeddingConfig with current state
+    """
+    # Check environment variable first
+    env_model = os.environ.get("EMBEDDING_MODEL")
+    if env_model:
+        if env_model.startswith("ollama/"):
+            return EmbeddingConfig(
+                provider=EmbeddingProvider.OLLAMA,
+                model=env_model,
+                source="env",
+            )
+        else:
+            return EmbeddingConfig(
+                provider=EmbeddingProvider.LITELLM,
+                model=env_model,
+                source="env",
+            )
+    
+    # Check config file
+    from ohtv.config import get_config_file_path
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    
+    config_path = get_config_file_path()
+    if config_path.exists():
+        try:
+            with open(config_path, "rb") as f:
+                file_config = tomllib.load(f)
+            file_model = file_config.get("embedding_model")
+            if file_model:
+                if file_model.startswith("ollama/"):
+                    return EmbeddingConfig(
+                        provider=EmbeddingProvider.OLLAMA,
+                        model=file_model,
+                        source="file",
+                    )
+                else:
+                    return EmbeddingConfig(
+                        provider=EmbeddingProvider.LITELLM,
+                        model=file_model,
+                        source="file",
+                    )
+        except Exception:
+            pass
+    
+    # Check if LLM_API_KEY is set (implies cloud embedding might work)
+    if os.environ.get("LLM_API_KEY"):
+        return EmbeddingConfig(
+            provider=EmbeddingProvider.LITELLM,
+            model="openai/text-embedding-3-small",  # Default
+            source="detected",
+        )
+    
+    return EmbeddingConfig(
+        provider=EmbeddingProvider.NONE,
+        model=None,
+        source="none",
+    )
+
+
+def test_current_config() -> EmbeddingConfig:
+    """Get current config and test if it works.
+    
+    Returns:
+        EmbeddingConfig with is_working and error populated
+    """
+    config = get_current_config()
+    
+    if not config.is_configured:
+        config.is_working = False
+        config.error = "No embedding model configured"
+        return config
+    
+    if config.provider == EmbeddingProvider.OLLAMA:
+        # Extract model name without ollama/ prefix
+        model_name = config.model.split("/", 1)[1] if "/" in config.model else config.model
+        success, error = test_ollama_embedding(model_name)
+        config.is_working = success
+        config.error = error
+    else:
+        success, error = test_litellm_embedding(config.model)
+        config.is_working = success
+        config.error = error
+    
+    return config
+
+
+def save_embedding_config(model: str, ollama_host: str | None = None) -> None:
+    """Save embedding configuration to config file.
+    
+    Args:
+        model: Full model name (e.g., "ollama/nomic-embed-text" or "openai/text-embedding-3-small")
+        ollama_host: Optional Ollama host URL to save
+    """
+    from ohtv.config import get_config_file_path
+    
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    
+    config_path = get_config_file_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Load existing config
+    existing = {}
+    if config_path.exists():
+        try:
+            with open(config_path, "rb") as f:
+                existing = tomllib.load(f)
+        except Exception:
+            pass
+    
+    # Update embedding config
+    existing["embedding_model"] = model
+    if ollama_host and ollama_host != "http://localhost:11434":
+        existing["ollama_host"] = ollama_host
+    
+    # Write back as TOML
+    lines = ["# ohtv configuration", "# See 'ohtv config --help' for available settings", ""]
+    for key, value in sorted(existing.items()):
+        if isinstance(value, str):
+            lines.append(f'{key} = "{value}"')
+        else:
+            lines.append(f"{key} = {value}")
+    lines.append("")
+    config_path.write_text("\n".join(lines))
+
+
+def get_effective_embedding_model() -> str | None:
+    """Get the effective embedding model to use.
+    
+    Checks env var first, then config file. Returns None if not configured.
+    This is the function that should be used by embedding operations.
+    """
+    # Environment variable takes precedence
+    env_model = os.environ.get("EMBEDDING_MODEL")
+    if env_model:
+        return env_model
+    
+    # Check config file
+    from ohtv.config import get_config_file_path
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    
+    config_path = get_config_file_path()
+    if config_path.exists():
+        try:
+            with open(config_path, "rb") as f:
+                file_config = tomllib.load(f)
+            return file_config.get("embedding_model")
+        except Exception:
+            pass
+    
+    return None
+
+
+def is_embedding_configured() -> bool:
+    """Check if embedding is configured (either via env or config file).
+    
+    This does NOT test if the configuration works, just if something is set.
+    """
+    # Check EMBEDDING_MODEL env var
+    if os.environ.get("EMBEDDING_MODEL"):
+        return True
+    
+    # Check LLM_API_KEY (implies default model can be used)
+    if os.environ.get("LLM_API_KEY"):
+        return True
+    
+    # Check config file
+    model = get_effective_embedding_model()
+    return model is not None

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -497,7 +497,7 @@ def config_embed(test: bool, reset: bool) -> None:
     """
     from ohtv.analysis.embeddings.config import (
         get_current_config, test_current_config, detect_ollama,
-        test_ollama_embedding, save_embedding_config, get_config_file_path,
+        test_ollama_embedding, save_embedding_config,
         RECOMMENDED_OLLAMA_MODELS, get_effective_embedding_model,
     )
     from ohtv.config import get_config_file_path

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -595,18 +595,9 @@ def _test_embedding_config() -> None:
         console.print("\nRun [cyan]ohtv config-embed[/cyan] to reconfigure.")
 
 
-def _run_embedding_wizard() -> None:
-    """Run the interactive embedding configuration wizard."""
-    from ohtv.analysis.embeddings.config import (
-        get_current_config, test_current_config, detect_ollama,
-        test_ollama_embedding, save_embedding_config,
-        RECOMMENDED_OLLAMA_MODELS, test_litellm_embedding,
-    )
-    from ohtv.config import get_config_file_path
-    from rich.prompt import Prompt, Confirm
+def _wizard_print_header() -> None:
+    """Print the wizard header panel."""
     from rich.panel import Panel
-    import os
-    
     console.print()
     console.print(Panel.fit(
         "[bold]Embedding Configuration Wizard[/bold]\n\n"
@@ -615,62 +606,52 @@ def _run_embedding_wizard() -> None:
         border_style="blue",
     ))
     console.print()
-    
-    # Step 1: Check current configuration
-    console.print("[bold]Step 1:[/bold] Checking current configuration...")
-    current = get_current_config()
-    
-    has_llm_key = bool(os.environ.get("LLM_API_KEY"))
-    ollama_status = detect_ollama()
-    
-    # Show what we found
-    console.print()
-    if current.is_configured:
-        console.print(f"  [green]✓[/green] Found configured model: [cyan]{current.model}[/cyan] (from {current.source})")
-        
-        # Test if it works
-        console.print("  Testing...", end=" ")
-        tested = test_current_config()
-        if tested.is_working:
-            console.print("[green]working![/green]")
-            console.print()
-            if not Confirm.ask("Current configuration is working. Reconfigure anyway?", default=False):
-                console.print("\n[dim]Keeping current configuration.[/dim]")
-                return
-        else:
-            console.print(f"[red]not working[/red] - {tested.error}")
-    else:
-        console.print("  [yellow]![/yellow] No embedding model configured")
-    
-    if has_llm_key:
-        console.print(f"  [green]✓[/green] LLM_API_KEY is set (cloud embeddings available)")
-    else:
-        console.print(f"  [dim]-[/dim] LLM_API_KEY not set")
-    
-    if ollama_status.is_running:
-        if ollama_status.available_models:
-            models_str = ", ".join(ollama_status.available_models[:3])
-            if len(ollama_status.available_models) > 3:
-                models_str += f" (+{len(ollama_status.available_models) - 3} more)"
-            console.print(f"  [green]✓[/green] Ollama is running with embedding models: {models_str}")
-        else:
-            console.print(f"  [green]✓[/green] Ollama is running (no embedding models installed)")
-    else:
+
+
+def _wizard_show_ollama_status(ollama_status) -> None:
+    """Display Ollama detection status."""
+    if not ollama_status.is_running:
         console.print(f"  [dim]-[/dim] Ollama not detected at {ollama_status.host}")
-    
+        return
+    if ollama_status.available_models:
+        models_str = ", ".join(ollama_status.available_models[:3])
+        if len(ollama_status.available_models) > 3:
+            models_str += f" (+{len(ollama_status.available_models) - 3} more)"
+        console.print(f"  [green]✓[/green] Ollama is running with embedding models: {models_str}")
+    else:
+        console.print(f"  [green]✓[/green] Ollama is running (no embedding models installed)")
+
+
+def _wizard_check_current_config(current, test_current_config) -> bool:
+    """Check and display current config. Returns False if user wants to keep it."""
+    from rich.prompt import Confirm
     console.print()
+    if not current.is_configured:
+        console.print("  [yellow]![/yellow] No embedding model configured")
+        return True
     
-    # Step 2: Choose provider
-    console.print("[bold]Step 2:[/bold] Choose embedding provider\n")
+    console.print(f"  [green]✓[/green] Found configured model: [cyan]{current.model}[/cyan] (from {current.source})")
+    console.print("  Testing...", end=" ")
+    tested = test_current_config()
+    if tested.is_working:
+        console.print("[green]working![/green]")
+        console.print()
+        if not Confirm.ask("Current configuration is working. Reconfigure anyway?", default=False):
+            console.print("\n[dim]Keeping current configuration.[/dim]")
+            return False
+    else:
+        console.print(f"[red]not working[/red] - {tested.error}")
+    return True
+
+
+def _wizard_build_options(ollama_status, has_llm_key: bool) -> tuple[list[str], dict]:
+    """Build provider selection options based on availability."""
+    options, option_map = [], {}
     
-    options = []
-    option_map = {}
-    
-    # Build options based on what's available
     if ollama_status.is_running and ollama_status.available_models:
-        best_ollama = ollama_status.available_models[0]
-        options.append(f"1. [green]Ollama[/green] - Local, free ({best_ollama} ready)")
-        option_map["1"] = ("ollama", best_ollama)
+        best = ollama_status.available_models[0]
+        options.append(f"1. [green]Ollama[/green] - Local, free ({best} ready)")
+        option_map["1"] = ("ollama", best)
     elif ollama_status.is_running:
         options.append("1. [yellow]Ollama[/yellow] - Local, free (needs model download)")
         option_map["1"] = ("ollama_setup", None)
@@ -687,19 +668,11 @@ def _run_embedding_wizard() -> None:
     
     options.append("3. Cancel")
     option_map["3"] = ("cancel", None)
-    
-    for opt in options:
-        console.print(f"  {opt}")
-    
-    console.print()
-    choice = Prompt.ask("Select option", choices=["1", "2", "3"], default="1" if ollama_status.is_running else "2" if has_llm_key else "3")
-    
-    provider, model = option_map[choice]
-    
-    if provider == "cancel":
-        console.print("\n[dim]Cancelled.[/dim]")
-        return
-    
+    return options, option_map
+
+
+def _wizard_show_setup_instructions(provider: str) -> None:
+    """Show setup instructions for unavailable providers."""
     if provider == "ollama_unavailable":
         console.print("\n[yellow]Ollama is not running.[/yellow]")
         console.print("\nTo use Ollama for free local embeddings:")
@@ -707,28 +680,28 @@ def _run_embedding_wizard() -> None:
         console.print("  2. Start the server: [cyan]ollama serve[/cyan]")
         console.print("  3. Pull a model: [cyan]ollama pull nomic-embed-text[/cyan]")
         console.print("  4. Run this wizard again: [cyan]ohtv config-embed[/cyan]")
-        return
-    
-    if provider == "openai_unavailable":
+    elif provider == "openai_unavailable":
         console.print("\n[yellow]LLM_API_KEY is not set.[/yellow]")
         console.print("\nTo use OpenAI embeddings:")
         console.print("  1. Get an API key from https://platform.openai.com")
-        console.print("  2. Set the environment variable:")
-        console.print("     [cyan]export LLM_API_KEY=sk-...[/cyan]")
+        console.print("  2. Set the environment variable: [cyan]export LLM_API_KEY=sk-...[/cyan]")
         console.print("  3. Run this wizard again: [cyan]ohtv config-embed[/cyan]")
         console.print("\n[dim]Or use Ollama for free local embeddings.[/dim]")
-        return
-    
-    if provider == "ollama_setup":
-        # Need to download a model
+    elif provider == "ollama_setup":
         console.print("\n[bold]Ollama Setup[/bold]")
-        console.print("\nNo embedding models found. Recommended model: [cyan]nomic-embed-text[/cyan]")
-        console.print("\nDownload it with:")
-        console.print("  [cyan]ollama pull nomic-embed-text[/cyan]")
+        console.print("\nNo embedding models found. Recommended: [cyan]nomic-embed-text[/cyan]")
+        console.print("\nDownload it with: [cyan]ollama pull nomic-embed-text[/cyan]")
         console.print("\nThen run this wizard again.")
-        return
+
+
+def _wizard_test_and_save(provider: str, model: str) -> None:
+    """Test the selected provider and save if successful."""
+    from ohtv.analysis.embeddings.config import (
+        test_ollama_embedding, test_litellm_embedding, save_embedding_config
+    )
+    from ohtv.config import get_config_file_path
+    from rich.prompt import Confirm
     
-    # Step 3: Test and save
     console.print()
     console.print("[bold]Step 3:[/bold] Testing configuration...")
     
@@ -742,18 +715,16 @@ def _run_embedding_wizard() -> None:
         success, error = test_litellm_embedding(model)
     
     if not success:
-        console.print(f"[red]failed[/red]")
+        console.print("[red]failed[/red]")
         console.print(f"\n[red]Error:[/red] {error}")
         return
     
     console.print("[green]success![/green]")
-    
-    # Save configuration
     console.print()
+    
     if Confirm.ask(f"Save [cyan]{full_model}[/cyan] as default embedding model?", default=True):
         save_embedding_config(full_model)
-        config_path = get_config_file_path()
-        console.print(f"\n[green]✓[/green] Saved to {config_path}")
+        console.print(f"\n[green]✓[/green] Saved to {get_config_file_path()}")
         console.print("\n[dim]You can now use:[/dim]")
         console.print("  [cyan]ohtv db embed[/cyan]    - Build embeddings for search")
         console.print("  [cyan]ohtv search[/cyan]      - Semantic search")
@@ -761,6 +732,53 @@ def _run_embedding_wizard() -> None:
     else:
         console.print("\n[dim]Not saved. To use this model temporarily:[/dim]")
         console.print(f"  [cyan]export EMBEDDING_MODEL={full_model}[/cyan]")
+
+
+def _run_embedding_wizard() -> None:
+    """Run the interactive embedding configuration wizard."""
+    from ohtv.analysis.embeddings.config import (
+        get_current_config, test_current_config, detect_ollama,
+    )
+    from rich.prompt import Prompt
+    import os
+    
+    _wizard_print_header()
+    
+    # Step 1: Detect providers
+    console.print("[bold]Step 1:[/bold] Checking current configuration...")
+    current = get_current_config()
+    has_llm_key = bool(os.environ.get("LLM_API_KEY"))
+    ollama_status = detect_ollama()
+    
+    if not _wizard_check_current_config(current, test_current_config):
+        return
+    
+    if has_llm_key:
+        console.print("  [green]✓[/green] LLM_API_KEY is set (cloud embeddings available)")
+    else:
+        console.print("  [dim]-[/dim] LLM_API_KEY not set")
+    _wizard_show_ollama_status(ollama_status)
+    console.print()
+    
+    # Step 2: Choose provider
+    console.print("[bold]Step 2:[/bold] Choose embedding provider\n")
+    options, option_map = _wizard_build_options(ollama_status, has_llm_key)
+    for opt in options:
+        console.print(f"  {opt}")
+    console.print()
+    
+    default = "1" if ollama_status.is_running else "2" if has_llm_key else "3"
+    choice = Prompt.ask("Select option", choices=["1", "2", "3"], default=default)
+    provider, model = option_map[choice]
+    
+    if provider == "cancel":
+        console.print("\n[dim]Cancelled.[/dim]")
+        return
+    if provider in ("ollama_unavailable", "openai_unavailable", "ollama_setup"):
+        _wizard_show_setup_instructions(provider)
+        return
+    
+    _wizard_test_and_save(provider, model)
 
 
 def _run_post_sync_processing(quiet: bool, verbose: bool, no_llm: bool = False, no_embed: bool = False) -> None:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -437,6 +437,20 @@ def _show_config() -> None:
     console.print()
     console.print(table)
     
+    # Show embedding configuration
+    console.print()
+    console.print("[bold]Embedding Configuration[/bold]")
+    try:
+        from ohtv.analysis.embeddings.config import get_current_config
+        embed_cfg = get_current_config()
+        if embed_cfg.is_configured:
+            console.print(f"  embedding_model: [cyan]{embed_cfg.model}[/cyan] ({_source_style(embed_cfg.source)})")
+        else:
+            console.print("  embedding_model: [dim]not configured[/dim]")
+            console.print("  [dim]Run 'ohtv config-embed' to set up embedding support[/dim]")
+    except Exception:
+        console.print("  embedding_model: [dim]not configured[/dim]")
+    
     # Show data directories
     console.print()
     console.print("[bold]Data Directories[/bold]")
@@ -450,6 +464,303 @@ def _show_config() -> None:
         console.print(f"  [green]✓[/green] manifest exists")
     else:
         console.print(f"  [yellow]![/yellow] manifest not found")
+
+
+@main.command("config-embed")
+@click.option("--test", is_flag=True, help="Test current configuration without changing it")
+@click.option("--reset", is_flag=True, help="Clear saved embedding configuration")
+def config_embed(test: bool, reset: bool) -> None:
+    """Configure embedding model for semantic search.
+    
+    \b
+    Runs a wizard to help configure embedding support. Automatically detects:
+    - Cloud embedding via LLM_API_KEY (OpenAI, etc.)
+    - Local Ollama server for free/offline embeddings
+    
+    \b
+    Usage:
+      ohtv config-embed           Run configuration wizard
+      ohtv config-embed --test    Test current configuration
+      ohtv config-embed --reset   Clear saved configuration
+    
+    \b
+    Supported providers:
+      Cloud (requires LLM_API_KEY):
+        - openai/text-embedding-3-small (default, recommended)
+        - openai/text-embedding-3-large
+        - mistral/mistral-embed
+      
+      Local (free, no API key):
+        - ollama/nomic-embed-text (recommended)
+        - ollama/mxbai-embed-large
+        - ollama/all-minilm
+    """
+    from ohtv.analysis.embeddings.config import (
+        get_current_config, test_current_config, detect_ollama,
+        test_ollama_embedding, save_embedding_config, get_config_file_path,
+        RECOMMENDED_OLLAMA_MODELS, get_effective_embedding_model,
+    )
+    from ohtv.config import get_config_file_path
+    from rich.prompt import Prompt, Confirm
+    from rich.panel import Panel
+    
+    if reset:
+        _reset_embedding_config()
+        return
+    
+    if test:
+        _test_embedding_config()
+        return
+    
+    # Run the wizard
+    _run_embedding_wizard()
+
+
+def _reset_embedding_config() -> None:
+    """Clear saved embedding configuration."""
+    from ohtv.config import get_config_file_path
+    
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    
+    config_path = get_config_file_path()
+    
+    if not config_path.exists():
+        console.print("[dim]No configuration file found.[/dim]")
+        return
+    
+    # Load and remove embedding keys
+    try:
+        with open(config_path, "rb") as f:
+            existing = tomllib.load(f)
+    except Exception:
+        existing = {}
+    
+    removed = []
+    if "embedding_model" in existing:
+        del existing["embedding_model"]
+        removed.append("embedding_model")
+    if "ollama_host" in existing:
+        del existing["ollama_host"]
+        removed.append("ollama_host")
+    
+    if not removed:
+        console.print("[dim]No embedding configuration to clear.[/dim]")
+        return
+    
+    # Write back
+    lines = ["# ohtv configuration", "# See 'ohtv config --help' for available settings", ""]
+    for key, value in sorted(existing.items()):
+        if isinstance(value, str):
+            lines.append(f'{key} = "{value}"')
+        else:
+            lines.append(f"{key} = {value}")
+    lines.append("")
+    config_path.write_text("\n".join(lines))
+    
+    console.print(f"[green]✓[/green] Cleared: {', '.join(removed)}")
+    console.print("[dim]Embedding will now use environment variables or defaults.[/dim]")
+
+
+def _test_embedding_config() -> None:
+    """Test the current embedding configuration."""
+    from ohtv.analysis.embeddings.config import test_current_config, get_current_config
+    
+    console.print("\n[bold]Testing Embedding Configuration[/bold]\n")
+    
+    # Show current config
+    config = get_current_config()
+    
+    if not config.is_configured:
+        console.print("[yellow]No embedding model configured.[/yellow]")
+        console.print("\nRun [cyan]ohtv config-embed[/cyan] to set up embedding support.")
+        return
+    
+    console.print(f"  Model:    [cyan]{config.model}[/cyan]")
+    console.print(f"  Provider: {config.provider.value}")
+    console.print(f"  Source:   {config.source}")
+    console.print()
+    
+    # Test it
+    console.print("Testing connection...", end=" ")
+    config = test_current_config()
+    
+    if config.is_working:
+        console.print("[green]✓ Working![/green]")
+    else:
+        console.print("[red]✗ Failed[/red]")
+        console.print(f"\n[red]Error:[/red] {config.error}")
+        console.print("\nRun [cyan]ohtv config-embed[/cyan] to reconfigure.")
+
+
+def _run_embedding_wizard() -> None:
+    """Run the interactive embedding configuration wizard."""
+    from ohtv.analysis.embeddings.config import (
+        get_current_config, test_current_config, detect_ollama,
+        test_ollama_embedding, save_embedding_config,
+        RECOMMENDED_OLLAMA_MODELS, test_litellm_embedding,
+    )
+    from ohtv.config import get_config_file_path
+    from rich.prompt import Prompt, Confirm
+    from rich.panel import Panel
+    import os
+    
+    console.print()
+    console.print(Panel.fit(
+        "[bold]Embedding Configuration Wizard[/bold]\n\n"
+        "This wizard will help you configure embedding support for\n"
+        "semantic search ([cyan]ohtv search[/cyan]) and RAG ([cyan]ohtv ask[/cyan]).",
+        border_style="blue",
+    ))
+    console.print()
+    
+    # Step 1: Check current configuration
+    console.print("[bold]Step 1:[/bold] Checking current configuration...")
+    current = get_current_config()
+    
+    has_llm_key = bool(os.environ.get("LLM_API_KEY"))
+    ollama_status = detect_ollama()
+    
+    # Show what we found
+    console.print()
+    if current.is_configured:
+        console.print(f"  [green]✓[/green] Found configured model: [cyan]{current.model}[/cyan] (from {current.source})")
+        
+        # Test if it works
+        console.print("  Testing...", end=" ")
+        tested = test_current_config()
+        if tested.is_working:
+            console.print("[green]working![/green]")
+            console.print()
+            if not Confirm.ask("Current configuration is working. Reconfigure anyway?", default=False):
+                console.print("\n[dim]Keeping current configuration.[/dim]")
+                return
+        else:
+            console.print(f"[red]not working[/red] - {tested.error}")
+    else:
+        console.print("  [yellow]![/yellow] No embedding model configured")
+    
+    if has_llm_key:
+        console.print(f"  [green]✓[/green] LLM_API_KEY is set (cloud embeddings available)")
+    else:
+        console.print(f"  [dim]-[/dim] LLM_API_KEY not set")
+    
+    if ollama_status.is_running:
+        if ollama_status.available_models:
+            models_str = ", ".join(ollama_status.available_models[:3])
+            if len(ollama_status.available_models) > 3:
+                models_str += f" (+{len(ollama_status.available_models) - 3} more)"
+            console.print(f"  [green]✓[/green] Ollama is running with embedding models: {models_str}")
+        else:
+            console.print(f"  [green]✓[/green] Ollama is running (no embedding models installed)")
+    else:
+        console.print(f"  [dim]-[/dim] Ollama not detected at {ollama_status.host}")
+    
+    console.print()
+    
+    # Step 2: Choose provider
+    console.print("[bold]Step 2:[/bold] Choose embedding provider\n")
+    
+    options = []
+    option_map = {}
+    
+    # Build options based on what's available
+    if ollama_status.is_running and ollama_status.available_models:
+        best_ollama = ollama_status.available_models[0]
+        options.append(f"1. [green]Ollama[/green] - Local, free ({best_ollama} ready)")
+        option_map["1"] = ("ollama", best_ollama)
+    elif ollama_status.is_running:
+        options.append("1. [yellow]Ollama[/yellow] - Local, free (needs model download)")
+        option_map["1"] = ("ollama_setup", None)
+    else:
+        options.append("1. [dim]Ollama[/dim] - Not running (start with: ollama serve)")
+        option_map["1"] = ("ollama_unavailable", None)
+    
+    if has_llm_key:
+        options.append("2. [green]OpenAI[/green] - Cloud, uses LLM_API_KEY (~$0.02/1M tokens)")
+        option_map["2"] = ("openai", "openai/text-embedding-3-small")
+    else:
+        options.append("2. [dim]OpenAI[/dim] - Requires LLM_API_KEY")
+        option_map["2"] = ("openai_unavailable", None)
+    
+    options.append("3. Cancel")
+    option_map["3"] = ("cancel", None)
+    
+    for opt in options:
+        console.print(f"  {opt}")
+    
+    console.print()
+    choice = Prompt.ask("Select option", choices=["1", "2", "3"], default="1" if ollama_status.is_running else "2" if has_llm_key else "3")
+    
+    provider, model = option_map[choice]
+    
+    if provider == "cancel":
+        console.print("\n[dim]Cancelled.[/dim]")
+        return
+    
+    if provider == "ollama_unavailable":
+        console.print("\n[yellow]Ollama is not running.[/yellow]")
+        console.print("\nTo use Ollama for free local embeddings:")
+        console.print("  1. Install Ollama: https://ollama.ai")
+        console.print("  2. Start the server: [cyan]ollama serve[/cyan]")
+        console.print("  3. Pull a model: [cyan]ollama pull nomic-embed-text[/cyan]")
+        console.print("  4. Run this wizard again: [cyan]ohtv config-embed[/cyan]")
+        return
+    
+    if provider == "openai_unavailable":
+        console.print("\n[yellow]LLM_API_KEY is not set.[/yellow]")
+        console.print("\nTo use OpenAI embeddings:")
+        console.print("  1. Get an API key from https://platform.openai.com")
+        console.print("  2. Set the environment variable:")
+        console.print("     [cyan]export LLM_API_KEY=sk-...[/cyan]")
+        console.print("  3. Run this wizard again: [cyan]ohtv config-embed[/cyan]")
+        console.print("\n[dim]Or use Ollama for free local embeddings.[/dim]")
+        return
+    
+    if provider == "ollama_setup":
+        # Need to download a model
+        console.print("\n[bold]Ollama Setup[/bold]")
+        console.print("\nNo embedding models found. Recommended model: [cyan]nomic-embed-text[/cyan]")
+        console.print("\nDownload it with:")
+        console.print("  [cyan]ollama pull nomic-embed-text[/cyan]")
+        console.print("\nThen run this wizard again.")
+        return
+    
+    # Step 3: Test and save
+    console.print()
+    console.print("[bold]Step 3:[/bold] Testing configuration...")
+    
+    if provider == "ollama":
+        full_model = f"ollama/{model}"
+        console.print(f"\n  Testing {full_model}...", end=" ")
+        success, error = test_ollama_embedding(model)
+    else:
+        full_model = model
+        console.print(f"\n  Testing {full_model}...", end=" ")
+        success, error = test_litellm_embedding(model)
+    
+    if not success:
+        console.print(f"[red]failed[/red]")
+        console.print(f"\n[red]Error:[/red] {error}")
+        return
+    
+    console.print("[green]success![/green]")
+    
+    # Save configuration
+    console.print()
+    if Confirm.ask(f"Save [cyan]{full_model}[/cyan] as default embedding model?", default=True):
+        save_embedding_config(full_model)
+        config_path = get_config_file_path()
+        console.print(f"\n[green]✓[/green] Saved to {config_path}")
+        console.print("\n[dim]You can now use:[/dim]")
+        console.print("  [cyan]ohtv db embed[/cyan]    - Build embeddings for search")
+        console.print("  [cyan]ohtv search[/cyan]      - Semantic search")
+        console.print("  [cyan]ohtv ask[/cyan]         - Ask questions about conversations")
+    else:
+        console.print("\n[dim]Not saved. To use this model temporarily:[/dim]")
+        console.print(f"  [cyan]export EMBEDDING_MODEL={full_model}[/cyan]")
 
 
 def _run_post_sync_processing(quiet: bool, verbose: bool, no_llm: bool = False, no_embed: bool = False) -> None:
@@ -596,11 +907,20 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
     from pathlib import Path
     from ohtv.db.stores import ConversationStore, EmbeddingStore
     from ohtv.filters import normalize_conversation_id
+    from ohtv.analysis.embeddings.config import is_embedding_configured, get_current_config
     
-    # Check if embedding is configured
-    if not os.environ.get("LLM_API_KEY"):
+    # Check if embedding is configured (env var, config file, or Ollama)
+    if not is_embedding_configured():
+        # Check if Ollama might be available as a fallback
+        from ohtv.analysis.embeddings.config import detect_ollama
+        ollama_status = detect_ollama()
+        
         if not quiet:
-            console.print("\n[dim]Skipping embeddings (LLM_API_KEY not set)[/dim]")
+            console.print("\n[dim]Skipping embeddings (not configured)[/dim]")
+            if ollama_status.is_running:
+                console.print("[dim]Tip: Ollama detected! Run 'ohtv config-embed' to set up free local embeddings.[/dim]")
+            else:
+                console.print("[dim]Run 'ohtv config-embed' to configure embedding support.[/dim]")
         return
     
     if not quiet:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -595,6 +595,7 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
     from ohtv.db import get_connection
     from pathlib import Path
     from ohtv.db.stores import ConversationStore, EmbeddingStore
+    from ohtv.filters import normalize_conversation_id
     
     # Check if embedding is configured
     if not os.environ.get("LLM_API_KEY"):
@@ -609,6 +610,9 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         conv_store = ConversationStore(conn)
         embed_store = EmbeddingStore(conn)
         
+        # Build set of already-embedded conversation IDs (normalized for comparison)
+        existing_ids = set(normalize_conversation_id(cid) for cid in embed_store.list_conversation_ids())
+        
         all_convs = conv_store.list_all()
         
         # Find conversations without embeddings that have local content
@@ -617,17 +621,18 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
         already_embedded = 0
         
         for conv in all_convs:
-            # Skip if no local directory or no events file
+            # Skip if no local directory or no events directory
             if not conv.location:
                 no_local_content += 1
                 continue
             conv_dir = Path(conv.location)
-            events_file = conv_dir / "events.json"
-            if not events_file.exists():
+            events_dir = conv_dir / "events"
+            if not events_dir.exists() or not events_dir.is_dir():
                 no_local_content += 1
                 continue
             
-            if embed_store.has_embedding(conv.id):
+            # Check using normalized ID (handles dash variations)
+            if normalize_conversation_id(conv.id) in existing_ids:
                 already_embedded += 1
                 continue
                 


### PR DESCRIPTION
## Summary

Adds an interactive wizard to help users configure embedding support for semantic search and RAG. The wizard auto-detects available providers and guides users through setup.

## Problem

Previously, configuring embeddings was confusing:
- Users didn't know if they needed `LLM_API_KEY` or could use Ollama
- Error messages weren't helpful when configuration was wrong
- No way to persist Ollama configuration (had to set env var every time)
- Sync flow would silently skip embeddings without explaining alternatives

## Solution

### New Command: `ohtv config-embed`

```bash
# Run the interactive wizard
ohtv config-embed

# Test current configuration
ohtv config-embed --test

# Clear saved configuration  
ohtv config-embed --reset
```

### Wizard Flow

1. **Detection Phase**
   - Checks for existing `EMBEDDING_MODEL` env var or config file setting
   - Tests if current configuration works
   - Detects if `LLM_API_KEY` is set (cloud embeddings available)
   - Probes local Ollama server for availability and installed models

2. **Selection Phase**
   - Shows available options with availability status
   - Ollama (green if running with models, yellow if needs setup, dim if not running)
   - OpenAI (green if API key set, dim otherwise)

3. **Test & Save Phase**
   - Tests the selected provider with a real embedding request
   - Saves working configuration to `~/.ohtv/config.toml`

### Example Output

```
╭─────────────────────────────────────╮
│   Embedding Configuration Wizard    │
│                                     │
│ This wizard will help you configure │
│ embedding support for semantic      │
│ search (ohtv search) and RAG        │
│ (ohtv ask).                         │
╰─────────────────────────────────────╯

Step 1: Checking current configuration...

  ✓ Ollama is running with embedding models: nomic-embed-text
  - LLM_API_KEY not set

Step 2: Choose embedding provider

  1. Ollama - Local, free (nomic-embed-text ready)
  2. OpenAI - Requires LLM_API_KEY
  3. Cancel

Select option [1/2/3] (1): 1

Step 3: Testing configuration...

  Testing ollama/nomic-embed-text... success!

Save ollama/nomic-embed-text as default embedding model? [Y/n]: y

✓ Saved to /Users/you/.ohtv/config.toml

You can now use:
  ohtv db embed    - Build embeddings for search
  ohtv search      - Semantic search
  ohtv ask         - Ask questions about conversations
```

### Other Improvements

- **`ohtv config`** now shows embedding configuration section
- **Sync flow** shows helpful hints when Ollama is detected but not configured
- **`get_embedding_model()`** now checks config file as fallback after env var

## Files Changed

- `src/ohtv/analysis/embeddings/config.py` - New module for embedding config detection/persistence
- `src/ohtv/analysis/embeddings/client.py` - Updated to check config file
- `src/ohtv/cli.py` - Added wizard command and updated related functions

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*