### PR TITLE
Move LLM analysis cache from conversation directories to ~/.ohtv

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,6 +934,33 @@ Actions by type:
   ...
 ```
 
+#### `ohtv db migrate-cache` - Migrate Cache Files
+
+Migrates LLM analysis cache files from legacy locations (inside conversation directories) to the centralized location (`~/.ohtv/cache/analysis/`). This is needed if you have cache files from older versions of ohtv.
+
+**Note:** If legacy cache files are detected, `ohtv gen objs` will display a warning prompting you to run this migration.
+
+```bash
+# Preview what would be migrated (no changes made)
+ohtv db migrate-cache --dry-run
+
+# Migrate cache files (copies to new location, keeps originals)
+ohtv db migrate-cache
+
+# Migrate and delete original files after successful copy
+ohtv db migrate-cache --delete-legacy
+
+# Show detailed progress
+ohtv db migrate-cache -v
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would be migrated without making changes |
+| `--delete-legacy` | Delete legacy cache files after successful migration |
+| `-v, --verbose` | Show detailed output |
+
 #### `ohtv db embed` - Build Embeddings for Search
 
 Generates vector embeddings for semantic search and RAG (Retrieval-Augmented Generation). Creates multiple embedding types per conversation:

--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -12,6 +12,11 @@ Cache design:
 Cache invalidation strategy:
 1. Quick check: Compare event count (fast, catches trajectory growth)
 2. Full check: Compare content hash per analysis (catches content changes)
+
+Cache location:
+- New location: ~/.ohtv/cache/analysis/<conversation_id>/objective_analysis.json
+- Legacy location: <conv_dir>/objective_analysis.json (in conversation directory)
+- The migrate_cache() function moves files from legacy to new location
 """
 
 import hashlib
@@ -22,6 +27,8 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
+
+from ohtv.config import get_analysis_cache_dir
 
 log = logging.getLogger("ohtv")
 
@@ -62,8 +69,41 @@ def load_events(conv_dir: Path) -> list[dict]:
     return events
 
 
+def _get_cache_file_path(conv_dir: Path) -> Path:
+    """Get the cache file path for a conversation.
+
+    Uses the new location (~/.ohtv/cache/analysis/<conv_id>/objective_analysis.json).
+    """
+    conv_id = conv_dir.name
+    return get_analysis_cache_dir() / conv_id / "objective_analysis.json"
+
+
+def _get_legacy_cache_file_path(conv_dir: Path) -> Path:
+    """Get the legacy cache file path (inside conversation directory)."""
+    return conv_dir / "objective_analysis.json"
+
+
+def has_legacy_cache_files(conv_dirs: list[Path]) -> list[Path]:
+    """Check if any conversation directories have legacy cache files.
+
+    Args:
+        conv_dirs: List of conversation directories to check
+
+    Returns:
+        List of conversation directories that have legacy cache files
+    """
+    legacy_dirs = []
+    for conv_dir in conv_dirs:
+        legacy_file = _get_legacy_cache_file_path(conv_dir)
+        if legacy_file.exists():
+            legacy_dirs.append(conv_dir)
+    return legacy_dirs
+
+
 def load_analysis(conv_dir: Path) -> dict | None:
-    """Load cached analysis from a conversation directory.
+    """Load cached analysis from a conversation.
+
+    Checks the new location first, then falls back to legacy location.
 
     Args:
         conv_dir: Path to conversation directory
@@ -72,9 +112,13 @@ def load_analysis(conv_dir: Path) -> dict | None:
         Analysis dict with keys like 'goal', 'primary_outcomes', etc.
         Returns None if no cache exists or no analysis found.
     """
-    cache_file = conv_dir / "objective_analysis.json"
+    # Try new location first
+    cache_file = _get_cache_file_path(conv_dir)
     if not cache_file.exists():
-        return None
+        # Fall back to legacy location
+        cache_file = _get_legacy_cache_file_path(conv_dir)
+        if not cache_file.exists():
+            return None
 
     try:
         data = json.loads(cache_file.read_text())
