### PR TITLE
feat(sync): add --repair option to check and fix sync state consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,21 +31,27 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
 
 2. **Sync-first architecture**: Cloud conversations must be synced locally before viewing (no direct API queries per-request)
 
-3. **Title derivation**: Local conversations derive titles from first user message (first 60 chars, word boundary truncation)
+3. **Sync state repair**: The `ohtv sync --repair` command checks and fixes sync state consistency:
+   - Compares manifest entries vs actual files on disk
+   - Queries cloud API for total conversation count
+   - Reports ghost entries (in manifest but not on disk) and orphaned files (on disk but not in manifest)
+   - With `--dry-run`, only reports; without, repairs by updating manifest
 
-4. **Timezone handling**: Cloud timestamps are UTC; local CLI timestamps lack timezone info. The codebase normalizes to UTC for sorting, then converts to local time for display. **Limitation:** Local timestamps are interpreted using the current machine's timezone - if data moves between machines with different timezones, times may display incorrectly.
+4. **Title derivation**: Local conversations derive titles from first user message (first 60 chars, word boundary truncation)
 
-5. **LLM analysis caching**: The `gen objs` command caches results keyed by parameter combination (context level, detail level, assess flag). Cache invalidates when event count changes (conversation grew) or when the prompt file changes (detected via prompt hash). Multi-conversation mode (batch) uses minimal context + brief detail for token efficiency.
+5. **Timezone handling**: Cloud timestamps are UTC; local CLI timestamps lack timezone info. The codebase normalizes to UTC for sorting, then converts to local time for display. **Limitation:** Local timestamps are interpreted using the current machine's timezone - if data moves between machines with different timezones, times may display incorrectly.
 
-6. **LLM timeout**: Default 300s. Override with `LLM_TIMEOUT` env var. CLI shows spinner during analysis.
+6. **LLM analysis caching**: The `gen objs` command caches results keyed by parameter combination (context level, detail level, assess flag). Cache invalidates when event count changes (conversation grew) or when the prompt file changes (detected via prompt hash). Multi-conversation mode (batch) uses minimal context + brief detail for token efficiency.
 
-7. **LLM cost tracking**: `analyze_objectives()` returns an `AnalysisResult` dataclass containing `analysis` (ObjectiveAnalysis), `cost` (float, dollars), and `from_cache` (bool). The `gen objs` command (batch mode) displays running cost in the progress bar during analysis and shows total cost after completion. Cost is obtained from `response.metrics.accumulated_cost` via the OpenHands SDK LLM class.
+7. **LLM timeout**: Default 300s. Override with `LLM_TIMEOUT` env var. CLI shows spinner during analysis.
 
-8. **Human-readable action details**: `-d` flag formats tool calls for readability (e.g., `$ git status` for terminal). Use `--debug-tool-call` for raw JSON.
+8. **LLM cost tracking**: `analyze_objectives()` returns an `AnalysisResult` dataclass containing `analysis` (ObjectiveAnalysis), `cost` (float, dollars), and `from_cache` (bool). The `gen objs` command (batch mode) displays running cost in the progress bar during analysis and shows total cost after completion. Cost is obtained from `response.metrics.accumulated_cost` via the OpenHands SDK LLM class.
 
-9. **Output truncation**: `-o` truncates to 2000 chars; `-O` shows full output. Both show exit codes.
+9. **Human-readable action details**: `-d` flag formats tool calls for readability (e.g., `$ git status` for terminal). Use `--debug-tool-call` for raw JSON.
 
-10. **SQLite indexing**: Lightweight index for conversations and relationships. See `docs/DATABASE.md`. Key points:
+10. **Output truncation**: `-o` truncates to 2000 chars; `-O` shows full output. Both show exit codes.
+
+11. **SQLite indexing**: Lightweight index for conversations and relationships. See `docs/DATABASE.md`. Key points:
     - Minimal footprint: metadata only, content stays on filesystem
     - Two-phase: `db scan` (fast registration) + `db process <stage>` (incremental)
     - Change detection: mtime as fast filter, event_count as checkpoint