@@ -88,7 +132,9 @@ def load_analysis(conv_dir: Path) -> dict | None:
 
 
 def load_all_analyses(conv_dir: Path) -> dict[str, dict]:
-    """Load all cached analyses from a conversation directory.
+    """Load all cached analyses from a conversation.
+
+    Checks the new location first, then falls back to legacy location.
 
     Args:
         conv_dir: Path to conversation directory
@@ -97,9 +143,13 @@ def load_all_analyses(conv_dir: Path) -> dict[str, dict]:
         Dict mapping cache_key to analysis dict.
         Returns empty dict if no cache exists.
     """
-    cache_file = conv_dir / "objective_analysis.json"
+    # Try new location first
+    cache_file = _get_cache_file_path(conv_dir)
     if not cache_file.exists():
-        return {}
+        # Fall back to legacy location
+        cache_file = _get_legacy_cache_file_path(conv_dir)
+        if not cache_file.exists():
+            return {}
 
     try:
         data = json.loads(cache_file.read_text())
@@ -192,8 +242,20 @@ class AnalysisCacheManager:
         self.model_class = model_class
 
     def get_cache_file(self, conv_dir: Path) -> Path:
-        """Get the cache file path for a conversation."""
+        """Get the cache file path for a conversation.
+
+        Uses the new location (~/.ohtv/cache/analysis/<conv_id>/<filename>).
+        """
+        conv_id = conv_dir.name
+        return get_analysis_cache_dir() / conv_id / self.cache_filename
+
+    def get_legacy_cache_file(self, conv_dir: Path) -> Path:
+        """Get the legacy cache file path (inside conversation directory)."""
         return conv_dir / self.cache_filename
+
+    def has_legacy_cache(self, conv_dir: Path) -> bool:
+        """Check if a legacy cache file exists for a conversation."""
+        return self.get_legacy_cache_file(conv_dir).exists()
 
     def _load_cache_data(self, cache_file: Path) -> dict | None:
         """Load raw cache data from file."""
@@ -214,6 +276,7 @@ class AnalysisCacheManager:
 
     def _save_cache_data(self, cache_file: Path, data: dict) -> None:
         """Save raw cache data to file."""
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text(json.dumps(data, indent=2, default=str))
 
     def load_cached(
@@ -225,6 +288,8 @@ class AnalysisCacheManager:
         **validation_kwargs,
     ) -> T | None:
         """Load cached analysis if valid.
+
+        Checks the new location first, then falls back to legacy location.
 
         Args:
             conv_dir: Conversation directory
@@ -238,8 +303,14 @@ class AnalysisCacheManager:
         Returns:
             Validated analysis or None if cache is invalid/missing.
         """
+        # Try new location first
         cache_file = self.get_cache_file(conv_dir)
         cache_data = self._load_cache_data(cache_file)
+
+        # Fall back to legacy location
+        if cache_data is None:
+            legacy_file = self.get_legacy_cache_file(conv_dir)
+            cache_data = self._load_cache_data(legacy_file)
 
         if cache_data is None:
             return None
@@ -459,6 +530,8 @@ class AnalysisCacheManager:
     def is_skipped(self, conv_dir: Path, event_count: int) -> str | None:
         """Check if conversation is marked as skipped.
 
+        Checks the new location first, then falls back to legacy location.
+
         Args:
             conv_dir: Conversation directory
             event_count: Current event count (for invalidation check)
@@ -466,8 +539,14 @@ class AnalysisCacheManager:
         Returns:
             Skip reason if skipped and still valid, None otherwise.
         """
+        # Try new location first
         cache_file = self.get_cache_file(conv_dir)
         cache_data = self._load_cache_data(cache_file)
+
+        # Fall back to legacy location
+        if cache_data is None:
+            legacy_file = self.get_legacy_cache_file(conv_dir)
+            cache_data = self._load_cache_data(legacy_file)
 
         if cache_data is None:
             return None
@@ -537,3 +616,80 @@ class AnalysisCacheManager:
         except Exception as e:
             # DB sync is optional, don't fail if it doesn't work
             log.debug("Failed to sync skip to DB (non-fatal): %s", e)
+
+
+def migrate_cache_file(
+    conv_dir: Path,
+    cache_filename: str = "objective_analysis.json",
+) -> bool:
+    """Migrate a single cache file from legacy to new location.
+
+    Copies the cache file from the conversation directory to the new
+    centralized cache location. Does not delete the original file
+    (to avoid data loss during migration).
+
+    Args:
+        conv_dir: Path to conversation directory
+        cache_filename: Name of the cache file
+
+    Returns:
+        True if migration was performed, False if no legacy file exists
+    """
+    import shutil
+
+    legacy_file = conv_dir / cache_filename
+    if not legacy_file.exists():
+        return False
+
+    # Get new location
+    conv_id = conv_dir.name
+    new_file = get_analysis_cache_dir() / conv_id / cache_filename
+
+    # Create parent directory
+    new_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Copy file (don't delete original for safety)
+    shutil.copy2(legacy_file, new_file)
+    log.debug("Migrated cache file: %s -> %s", legacy_file, new_file)
+
+    return True
+
+
+def delete_legacy_cache_file(
+    conv_dir: Path,
+    cache_filename: str = "objective_analysis.json",
+) -> bool:
+    """Delete a legacy cache file after migration.
+
+    Only call this after verifying the cache has been migrated successfully.
+
+    Args:
+        conv_dir: Path to conversation directory
+        cache_filename: Name of the cache file
+
+    Returns:
+        True if file was deleted, False if it didn't exist
+    """
+    legacy_file = conv_dir / cache_filename
+    if not legacy_file.exists():
+        return False
+
+    legacy_file.unlink()
+    log.debug("Deleted legacy cache file: %s", legacy_file)
+    return True
+
+
+def count_legacy_cache_files(conv_dirs: list[Path]) -> int:
+    """Count how many conversation directories have legacy cache files.
+
+    Args:
+        conv_dirs: List of conversation directories to check
+
+    Returns:
+        Number of directories with legacy cache files
+    """
+    count = 0
+    for conv_dir in conv_dirs:
+        if (conv_dir / "objective_analysis.json").exists():
+            count += 1
+    return count

--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -19,9 +19,11 @@ Cache location:
 - The migrate_cache() function moves files from legacy to new location
 """
 
+import filecmp
 import hashlib
 import json
 import logging
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypeVar
@@ -83,6 +85,31 @@ def _get_legacy_cache_file_path(conv_dir: Path) -> Path:
     return conv_dir / "objective_analysis.json"
 
 
+def _find_cache_file(conv_dir: Path, filename: str = "objective_analysis.json") -> Path | None:
+    """Find existing cache file, checking new location first then legacy.
+
+    Args:
+        conv_dir: Path to conversation directory
+        filename: Cache filename to look for
+
+    Returns:
+        Path to existing cache file, or None if no cache exists.
+        Prefers new location (~/.ohtv/cache/) over legacy (conversation dir).
+    """
+    # Try new location first
+    conv_id = conv_dir.name
+    new_file = get_analysis_cache_dir() / conv_id / filename
+    if new_file.exists():
+        return new_file
+
+    # Fall back to legacy location
+    legacy_file = conv_dir / filename
+    if legacy_file.exists():
+        return legacy_file
+
+    return None
+
+
 def has_legacy_cache_files(conv_dirs: list[Path]) -> list[Path]:
     """Check if any conversation directories have legacy cache files.
 
@@ -112,13 +139,9 @@ def load_analysis(conv_dir: Path) -> dict | None:
         Analysis dict with keys like 'goal', 'primary_outcomes', etc.
         Returns None if no cache exists or no analysis found.
     """
-    # Try new location first
-    cache_file = _get_cache_file_path(conv_dir)
-    if not cache_file.exists():
-        # Fall back to legacy location
-        cache_file = _get_legacy_cache_file_path(conv_dir)
-        if not cache_file.exists():
-            return None
+    cache_file = _find_cache_file(conv_dir)
+    if cache_file is None:
+        return None
 
     try:
         data = json.loads(cache_file.read_text())