@@ -54,20 +60,20 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - **Stage order**: refs → actions → branch_context → push_pr_links (defined in `stages/__init__.py`)
     - **Dependency caveat**: Stages don't validate dependencies - running a stage before its dependencies completes successfully but does nothing useful (marks itself complete with empty results). Always use `db process all` to ensure correct ordering.
 
-11. **Data directory separation**:
+12. **Data directory separation**:
     - `~/.openhands/`: Read-only source data (only `sync` writes here)
     - `~/.ohtv/`: All ohtv-generated data (database, logs, cache). Override with `OHTV_DIR`.
 
-12. **Filter matching**: PR/repo/action filters require indexed database (`db scan && db process all`). PR filter uses precise matching (`#1` won't match `#10`). Action+repo combined filter uses target URLs when available.
+13. **Filter matching**: PR/repo/action filters require indexed database (`db scan && db process all`). PR filter uses precise matching (`#1` won't match `#10`). Action+repo combined filter uses target URLs when available.
 
-13. **Conversation ID normalization**: Database stores IDs without dashes; LocalSource returns with dashes. The `filters` module and `_find_conversation_dir` normalize both formats (removing dashes before directory lookup).
+14. **Conversation ID normalization**: Database stores IDs without dashes; LocalSource returns with dashes. The `filters` module and `_find_conversation_dir` normalize both formats (removing dashes before directory lookup).
 
-14. **Refs command dual mode**: The `refs` command supports two modes:
+15. **Refs command dual mode**: The `refs` command supports two modes:
     - **Single conversation mode**: `refs <id>` - Shows rich display with interaction annotations
     - **Multi-conversation mode**: `refs -D` (or other filters) - Aggregates and deduplicates refs across conversations
     - Machine-readable formats (`-1`, `--format lines|csv|json`) suppress rich output for automation
 
-15. **Terminal confirmation prompts**: Use Rich's `Confirm.ask()` with the same console instance:
+16. **Terminal confirmation prompts**: Use Rich's `Confirm.ask()` with the same console instance:
     ```python
     from rich.prompt import Confirm
     if not Confirm.ask("Are you sure?", console=console, default=False):
@@ -75,25 +81,25 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
         return
     ```
 
-16. **Branch and PR tracking**: 
+17. **Branch and PR tracking**: 
     - **Branch refs**: Branches are first-class refs (like issues/PRs). The `branch_context` stage creates branch refs from GIT_PUSH actions
     - **Push-PR linking**: The `push_pr_links` stage correlates pushes with PRs via branch matching
     - **Conservative approach**: Only links when full owner/repo/branch qualification exists on both sides
     - **Current limitation**: Temporal ordering not yet implemented (pushes before PR creation don't link correctly)
     - **Design doc**: See `docs/DESIGN_TEMPORAL_PR_LINKING.md` for planned improvements
 
-17. **Processing stage order**: `refs → actions → branch_context → push_pr_links`
+18. **Processing stage order**: `refs → actions → branch_context → push_pr_links`
     - Each stage can run independently but has dependencies
     - `all` runs all stages in correct order
 
-18. **Error analysis**: The `errors` module (`src/ohtv/errors.py`) tracks agent/LLM errors that impact agent behavior:
+19. **Error analysis**: The `errors` module (`src/ohtv/errors.py`) tracks agent/LLM errors that impact agent behavior:
     - **ConversationErrorEvent**: Terminal errors (LLM errors, budget exceeded, API failures)
     - **AgentErrorEvent**: Agent-level errors (sandbox restarts, tool validation failures)
     - Does NOT track routine terminal command failures (non-zero exit codes)
     - Errors are classified as TERMINAL (conversation stopped) or RECOVERED (agent continued)
     - Used by `ohtv errors <id>` command and `ohtv list --errors-only` filter
 
-19. **LLM analysis performance timing**: The `analysis/objectives.py` module has timing instrumentation. Check `~/.ohtv/logs/ohtv.log` for entries like:
+20. **LLM analysis performance timing**: The `analysis/objectives.py` module has timing instrumentation. Check `~/.ohtv/logs/ohtv.log` for entries like:
     ```
     TIMING load_events: 11.3ms
     TIMING import_sdk: 1962.5ms
@@ -106,7 +112,7 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - Event loading/transcript building: <100ms
     - Cache operations: <10ms
 
-20. **Parallel processing**: Multiple commands use parallel processing with 20 workers:
+21. **Parallel processing**: Multiple commands use parallel processing with 20 workers:
     - **`gen objs`** (batch mode): Parallel LLM analysis of conversations
     - **`sync`**: Parallel download of conversations from cloud
     - **`db embed`**: Parallel embedding generation
@@ -118,12 +124,12 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - `RateTracker` - Thread-safe rate tracking with smoothing
     - `run_parallel(items, process_fn, ...)` - Generic parallel execution helper
 
-21. **Model configuration**: LLM model can be set via:
+22. **Model configuration**: LLM model can be set via:
     - CLI: `--model/-m` option on `gen objs` command
     - Environment: `LLM_MODEL` env var (used by SDK's `LLM.load_from_env()`)
     - Try `haiku` for faster/cheaper analysis, `opus` for higher quality
 
-22. **Analysis cache indexing**: The database tracks LLM analysis cache state for fast lookup. Key tables:
+23. **Analysis cache indexing**: The database tracks LLM analysis cache state for fast lookup. Key tables:
     - `analysis_cache`: Tracks which conversations have cached analysis (by cache_key, event_count, content_hash)
     - `analysis_skips`: Tracks conversations that cannot be analyzed (no events, no content)
     - **520x speedup**: Cache status check via DB (4ms for 700+ convs) vs loading event files (2+ seconds)
@@ -131,21 +137,21 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - **Auto-sync**: Cache entries automatically sync to DB when `gen objs` command saves results
     - **Cache key format**: `assess=False,context_level=minimal,detail_level=brief` (sorted alphabetically)
 
-23. **Database-first conversation listing**: The database stores full conversation metadata for fast listing:
+24. **Database-first conversation listing**: The database stores full conversation metadata for fast listing:
     - Columns: `title`, `created_at`, `updated_at`, `selected_repository`, `source`
     - **45x speedup**: List with date filter via DB (15ms) vs filesystem scanning (3.8s for 1000+ convs)
     - **Auto-populated**: `db scan` extracts metadata from event files
     - **Graceful fallback**: Uses filesystem if DB unavailable or metadata not populated
     - Date filtering is pushed down to DB query when available
 
-24. **Automatic database maintenance**: The system automatically runs migrations and maintenance tasks:
+25. **Automatic database maintenance**: The system automatically runs migrations and maintenance tasks:
     - **No manual intervention**: Users never need to run `db scan --force` or know about migrations
     - **Maintenance tracking**: `maintenance_tasks` table tracks what's been done
     - **One-time tasks**: Metadata backfill and cache indexing run automatically after their migrations
     - **Progress display**: Long-running tasks show progress bars
     - **Implementation**: `ensure_db_ready()` in `db/maintenance.py` handles all maintenance
 
-25. **Customizable prompts**: LLM analysis prompts are stored as markdown files for user customization:
+26. **Customizable prompts**: LLM analysis prompts are stored as markdown files for user customization:
     - **Default prompts**: `src/ohtv/prompts/*.md` - 6 prompt variants (brief, standard, detailed × assess/no-assess)
     - **User prompts**: `~/.ohtv/prompts/*.md` - Override defaults by copying and editing
     - **Load order**: User prompts checked first, then package defaults

--- a/README.md
+++ b/README.md
@@ -788,6 +788,10 @@ ohtv sync --dry-run
 # Check sync status
 ohtv sync --status
 
+# Check and repair sync state consistency
+ohtv sync --repair --dry-run  # Check only
+ohtv sync --repair            # Fix inconsistencies
+
 # Quiet mode (for cron jobs)
 ohtv sync --quiet
 ```
@@ -799,6 +803,7 @@ ohtv sync --quiet
 | `--since DATE` | Only sync conversations updated after date |
 | `--dry-run` | Show what would sync without downloading |
 | `-s, --status` | Show sync status |
+| `--repair` | Check and fix sync state (manifest vs disk vs cloud) |
 | `-p, --process` | Run all processing stages after sync |
 | `-q, --quiet` | Minimal output for cron jobs |
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -76,7 +76,7 @@ class SectionedGroup(click.Group):
 
 from ohtv.logging import setup_logging
 from ohtv.sources import ConversationInfo, LocalSource
-from ohtv.sync import SyncAbortedError, SyncAuthError, SyncManager, SyncResult
+from ohtv.sync import RepairResult, SyncAbortedError, SyncAuthError, SyncManager, SyncResult
 
 console = Console()
 
@@ -242,6 +242,7 @@ def main() -> None:
 @click.option("--dry-run", is_flag=True, help="Show what would sync without downloading")
 @click.option("--max-new", "-n", type=int, help="Maximum number of NEW conversations to sync")
 @click.option("--status", "-s", is_flag=True, help="Show sync status")
+@click.option("--repair", is_flag=True, help="Check and repair sync state consistency")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output for cron jobs")
 @click.option("--verbose", "-v", is_flag=True, help="Show debug output")
 @click.option("--no-llm", is_flag=True, help="Skip LLM-powered analysis (summaries won't be generated)")
@@ -252,6 +253,7 @@ def sync(
     dry_run: bool,
     max_new: int | None,
     status: bool,
+    repair: bool,
     quiet: bool,
     verbose: bool,
     no_llm: bool,
@@ -269,6 +271,8 @@ def sync(
     
     Combining --force with -n resets local storage to only the N most
     recent conversations (destructive operation, requires confirmation).
+    
+    Use --repair to check and fix sync state consistency (manifest vs disk vs cloud).
     """
     _init_logging(verbose=verbose)
 
@@ -277,6 +281,10 @@ def sync(
 
     if status:
         _show_status(manager)
+        return
+
+    if repair:
+        _run_repair(manager, fix=not dry_run, quiet=quiet)
         return
 
     if not config.api_key:
@@ -717,6 +725,70 @@ def _show_status(manager: SyncManager) -> None:
         table.add_row("Pending retries", f"[red]{pending} failed[/red]")
 
     console.print(table)
+
+
+def _run_repair(manager: SyncManager, fix: bool, quiet: bool) -> None:
+    """Check and optionally repair sync state consistency."""
+    try:
+        result = manager.repair(fix=fix, check_cloud=True)
+    except SyncAuthError as e:
+        console.print(f"[red]Authentication error:[/red] {e}")
+        raise SystemExit(1)
+    
+    if quiet:
+        # Quiet mode: just exit with status code
+        if result.is_consistent and result.cloud_disk_match:
+            raise SystemExit(0)
+        raise SystemExit(1)
+    
+    # Display results
+    table = Table(title="Sync State Consistency Check", show_header=False)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    
+    table.add_row("Cloud conversations", str(result.cloud_count) if result.cloud_count else "[dim]unavailable[/dim]")
+    table.add_row("Manifest entries", str(result.manifest_count))
+    table.add_row("Conversations on disk", str(result.disk_count))
+    
+    console.print(table)
+    console.print()
+    
+    # Cloud vs disk comparison
+    if result.cloud_count:
+        if result.cloud_disk_match:
+            console.print("[green]✓[/green] Cloud and disk counts match")
+        else:
+            diff = result.cloud_count - result.disk_count
+            if diff > 0:
+                console.print(f"[yellow]⚠[/yellow] Missing {diff} conversation(s) from cloud")
+            else:
+                console.print(f"[yellow]⚠[/yellow] {-diff} more conversation(s) on disk than in cloud")
+    
+    # Ghost entries (in manifest but not on disk)
+    if result.ghost_entries:
+        console.print(f"\n[red]✗[/red] Ghost entries (in manifest but not on disk): {len(result.ghost_entries)}")
+        for conv_id in result.ghost_entries[:10]:
+            console.print(f"  [dim]{conv_id}[/dim]")
+        if len(result.ghost_entries) > 10:
+            console.print(f"  [dim]... and {len(result.ghost_entries) - 10} more[/dim]")
+    
+    # Orphaned files (on disk but not in manifest)
+    if result.orphaned_files:
+        console.print(f"\n[yellow]⚠[/yellow] Orphaned files (on disk but not in manifest): {len(result.orphaned_files)}")
+        for conv_id in result.orphaned_files[:10]:
+            console.print(f"  [dim]{conv_id}[/dim]")
+        if len(result.orphaned_files) > 10:
+            console.print(f"  [dim]... and {len(result.orphaned_files) - 10} more[/dim]")
+    
+    # Summary
+    console.print()
+    if result.is_consistent:
+        console.print("[green]✓[/green] Manifest and disk are consistent")
+    elif fix:
+        console.print(f"[green]✓[/green] Repaired: removed {result.removed_from_manifest} ghost entries, "
+                      f"added {result.added_to_manifest} orphaned files to manifest")
+    else:
+        console.print("[yellow]Run with --repair (without --dry-run) to fix inconsistencies[/yellow]")
 
 
 def _error_no_api_key() -> None:

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -63,6 +63,27 @@ class SyncResult:
 
 
 @dataclass
+class RepairResult:
+    """Results of a repair operation."""
+
+    cloud_count: int = 0
+    manifest_count: int = 0
+    disk_count: int = 0
+    ghost_entries: list[str] = field(default_factory=list)  # In manifest but not on disk
+    orphaned_files: list[str] = field(default_factory=list)  # On disk but not in manifest
+    added_to_manifest: int = 0
+    removed_from_manifest: int = 0
+
+    @property
+    def is_consistent(self) -> bool:
+        return not self.ghost_entries and not self.orphaned_files
+
+    @property
+    def cloud_disk_match(self) -> bool:
+        return self.cloud_count == self.disk_count
+
+
+@dataclass
 class SyncManifest:
     """Persistent sync state."""
 
@@ -547,6 +568,108 @@ class SyncManager:
     def get_local_conversation_count(self) -> int:
         """Get count of locally synced conversations."""
         return len(self.manifest.conversations)
+
+    def repair(
+        self,
+        fix: bool = False,
+        check_cloud: bool = True,
+    ) -> RepairResult:
+        """Check and optionally repair sync state consistency.
+        
+        Compares:
+        1. Manifest entries vs actual files on disk
+        2. Total cloud conversations vs local count
+        
+        Args:
+            fix: If True, repair inconsistencies (add orphaned files to manifest,
+                 remove ghost entries)
+            check_cloud: If True, query cloud API for total conversation count
+        
+        Returns:
+            RepairResult with counts and lists of discrepancies
+        """
+        result = RepairResult()
+        
+        # Get manifest conversation IDs (normalized without dashes)
+        manifest_ids = set(self.manifest.conversations.keys())
+        result.manifest_count = len(manifest_ids)
+        
+        # Scan disk for actual conversation directories
+        disk_ids: set[str] = set()
+        synced_dir = self.config.synced_conversations_dir
+        if synced_dir.exists():
+            for d in synced_dir.iterdir():
+                if d.is_dir():
+                    # Normalize: remove dashes from UUID format
+                    conv_id = d.name.replace("-", "")
+                    disk_ids.add(conv_id)
+        result.disk_count = len(disk_ids)
+        
+        # Find discrepancies
+        result.ghost_entries = sorted(manifest_ids - disk_ids)
+        result.orphaned_files = sorted(disk_ids - manifest_ids)
+        
+        log.info(
+            "Repair check: manifest=%d, disk=%d, ghosts=%d, orphaned=%d",
+            result.manifest_count, result.disk_count,
+            len(result.ghost_entries), len(result.orphaned_files)
+        )
+        
+        # Check cloud count if requested and API key available
+        if check_cloud and self.config.api_key:
+            try:
+                with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
+                    result.cloud_count = client.count_conversations()
+                    log.info("Cloud conversation count: %d", result.cloud_count)
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in (401, 403):
+                    raise SyncAuthError(f"Authentication failed (HTTP {e.response.status_code}). Check your API key.")
+                log.warning("Failed to get cloud count: HTTP %s", e.response.status_code)
+            except (httpx.TimeoutException, httpx.ConnectError) as e:
+                log.warning("Failed to get cloud count: %s", e)
+        
+        # Apply fixes if requested
+        if fix:
+            # Remove ghost entries from manifest
+            for ghost_id in result.ghost_entries:
+                del self.manifest.conversations[ghost_id]
+                result.removed_from_manifest += 1
+            
+            # Add orphaned files to manifest
+            for orphan_id in result.orphaned_files:
+                conv_dir = self._find_conversation_dir(orphan_id)
+                if conv_dir:
+                    self.manifest.conversations[orphan_id] = {
+                        "title": None,  # Unknown - could fetch from cloud if needed
+                        "updated_at": None,
+                        "event_count": count_events(conv_dir),
+                        "downloaded_at": _format_datetime(datetime.now(timezone.utc)),
+                    }
+                    result.added_to_manifest += 1
+            
+            if result.removed_from_manifest > 0 or result.added_to_manifest > 0:
+                self.manifest.save(self.manifest_path)
+                log.info(
+                    "Repair applied: removed %d ghost entries, added %d orphaned files",
+                    result.removed_from_manifest, result.added_to_manifest
+                )
+        
+        return result
+
+    def _find_conversation_dir(self, conv_id: str) -> Path | None:
+        """Find conversation directory on disk, handling UUID format variations."""
+        synced_dir = self.config.synced_conversations_dir
+        # Try without dashes first
+        conv_dir = synced_dir / conv_id
+        if conv_dir.exists():
+            return conv_dir
+        # Try with dashes (UUID format)
+        if len(conv_id) == 32:
+            formatted = f"{conv_id[:8]}-{conv_id[8:12]}-{conv_id[12:16]}-{conv_id[16:20]}-{conv_id[20:]}"
+            conv_dir = synced_dir / formatted
+            if conv_dir.exists():
+                return conv_dir
+        return None
 
     def reset_to_n_newest(
         self,

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ohtv.sync import SyncManager, SyncManifest, SyncResult
+from ohtv.sync import RepairResult, SyncManager, SyncManifest, SyncResult
 
 
 class TestSyncResult:
@@ -470,3 +470,219 @@ def _create_minimal_zip() -> bytes:
             "kind": "MessageEvent",
         }))
     return buffer.getvalue()
+
+
+class TestRepairResult:
+    """Tests for RepairResult dataclass."""
+
+    def test_is_consistent_when_no_discrepancies(self):
+        result = RepairResult(
+            manifest_count=10,
+            disk_count=10,
+            ghost_entries=[],
+            orphaned_files=[],
+        )
+        assert result.is_consistent is True
+
+    def test_is_consistent_false_when_ghosts(self):
+        result = RepairResult(
+            ghost_entries=["abc123"],
+            orphaned_files=[],
+        )
+        assert result.is_consistent is False
+
+    def test_is_consistent_false_when_orphaned(self):
+        result = RepairResult(
+            ghost_entries=[],
+            orphaned_files=["xyz789"],
+        )
+        assert result.is_consistent is False
+
+    def test_cloud_disk_match_when_equal(self):
+        result = RepairResult(cloud_count=100, disk_count=100)
+        assert result.cloud_disk_match is True
+
+    def test_cloud_disk_match_false_when_different(self):
+        result = RepairResult(cloud_count=100, disk_count=50)
+        assert result.cloud_disk_match is False
+
+
+class TestSyncManagerRepair:
+    """Tests for SyncManager.repair method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.synced_conversations_dir.mkdir(parents=True)
+        config.api_key = None  # No API key - skip cloud check
+        config.cloud_api_url = "https://example.com"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_detects_consistent_state(self, manager):
+        """Test that repair detects when manifest and disk are consistent."""
+        # Add conversation to manifest
+        manager.manifest.conversations = {
+            "abc123": {"title": "Test", "event_count": 5},
+        }
+        
+        # Create matching directory on disk
+        conv_dir = manager.config.synced_conversations_dir / "abc123"
+        conv_dir.mkdir()
+        
+        result = manager.repair(fix=False, check_cloud=False)
+        
+        assert result.manifest_count == 1
+        assert result.disk_count == 1
+        assert result.is_consistent is True
+        assert len(result.ghost_entries) == 0
+        assert len(result.orphaned_files) == 0
+
+    def test_detects_ghost_entries(self, manager):
+        """Test that repair detects entries in manifest but not on disk."""
+        # Add conversation to manifest but NOT on disk
+        manager.manifest.conversations = {
+            "ghost123": {"title": "Ghost", "event_count": 5},
+        }
+        
+        result = manager.repair(fix=False, check_cloud=False)
+        
+        assert result.manifest_count == 1
+        assert result.disk_count == 0
+        assert result.is_consistent is False
+        assert "ghost123" in result.ghost_entries
+
+    def test_detects_orphaned_files(self, manager):
+        """Test that repair detects files on disk but not in manifest."""
+        # Create directory on disk but NOT in manifest
+        conv_dir = manager.config.synced_conversations_dir / "orphan456"
+        conv_dir.mkdir()
+        
+        result = manager.repair(fix=False, check_cloud=False)
+        
+        assert result.manifest_count == 0
+        assert result.disk_count == 1
+        assert result.is_consistent is False
+        assert "orphan456" in result.orphaned_files
+
+    def test_normalizes_uuid_format(self, manager):
+        """Test that repair handles UUID format with dashes."""
+        # Add conversation to manifest without dashes (32 chars)
+        manager.manifest.conversations = {
+            "abc12345678901234567890123456abc": {"title": "Test"},
+        }
+        
+        # Create directory on disk WITH dashes (UUID format: 8-4-4-4-12)
+        uuid_format = "abc12345-6789-0123-4567-890123456abc"
+        conv_dir = manager.config.synced_conversations_dir / uuid_format
+        conv_dir.mkdir()
+        
+        result = manager.repair(fix=False, check_cloud=False)
+        
+        # Should detect the match despite format difference
+        assert result.is_consistent is True
+
+    def test_fix_removes_ghost_entries(self, manager):
+        """Test that repair with fix=True removes ghost entries."""
+        # Add ghost entry
+        manager.manifest.conversations = {
+            "ghost123": {"title": "Ghost"},
+            "real456": {"title": "Real"},
+        }
+        
+        # Only create real456 on disk
+        (manager.config.synced_conversations_dir / "real456").mkdir()
+        
+        result = manager.repair(fix=True, check_cloud=False)
+        
+        assert result.removed_from_manifest == 1
+        assert "ghost123" not in manager.manifest.conversations
+        assert "real456" in manager.manifest.conversations
+
+    def test_fix_adds_orphaned_files(self, manager):
+        """Test that repair with fix=True adds orphaned files to manifest."""
+        # Create orphaned directory with events subdirectory
+        conv_dir = manager.config.synced_conversations_dir / "orphan789"
+        events_dir = conv_dir / "events"
+        events_dir.mkdir(parents=True)
+        # Add an event file (count_events looks for files starting with "event_")
+        (events_dir / "event_000001_abc.json").write_text('{"id": "abc"}')
+        
+        result = manager.repair(fix=True, check_cloud=False)
+        
+        assert result.added_to_manifest == 1
+        assert "orphan789" in manager.manifest.conversations
+        # event_count may be 0 or 1 depending on count_events implementation
+        assert "event_count" in manager.manifest.conversations["orphan789"]
+
+    def test_fix_saves_manifest(self, manager):
+        """Test that repair with fix=True saves the updated manifest."""
+        # Create orphaned directory
+        conv_dir = manager.config.synced_conversations_dir / "orphan000"
+        conv_dir.mkdir()
+        
+        result = manager.repair(fix=True, check_cloud=False)
+        
+        # Verify manifest was saved by reloading
+        reloaded = SyncManifest.load(manager.manifest_path)
+        assert "orphan000" in reloaded.conversations
+
+    def test_no_changes_when_fix_false(self, manager):
+        """Test that repair with fix=False doesn't modify anything."""
+        # Create orphaned directory
+        conv_dir = manager.config.synced_conversations_dir / "orphan111"
+        conv_dir.mkdir()
+        
+        result = manager.repair(fix=False, check_cloud=False)
+        
+        assert result.added_to_manifest == 0
+        assert result.removed_from_manifest == 0
+        assert "orphan111" not in manager.manifest.conversations
+
+
+class TestSyncManagerFindConversationDir:
+    """Tests for SyncManager._find_conversation_dir method."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """Create a SyncManager with mocked config."""
+        config = MagicMock()
+        config.synced_conversations_dir = tmp_path / "synced"
+        config.synced_conversations_dir.mkdir(parents=True)
+        config.api_key = "test-key"
+        
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_finds_dir_without_dashes(self, manager):
+        """Test finding directory when ID has no dashes."""
+        conv_id = "abc12345678901234567890123456"
+        conv_dir = manager.config.synced_conversations_dir / conv_id
+        conv_dir.mkdir()
+        
+        result = manager._find_conversation_dir(conv_id)
+        
+        assert result == conv_dir
+
+    def test_finds_dir_with_uuid_format(self, manager):
+        """Test finding directory when stored with UUID dashes."""
+        # 32 hex chars (standard UUID without dashes)
+        conv_id = "abc12345678901234567890123456abc"
+        # Standard UUID format with dashes (8-4-4-4-12)
+        uuid_format = "abc12345-6789-0123-4567-890123456abc"
+        
+        conv_dir = manager.config.synced_conversations_dir / uuid_format
+        conv_dir.mkdir()
+        
+        result = manager._find_conversation_dir(conv_id)
+        
+        assert result == conv_dir
+
+    def test_returns_none_for_nonexistent(self, manager):
+        """Test that None is returned for nonexistent directory."""
+        result = manager._find_conversation_dir("nonexistent123")
+        
+        assert result is None


### PR DESCRIPTION
## Summary

Adds `ohtv sync --repair` command to diagnose and fix sync state inconsistencies that can occur after failed syncs or when the manifest gets out of sync with actual files on disk.

## Problem

After a sync failure and resume, the manifest may not accurately reflect:
- Files that are actually on disk (orphaned files)
- Entries that point to missing files (ghost entries)
- Total conversations available in the cloud

## Solution

The new `--repair` option:
1. Compares manifest entries vs actual files on disk
2. Queries cloud API for total conversation count
3. Reports discrepancies with clear categorization
4. With `--dry-run`: only reports (check mode)
5. Without `--dry-run`: fixes by updating manifest

## Usage

```bash
# Check only (dry-run mode)
ohtv sync --repair --dry-run

# Check and fix
ohtv sync --repair
```

## Example Output

```
  Sync State Consistency Check  
┌───────────────────────┬──────┐
│ Cloud conversations   │ 1058 │
│ Manifest entries      │ 64   │
│ Conversations on disk │ 503  │
└───────────────────────┴──────┘

⚠ Missing 555 conversation(s) from cloud

⚠ Orphaned files (on disk but not in manifest): 439
  00c78bbdbfb44e8eb730992fbcaedc09
  ...

✓ Repaired: removed 0 ghost entries, added 439 orphaned files to manifest
```

## Key Decisions

- **UUID normalization**: Handles both dashed (UUID format) and non-dashed ID formats transparently
- **Graceful degradation**: Works without API key (shows "unavailable" for cloud count)
- **Dry-run safety**: `--dry-run` reports issues without modifying manifest
- **Idempotent repairs**: Running repair multiple times on consistent state is safe

## Changes

- `src/ohtv/sync.py`: Added `RepairResult` dataclass and `repair()` method to `SyncManager`
- `src/ohtv/cli.py`: Added `--repair` option and `_run_repair()` helper with rich display
- `tests/unit/test_sync.py`: Added 16 new tests (47 total sync tests passing)
- `README.md`: Updated sync command documentation
- `AGENTS.md`: Added sync repair architecture documentation

## Test Coverage

- **Unit tests**: 16 new tests for `RepairResult` and `SyncManager.repair()` 
- **Manual tests**: 8 end-to-end scenarios verified (see PR comments)
- **All tests pass**: 898 tests total ✅

---
*This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford.*