@@ -143,13 +166,9 @@ def load_all_analyses(conv_dir: Path) -> dict[str, dict]:
         Dict mapping cache_key to analysis dict.
         Returns empty dict if no cache exists.
     """
-    # Try new location first
-    cache_file = _get_cache_file_path(conv_dir)
-    if not cache_file.exists():
-        # Fall back to legacy location
-        cache_file = _get_legacy_cache_file_path(conv_dir)
-        if not cache_file.exists():
-            return {}
+    cache_file = _find_cache_file(conv_dir)
+    if cache_file is None:
+        return {}
 
     try:
         data = json.loads(cache_file.read_text())
@@ -279,6 +298,23 @@ class AnalysisCacheManager:
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text(json.dumps(data, indent=2, default=str))
 
+    def _find_cache_data(self, conv_dir: Path) -> dict | None:
+        """Find and load cache data, checking new location first then legacy.
+
+        Args:
+            conv_dir: Conversation directory
+
+        Returns:
+            Cache data dict, or None if no valid cache exists.
+        """
+        # Try new location first
+        cache_data = self._load_cache_data(self.get_cache_file(conv_dir))
+        if cache_data is not None:
+            return cache_data
+
+        # Fall back to legacy location
+        return self._load_cache_data(self.get_legacy_cache_file(conv_dir))
+
     def load_cached(
         self,
         conv_dir: Path,
@@ -303,15 +339,7 @@ class AnalysisCacheManager:
         Returns:
             Validated analysis or None if cache is invalid/missing.
         """
-        # Try new location first
-        cache_file = self.get_cache_file(conv_dir)
-        cache_data = self._load_cache_data(cache_file)
-
-        # Fall back to legacy location
-        if cache_data is None:
-            legacy_file = self.get_legacy_cache_file(conv_dir)
-            cache_data = self._load_cache_data(legacy_file)
-
+        cache_data = self._find_cache_data(conv_dir)
         if cache_data is None:
             return None
 
@@ -539,15 +567,7 @@ class AnalysisCacheManager:
         Returns:
             Skip reason if skipped and still valid, None otherwise.
         """
-        # Try new location first
-        cache_file = self.get_cache_file(conv_dir)
-        cache_data = self._load_cache_data(cache_file)
-
-        # Fall back to legacy location
-        if cache_data is None:
-            legacy_file = self.get_legacy_cache_file(conv_dir)
-            cache_data = self._load_cache_data(legacy_file)
-
+        cache_data = self._find_cache_data(conv_dir)
         if cache_data is None:
             return None
 
@@ -618,9 +638,16 @@ class AnalysisCacheManager:
             log.debug("Failed to sync skip to DB (non-fatal): %s", e)
 
 
+class MigrationError(Exception):
+    """Raised when cache file migration fails verification."""
+
+    pass
+
+
 def migrate_cache_file(
     conv_dir: Path,
     cache_filename: str = "objective_analysis.json",
+    verify: bool = True,
 ) -> bool:
     """Migrate a single cache file from legacy to new location.
 
@@ -631,12 +658,15 @@ def migrate_cache_file(
     Args:
         conv_dir: Path to conversation directory
         cache_filename: Name of the cache file
+        verify: If True, verify the copy succeeded before returning
 
     Returns:
         True if migration was performed, False if no legacy file exists
-    """
-    import shutil
 
+    Raises:
+        MigrationError: If verification fails (copy incomplete or unreadable)
+        OSError: If there's insufficient disk space or permission issues
+    """
     legacy_file = conv_dir / cache_filename
     if not legacy_file.exists():
         return False
@@ -645,13 +675,54 @@ def migrate_cache_file(
     conv_id = conv_dir.name
     new_file = get_analysis_cache_dir() / conv_id / cache_filename
 
-    # Create parent directory
-    new_file.parent.mkdir(parents=True, exist_ok=True)
+    # Check disk space before copying (rough estimate: need at least 2x file size)
+    source_size = legacy_file.stat().st_size
+    try:
+        target_dir = new_file.parent
+        target_dir.mkdir(parents=True, exist_ok=True)
+        free_space = shutil.disk_usage(target_dir).free
+        if free_space < source_size * 2:
+            raise MigrationError(
+                f"Insufficient disk space: {free_space} bytes free, "
+                f"need at least {source_size * 2} bytes"
+            )
+    except (OSError, AttributeError):
+        # disk_usage might not be available on all platforms
+        pass
 
     # Copy file (don't delete original for safety)
     shutil.copy2(legacy_file, new_file)
-    log.debug("Migrated cache file: %s -> %s", legacy_file, new_file)
 
+    if verify:
+        # Verify the copy succeeded
+        if not new_file.exists():
+            raise MigrationError(f"Target file not created: {new_file}")
+
+        # Verify file contents match
+        if not filecmp.cmp(legacy_file, new_file, shallow=False):
+            # Clean up failed copy
+            try:
+                new_file.unlink()
+            except OSError:
+                pass
+            raise MigrationError(
+                f"File content mismatch after copy: {legacy_file} -> {new_file}"
+            )
+
+        # Verify the new file is readable and valid JSON
+        try:
+            data = json.loads(new_file.read_text())
+            if "analyses" not in data and "skipped" not in data:
+                log.warning("Migrated file has unexpected format: %s", new_file)
+        except (json.JSONDecodeError, OSError) as e:
+            # Clean up corrupted file
+            try:
+                new_file.unlink()
+            except OSError:
+                pass
+            raise MigrationError(f"Migrated file is not readable: {e}")
+
+    log.debug("Migrated cache file: %s -> %s", legacy_file, new_file)
     return True
 
 

--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -110,8 +110,8 @@ def _find_cache_file(conv_dir: Path, filename: str = "objective_analysis.json") 
     return None
 
 
-def has_legacy_cache_files(conv_dirs: list[Path]) -> list[Path]:
-    """Check if any conversation directories have legacy cache files.
+def find_legacy_cache_files(conv_dirs: list[Path]) -> list[Path]:
+    """Find conversation directories that have legacy cache files.
 
     Args:
         conv_dirs: List of conversation directories to check
@@ -675,7 +675,9 @@ def migrate_cache_file(
     conv_id = conv_dir.name
     new_file = get_analysis_cache_dir() / conv_id / cache_filename
 
-    # Check disk space before copying (rough estimate: need at least 2x file size)
+    # Check disk space before copying. We require 2x file size as a safety margin:
+    # 1x for the actual copy, plus 1x buffer for filesystem overhead (block allocation,
+    # journaling, metadata) and to avoid filling the disk completely.
     source_size = legacy_file.stat().st_size
     try:
         target_dir = new_file.parent
@@ -759,8 +761,4 @@ def count_legacy_cache_files(conv_dirs: list[Path]) -> int:
     Returns:
         Number of directories with legacy cache files
     """
-    count = 0
-    for conv_dir in conv_dirs:
-        if (conv_dir / "objective_analysis.json").exists():
-            count += 1
-    return count
+    return len(find_legacy_cache_files(conv_dirs))

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -7152,7 +7152,11 @@ def _run_batch_objectives_analysis(
 
     # Check for legacy cache files and warn user
     from ohtv.analysis.cache import count_legacy_cache_files
-    conv_dirs = [Path(c.location) for c in conversations if c.location]
+    conv_dirs = []
+    for c in conversations:
+        result = _find_conversation_dir(config, c.lookup_id)
+        if result:
+            conv_dirs.append(result[0])
     legacy_count = count_legacy_cache_files(conv_dirs)
     if legacy_count > 0:
         console.print(f"[yellow]Warning:[/yellow] {legacy_count} cache file(s) in unsupported location.")

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -6111,11 +6111,17 @@ def db_index_cache(verbose: bool) -> None:
             for conv in conversations:
                 progress.update(task, current=conv.id[:12] + "...")
                 
-                # Find cache file
+                # Find cache file - check new location first, then legacy
                 conv_dir = Path(conv.location)
-                cache_file = conv_dir / "objective_analysis.json"
+                from ohtv.config import get_analysis_cache_dir
+                new_cache_file = get_analysis_cache_dir() / conv.id / "objective_analysis.json"
+                legacy_cache_file = conv_dir / "objective_analysis.json"
                 
-                if not cache_file.exists():
+                if new_cache_file.exists():
+                    cache_file = new_cache_file
+                elif legacy_cache_file.exists():
+                    cache_file = legacy_cache_file
+                else:
                     progress.advance(task)
                     continue
                 
@@ -6175,6 +6181,109 @@ def db_index_cache(verbose: bool) -> None:
         console.print(f"[yellow]![/yellow] {errors} error(s) reading cache files")
     if indexed == 0 and skipped == 0 and summaries_updated == 0 and errors == 0:
         console.print("[dim]No cache files found to index.[/dim]")
+
+
+@db.command("migrate-cache")
+@click.option("--delete-legacy", is_flag=True, help="Delete legacy cache files after migration")
+@click.option("--dry-run", is_flag=True, help="Show what would be migrated without doing it")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+def db_migrate_cache(delete_legacy: bool, dry_run: bool, verbose: bool) -> None:
+    """Migrate analysis cache files from conversation directories to ~/.ohtv.
+
+    Cache files were previously stored inside each conversation directory
+    (~/.openhands/cloud/conversations/<id>/objective_analysis.json).
+    This command moves them to the centralized location
+    (~/.ohtv/cache/analysis/<id>/objective_analysis.json).
+
+    By default, files are copied (not moved) to avoid data loss. Use
+    --delete-legacy to remove the original files after successful migration.
+    """
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+    from ohtv.analysis.cache import (
+        migrate_cache_file,
+        delete_legacy_cache_file,
+        count_legacy_cache_files,
+    )
+    from ohtv.config import get_analysis_cache_dir
+
+    config = Config.from_env()
+
+    # Collect all conversation directories
+    conv_dirs = []
+    for base_dir in [config.local_conversations_dir, config.synced_conversations_dir]:
+        if base_dir.exists():
+            for conv_dir in base_dir.iterdir():
+                if conv_dir.is_dir():
+                    conv_dirs.append(conv_dir)
+
+    # Add extra conversation paths
+    for extra_path in config.extra_conversation_paths:
+        if extra_path.exists():
+            for conv_dir in extra_path.iterdir():
+                if conv_dir.is_dir():
+                    conv_dirs.append(conv_dir)
+
+    # Count legacy cache files
+    legacy_count = count_legacy_cache_files(conv_dirs)
+
+    if legacy_count == 0:
+        console.print("[dim]No legacy cache files found to migrate.[/dim]")
+        return
+
+    console.print(f"Found [bold]{legacy_count}[/bold] legacy cache file(s) to migrate")
+    console.print(f"Target: {get_analysis_cache_dir()}")
+
+    if dry_run:
+        console.print("\n[dim]Dry run - no files will be modified.[/dim]")
+        return
+
+    migrated = 0
+    deleted = 0
+    errors = 0
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]Migrating cache files"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("[dim]{task.fields[current]}[/dim]"),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task(
+            "Migrating",
+            total=len(conv_dirs),
+            current="",
+        )
+
+        for conv_dir in conv_dirs:
+            progress.update(task, current=conv_dir.name[:12] + "...")
+
+            try:
+                if migrate_cache_file(conv_dir):
+                    migrated += 1
+                    if verbose:
+                        console.print(f"  [green]✓[/green] {conv_dir.name}")
+
+                    if delete_legacy:
+                        if delete_legacy_cache_file(conv_dir):
+                            deleted += 1
+            except (OSError, IOError) as e:
+                errors += 1
+                if verbose:
+                    console.print(f"  [red]✗[/red] {conv_dir.name}: {e}")
+
+            progress.advance(task)
+
+    # Display results
+    if migrated > 0:
+        console.print(f"[green]✓[/green] Migrated {migrated} cache file(s)")
+    if deleted > 0:
+        console.print(f"[green]✓[/green] Deleted {deleted} legacy file(s)")
+    if errors > 0:
+        console.print(f"[yellow]![/yellow] {errors} error(s) during migration")
+    if migrated == 0 and errors == 0:
+        console.print("[dim]No cache files needed migration.[/dim]")
 
 
 @db.command("reset")
@@ -7040,6 +7149,15 @@ def _run_batch_objectives_analysis(
     if not conversations:
         console.print("[dim]No conversations found matching the criteria.[/dim]")
         return
+
+    # Check for legacy cache files and warn user
+    from ohtv.analysis.cache import count_legacy_cache_files
+    conv_dirs = [Path(c.location) for c in conversations if c.location]
+    legacy_count = count_legacy_cache_files(conv_dirs)
+    if legacy_count > 0:
+        console.print(f"[yellow]Warning:[/yellow] {legacy_count} cache file(s) in unsupported location.")
+        console.print("[dim]Run 'ohtv db migrate-cache' to relocate them to ~/.ohtv/cache/analysis/[/dim]")
+        console.print()
 
     # Import analysis module
     try:

--- a/src/ohtv/config.py
+++ b/src/ohtv/config.py
@@ -235,6 +235,15 @@ def get_ohtv_dir() -> Path:
     return Path.home() / ".ohtv"
 
 
+def get_analysis_cache_dir() -> Path:
+    """Get the analysis cache directory (~/.ohtv/cache/analysis).
+
+    LLM analysis cache files are stored here, organized by conversation ID.
+    This keeps caches separate from source conversation data in ~/.openhands/.
+    """
+    return get_ohtv_dir() / "cache" / "analysis"
+
+
 def save_config_value(key: str, value: str) -> None:
     """Save a configuration value to the config file.
     

--- a/src/ohtv/db/maintenance.py
+++ b/src/ohtv/db/maintenance.py
@@ -153,7 +153,7 @@ def _check_cache_index_needed(conn: sqlite3.Connection) -> bool:
     Returns True if:
     - Task hasn't been completed AND
     - analysis_cache table is empty AND
-    - Cache files exist on disk
+    - Cache files exist on disk (in new <conv_id>/objective_analysis.json format)
     """
     if is_task_completed(conn, "cache_index_backfill_005"):
         return False
@@ -165,14 +165,14 @@ def _check_cache_index_needed(conn: sqlite3.Connection) -> bool:
         # Already has data, mark as done
         return False
     
-    # Check if cache files exist
-    from ohtv.config import get_ohtv_dir
-    cache_dir = get_ohtv_dir() / "cache" / "analysis"
+    # Check if cache files exist (new structure: <conv_id>/objective_analysis.json)
+    from ohtv.config import get_analysis_cache_dir
+    cache_dir = get_analysis_cache_dir()
     if not cache_dir.exists():
         return False
     
-    # Check if there are any cache files
-    cache_files = list(cache_dir.glob("*.json"))
+    # Check for subdirectories containing objective_analysis.json
+    cache_files = list(cache_dir.glob("*/objective_analysis.json"))
     return len(cache_files) > 0
 
 
@@ -182,21 +182,23 @@ def _execute_cache_index_backfill(
 ) -> dict:
     """Index existing cache files into the database.
     
-    This reads all JSON cache files and creates corresponding entries
+    This reads all JSON cache files from the new structure
+    (<conv_id>/objective_analysis.json) and creates corresponding entries
     in the analysis_cache and analysis_skips tables.
     """
     import json as json_module
-    from ohtv.config import get_ohtv_dir
+    from ohtv.config import get_analysis_cache_dir
     from ohtv.db.stores import AnalysisCacheStore
     from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry, AnalysisSkipEntry
     from ohtv.analysis.cache import make_cache_key
     
-    cache_dir = get_ohtv_dir() / "cache" / "analysis"
+    cache_dir = get_analysis_cache_dir()
     if not cache_dir.exists():
         return {"cached": 0, "skipped": 0}
     
     store = AnalysisCacheStore(conn)
-    cache_files = list(cache_dir.glob("*.json"))
+    # New structure: <conv_id>/objective_analysis.json
+    cache_files = list(cache_dir.glob("*/objective_analysis.json"))
     
     total = len(cache_files)
     cached_count = 0
@@ -208,7 +210,8 @@ def _execute_cache_index_backfill(
         
         try:
             data = json_module.loads(cache_file.read_text())
-            conv_id = cache_file.stem  # Filename without .json
+            # New structure: parent directory name is the conversation ID
+            conv_id = cache_file.parent.name
             
             # Check if this is a skip marker
             if data.get("skipped"):


### PR DESCRIPTION
## Summary

This PR moves LLM analysis cache files from inside conversation directories (`~/.openhands/cloud/conversations/<id>/objective_analysis.json`) to a centralized location (`~/.ohtv/cache/analysis/<id>/objective_analysis.json`).

## Problem

As described in #7, storing cache files inside conversation directories had several issues:
1. **Pollutes source data**: The `~/.openhands/` directory should be read-only source data (per AGENTS.md design principle #11), but we were writing cache files there
2. **Inconsistent with other ohtv data**: Database, logs, sync manifest, and config are already in `~/.ohtv/`
3. **Harder to manage**: Cannot easily clear all caches, backup caches separately, or see cache storage usage

## Solution

- **New cache location**: `~/.ohtv/cache/analysis/<conversation_id>/objective_analysis.json`
- **Backward compatibility**: All read operations fall back to the legacy location if the new location does not have the file
- **Migration command**: `ohtv db migrate-cache` copies files from old to new location with verification
- **Warning display**: `ohtv gen objs` shows a warning when legacy cache files are detected

## Changes

### `src/ohtv/config.py`
- Added `get_analysis_cache_dir()` helper

### `src/ohtv/analysis/cache.py`
- Updated `AnalysisCacheManager.get_cache_file()` to use new location
- Added `get_legacy_cache_file()` and `has_legacy_cache()` methods
- Added `_find_cache_file()` and `_find_cache_data()` helpers for consistent cache location logic
- Updated `load_cached()` and `is_skipped()` to check both locations
- Added `migrate_cache_file()` with verification (disk space, content match, JSON validation)
- Added `delete_legacy_cache_file()` and `find_legacy_cache_files()` functions
- Added `MigrationError` exception for verification failures

### `src/ohtv/cli.py`
- Added `ohtv db migrate-cache` command with `--delete-legacy`, `--dry-run`, and `-v` options
- Added warning in `ohtv gen objs` when legacy cache files are detected
- Updated `db index-cache` to check both locations

### `src/ohtv/db/maintenance.py`
- Updated cache index backfill for new directory structure

### `README.md`
- Added documentation for `ohtv db migrate-cache` command

## Key Decisions During Review

1. **Function naming**: Renamed `has_legacy_cache_files()` → `find_legacy_cache_files()` since it returns a list, not a bool
2. **Code consolidation**: `count_legacy_cache_files()` now uses `find_legacy_cache_files()` to avoid duplication
3. **Disk space check**: Added 2x multiplier comment explaining the safety margin for filesystem overhead
4. **Migration verification**: Added comprehensive verification (existence check, byte-for-byte comparison via `filecmp.cmp()`, JSON validation) before reporting success
5. **Bug fix**: Fixed critical bug where `gen objs` crashed with `AttributeError` by using `_find_conversation_dir()` instead of non-existent `location` attribute

## Test Coverage

### Manual Testing ✅
- `ohtv db migrate-cache --help` - Shows usage with all options
- `ohtv db migrate-cache --dry-run` - Reports files without modifying
- `ohtv db migrate-cache -v` - Copies files with verbose progress
- `ohtv db migrate-cache --delete-legacy` - Deletes legacy files after successful copy
- Warning display in `gen objs` - Shows warning when legacy files exist
- Cache fallback - Reads from legacy location when new location is empty
- Cache location preference - New location is preferred over legacy

### Unit Tests ✅
913 tests passed (0 failures)

Fixes #7

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._