### PR TITLE
feat: Database cleanup - orphaned embeddings and duplicate conversations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,3 +391,21 @@ ohtv gen run themes.discover --week
 ```
 
 **Tests**: 64 new tests for periods and input parsing (601 total tests passing)
+
+## Bugfix: Conversation ID Normalization in analysis_cache (Migration 011)
+
+**Problem**: The `ohtv db status` command reported false "missing embeddings" (e.g., "3060 / 5195 cached analyses need embeddings") when embeddings actually existed. Running `ohtv db embed` would skip all conversations saying they were already embedded, but the missing count never decreased.
+
+**Root cause**: Conversation IDs were stored inconsistently:
+- `embeddings` table: Always stored without dashes (normalized)
+- `analysis_cache` table: Some entries stored with dashes, some without
+- The JOIN query in `count_cached_missing_embeddings()` required exact match, so dashed IDs couldn't find their non-dashed embeddings
+
+**Fix**:
+1. Migration 011 (`011_normalize_cache_ids.py`): Removes duplicate dashed entries that have matching non-dashed versions, and normalizes any remaining dashed entries
+2. `AnalysisCacheStore.upsert_cache()`: Now normalizes conversation IDs (removes dashes) before storing
+3. `AnalysisCacheStore.upsert_skip()`: Same normalization
+4. `AnalysisCacheStore.delete_for_conversation()`: Same normalization
+5. `estimate_conversation_tokens()`: Now uses `load_all_analyses()` instead of `load_analysis()` to count all analysis variants for accurate embedding estimates
+
+**Testing**: Run `ohtv db status` - the "Missing embeddings" count should now reflect only genuinely missing embeddings, not false positives from ID format mismatches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,3 +409,27 @@ ohtv gen run themes.discover --week
 5. `estimate_conversation_tokens()`: Now uses `load_all_analyses()` instead of `load_analysis()` to count all analysis variants for accurate embedding estimates
 
 **Testing**: Run `ohtv db status` - the "Missing embeddings" count should now reflect only genuinely missing embeddings, not false positives from ID format mismatches.
+
+## Bugfix: Duplicate Conversations from Dashed IDs (Migration 012)
+
+**Problem**: Database showed ~2450 conversations when only ~1280 existed on disk. The `db status` showed nearly double the expected conversation count.
+
+**Root cause**: Two code paths created conversation records with different ID formats:
+1. Scanner uses directory name (no dashes): e.g., `005915fd6ca64291b7a8b3adb446392a`
+2. `_get_conversation_info()` read `id` from `base_state.json` which sometimes has dashes: `005915fd-6ca6-4291-b7a8-b3adb446392a`
+
+This happened with LXA (OpenHands desktop) conversations where `base_state.json` contains dashed IDs but directories are named without dashes. When `_ensure_refs_indexed` was called, it created a second (ghost) entry with the dashed ID.
+
+**Fix**:
+1. `_get_conversation_info()`: Now normalizes IDs (removes dashes) from both directory name and `base_state.json`
+2. Migration 012 (`012_normalize_conversation_ids.py`):
+   - Temporarily disables FK constraints
+   - For each dashed conversation ID that has a normalized counterpart:
+     - Deletes all child records referencing the dashed ID
+     - Deletes the dashed conversation entry
+   - For dashed IDs without counterparts: updates them and their child records to normalized format
+   - Re-enables FK constraints
+
+**Child tables affected**: `conversation_repos`, `conversation_refs`, `actions`, `conversation_stages`, `analysis_cache`, `analysis_skips`, `embeddings`
+
+**Testing**: Run `ohtv db status` - conversation count should match actual conversations on disk.

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -256,35 +256,44 @@ def estimate_conversation_tokens(
 
     Args:
         conv_dir: Path to conversation directory
-        analysis: Cached analysis dict (optional)
+        analysis: Cached analysis dict (optional, for backwards compatibility)
         refs: Git refs (optional)
 
     Returns:
         Tuple of (estimated_tokens, estimated_embeddings)
     """
-    from ohtv.analysis.cache import load_events, load_analysis
+    from ohtv.analysis.cache import load_events, load_all_analyses
     from .chunking import estimate_tokens
-    from .text_builders import build_conversation_texts
+    from .text_builders import build_conversation_texts, build_analysis_text
 
     events = load_events(conv_dir)
     if not events:
         return 0, 0
 
-    if analysis is None:
-        analysis = load_analysis(conv_dir)
-
-    texts = build_conversation_texts(events, analysis, refs)
+    # Load ALL analysis variants to get accurate estimate
+    all_analyses: dict[str, dict] = {}
+    if analysis is not None:
+        all_analyses[""] = analysis
+    else:
+        all_analyses = load_all_analyses(conv_dir)
+    
+    # Use first analysis for summary/content estimation
+    first_analysis = next(iter(all_analyses.values()), None) if all_analyses else None
+    texts = build_conversation_texts(events, first_analysis, refs)
 
     # Check if there's any embeddable content
-    if not texts.analysis_chunks and not texts.summary_chunks and not texts.content_chunks:
+    if not all_analyses and not texts.summary_chunks and not texts.content_chunks:
         return 0, 0
 
     total_tokens = 0
     total_embeddings = 0
 
-    for chunk in texts.analysis_chunks:
-        total_tokens += chunk.estimated_tokens
-        total_embeddings += 1
+    # Count analysis embeddings for ALL variants
+    for analysis_data in all_analyses.values():
+        analysis_text = build_analysis_text(analysis_data)
+        if analysis_text:
+            total_tokens += estimate_tokens(analysis_text)
+            total_embeddings += 1
 
     for chunk in texts.summary_chunks:
         total_tokens += chunk.estimated_tokens

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -4742,8 +4742,11 @@ def _find_conversation_dir(config: Config, conv_id: str) -> tuple[Path, bool] | 
 
 
 def _get_conversation_info(conv_dir: Path) -> tuple[str, str]:
-    """Get conversation ID and title from metadata or first user message."""
-    conv_id = conv_dir.name
+    """Get conversation ID and title from metadata or first user message.
+    
+    Always returns normalized conversation ID (without dashes).
+    """
+    conv_id = conv_dir.name.replace("-", "")  # Normalize to no dashes
     title = ""
 
     # Try to get title from base_state.json
@@ -4753,7 +4756,8 @@ def _get_conversation_info(conv_dir: Path) -> tuple[str, str]:
             data = json.loads(base_state.read_text())
             title = data.get("title", "")
             if data.get("id"):
-                conv_id = data["id"]
+                # Normalize ID from base_state.json (remove dashes)
+                conv_id = data["id"].replace("-", "")
         except (json.JSONDecodeError, OSError):
             pass
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -6046,11 +6046,16 @@ def db_status() -> None:
         # Missing embeddings check - now properly joins on cache_key
         missing_count = embed_store.count_cached_missing_embeddings()
         total_cached = cache_store.count_cached()
+        orphaned_count = embed_store.count_orphaned_analysis_embeddings()
         
-        if missing_count > 0:
-            console.print(f"\n[yellow]⚠ Missing embeddings:[/yellow]")
-            console.print(f"  Cached analyses without embedding: {missing_count} / {total_cached}")
-            console.print("  [dim]Run 'ohtv db embed' to generate missing embeddings[/dim]")
+        if missing_count > 0 or orphaned_count > 0:
+            console.print(f"\n[yellow]⚠ Embedding issues:[/yellow]")
+            if missing_count > 0:
+                console.print(f"  Missing: {missing_count} / {total_cached} cached analyses need embeddings")
+                console.print("  [dim]Run 'ohtv db embed' to generate missing embeddings[/dim]")
+            if orphaned_count > 0:
+                console.print(f"  Orphaned: {orphaned_count} analysis embeddings without matching cache")
+                console.print("  [dim]Will be cleaned up automatically on next db operation[/dim]")
         elif total_cached > 0:
             console.print(f"\n[green]✓ All {total_cached} cached analyses have embeddings[/green]")
 

--- a/src/ohtv/db/maintenance.py
+++ b/src/ohtv/db/maintenance.py
@@ -374,6 +374,55 @@ def _execute_prompt_hash_backfill(
 
 
 # =============================================================================
+# Task: Orphaned Embedding Cleanup (after migration 010)
+# =============================================================================
+
+def _check_orphaned_embeddings_cleanup_needed(conn: sqlite3.Connection) -> bool:
+    """Check if orphaned embedding cleanup is needed.
+    
+    Returns True if:
+    - Task hasn't been completed AND
+    - There are orphaned analysis embeddings (legacy NULL cache_key or
+      cache_key not in analysis_cache)
+    """
+    if is_task_completed(conn, "orphaned_embeddings_cleanup_010"):
+        return False
+    
+    from ohtv.db.stores import EmbeddingStore
+    embed_store = EmbeddingStore(conn)
+    orphaned_count = embed_store.count_orphaned_analysis_embeddings()
+    return orphaned_count > 0
+
+
+def _execute_orphaned_embeddings_cleanup(
+    conn: sqlite3.Connection,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> dict:
+    """Delete orphaned analysis embeddings.
+    
+    Removes analysis embeddings that have NULL cache_key (legacy) or
+    have a cache_key that doesn't exist in analysis_cache.
+    """
+    from ohtv.db.stores import EmbeddingStore
+    
+    embed_store = EmbeddingStore(conn)
+    
+    # Get count for progress reporting
+    orphaned_count = embed_store.count_orphaned_analysis_embeddings()
+    
+    if on_progress:
+        on_progress(0, orphaned_count)
+    
+    # Delete orphaned embeddings
+    deleted = embed_store.delete_orphaned_analysis_embeddings()
+    
+    if on_progress:
+        on_progress(deleted, deleted)
+    
+    return {"orphaned_found": orphaned_count, "deleted": deleted}
+
+
+# =============================================================================
 # Task Registry
 # =============================================================================
 
@@ -398,6 +447,13 @@ MAINTENANCE_TASKS: list[MaintenanceTask] = [
         triggered_by="feature_prompt_customization",
         check_needed=_check_prompt_hash_backfill_needed,
         execute=_execute_prompt_hash_backfill,
+    ),
+    MaintenanceTask(
+        name="orphaned_embeddings_cleanup_010",
+        description="Cleaning up orphaned analysis embeddings",
+        triggered_by="migration_010",
+        check_needed=_check_orphaned_embeddings_cleanup_needed,
+        execute=_execute_orphaned_embeddings_cleanup,
     ),
 ]
 

--- a/src/ohtv/db/migrations/011_normalize_cache_ids.py
+++ b/src/ohtv/db/migrations/011_normalize_cache_ids.py
@@ -1,0 +1,80 @@
+"""Migration 011: Normalize conversation IDs in analysis_cache.
+
+This migration fixes a bug where some conversation IDs in analysis_cache
+were stored with dashes while embeddings use normalized (no-dash) IDs.
+This caused false "missing embeddings" reports because the JOIN couldn't
+match dashed IDs to their corresponding embeddings.
+
+The fix:
+1. For each dashed entry, check if a normalized entry with same cache_key exists
+2. If normalized exists, delete the dashed duplicate
+3. If normalized doesn't exist, update the dashed entry to use normalized ID
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Normalize dashed conversation IDs in analysis_cache table."""
+    cursor = conn.cursor()
+    
+    # Find all dashed entries
+    cursor.execute(
+        """
+        SELECT conversation_id, cache_key
+        FROM analysis_cache
+        WHERE conversation_id LIKE '%-%'
+        """
+    )
+    dashed_entries = cursor.fetchall()
+    
+    if not dashed_entries:
+        return  # Nothing to migrate
+    
+    deleted = 0
+    updated = 0
+    
+    for conv_id, cache_key in dashed_entries:
+        normalized_id = conv_id.replace("-", "")
+        
+        # Check if normalized version exists
+        cursor.execute(
+            """
+            SELECT 1 FROM analysis_cache
+            WHERE conversation_id = ? AND cache_key = ?
+            """,
+            (normalized_id, cache_key),
+        )
+        normalized_exists = cursor.fetchone() is not None
+        
+        if normalized_exists:
+            # Delete the dashed duplicate
+            cursor.execute(
+                """
+                DELETE FROM analysis_cache
+                WHERE conversation_id = ? AND cache_key = ?
+                """,
+                (conv_id, cache_key),
+            )
+            deleted += 1
+        else:
+            # Update dashed to normalized
+            cursor.execute(
+                """
+                UPDATE analysis_cache
+                SET conversation_id = ?
+                WHERE conversation_id = ? AND cache_key = ?
+                """,
+                (normalized_id, conv_id, cache_key),
+            )
+            updated += 1
+    
+    conn.commit()
+    
+    # Log results (visible in debug logs)
+    import logging
+    log = logging.getLogger("ohtv")
+    log.info(
+        "Migration 011: Normalized %d dashed entries (deleted=%d duplicates, updated=%d)",
+        len(dashed_entries), deleted, updated,
+    )

--- a/src/ohtv/db/migrations/012_normalize_conversation_ids.py
+++ b/src/ohtv/db/migrations/012_normalize_conversation_ids.py
@@ -1,0 +1,115 @@
+"""Migration 012: Normalize conversation IDs in conversations table.
+
+This migration fixes a bug where some conversation IDs were stored with dashes
+(from base_state.json) while the scanner uses directory names (no dashes).
+This caused duplicate entries in the conversations table.
+
+Strategy:
+1. Find all dashed conversation IDs that have a normalized counterpart
+2. For those duplicates, delete all references to the dashed ID from child tables
+3. Delete the dashed entry from conversations table
+4. For dashed IDs without a normalized counterpart, update them and their references
+
+The dashed entries typically have empty source/title fields because they were
+created via _ensure_refs_indexed before the scanner processed them.
+"""
+
+import sqlite3
+import logging
+
+log = logging.getLogger("ohtv")
+
+# Tables that have conversation_id foreign keys
+CHILD_TABLES = [
+    "conversation_repos",  # renamed from repo_links
+    "conversation_refs",   # renamed from ref_links
+    "actions",
+    "conversation_stages",
+    "analysis_cache",
+    "analysis_skips",
+    "embeddings",
+]
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Normalize dashed conversation IDs in conversations table."""
+    cursor = conn.cursor()
+    
+    # Temporarily disable foreign key constraints for the bulk update
+    cursor.execute("PRAGMA foreign_keys = OFF")
+    
+    try:
+        # Find all dashed entries in conversations
+        cursor.execute(
+            """
+            SELECT id FROM conversations WHERE id LIKE '%-%'
+            """
+        )
+        dashed_entries = [row[0] for row in cursor.fetchall()]
+        
+        if not dashed_entries:
+            log.info("Migration 012: No dashed conversation IDs found")
+            return
+        
+        deleted_convs = 0
+        updated_convs = 0
+        
+        for conv_id in dashed_entries:
+            normalized_id = conv_id.replace("-", "")
+            
+            # Check if normalized version exists
+            cursor.execute(
+                "SELECT id FROM conversations WHERE id = ?",
+                (normalized_id,),
+            )
+            normalized_exists = cursor.fetchone() is not None
+            
+            if normalized_exists:
+                # Delete records from child tables that reference the dashed ID
+                for table in CHILD_TABLES:
+                    if _table_exists(cursor, table):
+                        cursor.execute(
+                            f"DELETE FROM {table} WHERE conversation_id = ?",
+                            (conv_id,),
+                        )
+                
+                # Delete the dashed conversation entry
+                cursor.execute(
+                    "DELETE FROM conversations WHERE id = ?",
+                    (conv_id,),
+                )
+                deleted_convs += 1
+            else:
+                # No normalized version - update this entry and all references
+                for table in CHILD_TABLES:
+                    if _table_exists(cursor, table):
+                        cursor.execute(
+                            f"UPDATE {table} SET conversation_id = ? WHERE conversation_id = ?",
+                            (normalized_id, conv_id),
+                        )
+                
+                cursor.execute(
+                    "UPDATE conversations SET id = ? WHERE id = ?",
+                    (normalized_id, conv_id),
+                )
+                updated_convs += 1
+        
+        conn.commit()
+        
+        log.info(
+            "Migration 012: Normalized %d dashed conversation IDs "
+            "(deleted=%d duplicates, updated=%d orphans)",
+            len(dashed_entries), deleted_convs, updated_convs,
+        )
+    finally:
+        # Re-enable foreign key constraints
+        cursor.execute("PRAGMA foreign_keys = ON")
+
+
+def _table_exists(cursor: sqlite3.Cursor, table_name: str) -> bool:
+    """Check if a table exists in the database."""
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    return cursor.fetchone() is not None

--- a/src/ohtv/db/stores/analysis_cache_store.py
+++ b/src/ohtv/db/stores/analysis_cache_store.py
@@ -76,6 +76,9 @@ class AnalysisCacheStore:
         """Insert or update a cache entry."""
         analyzed_at_str = entry.analyzed_at.isoformat()
         
+        # Normalize conversation ID (remove dashes) to match embeddings table
+        normalized_id = entry.conversation_id.replace("-", "")
+        
         self.conn.execute(
             """
             INSERT INTO analysis_cache (conversation_id, cache_key, event_count, content_hash, analyzed_at)
@@ -86,7 +89,7 @@ class AnalysisCacheStore:
                 analyzed_at = excluded.analyzed_at
             """,
             (
-                entry.conversation_id,
+                normalized_id,
                 entry.cache_key,
                 entry.event_count,
                 entry.content_hash,
@@ -97,12 +100,15 @@ class AnalysisCacheStore:
         # Clear any skip marker when we successfully cache
         self.conn.execute(
             "DELETE FROM analysis_skips WHERE conversation_id = ?",
-            (entry.conversation_id,),
+            (normalized_id,),
         )
     
     def upsert_skip(self, entry: AnalysisSkipEntry) -> None:
         """Insert or update a skip entry."""
         skipped_at_str = entry.skipped_at.isoformat()
+        
+        # Normalize conversation ID (remove dashes) for consistency
+        normalized_id = entry.conversation_id.replace("-", "")
         
         self.conn.execute(
             """
@@ -114,7 +120,7 @@ class AnalysisCacheStore:
                 skipped_at = excluded.skipped_at
             """,
             (
-                entry.conversation_id,
+                normalized_id,
                 entry.event_count,
                 entry.reason,
                 skipped_at_str,
@@ -236,11 +242,14 @@ class AnalysisCacheStore:
     
     def delete_for_conversation(self, conversation_id: str) -> None:
         """Delete all cache and skip entries for a conversation."""
+        # Normalize conversation ID (remove dashes) for consistency
+        normalized_id = conversation_id.replace("-", "")
+        
         self.conn.execute(
             "DELETE FROM analysis_cache WHERE conversation_id = ?",
-            (conversation_id,),
+            (normalized_id,),
         )
         self.conn.execute(
             "DELETE FROM analysis_skips WHERE conversation_id = ?",
-            (conversation_id,),
+            (normalized_id,),
         )

--- a/src/ohtv/db/stores/embedding_store.py
+++ b/src/ohtv/db/stores/embedding_store.py
@@ -649,3 +649,60 @@ class EmbeddingStore:
         """Return count of FTS indexed conversations."""
         cursor = self.conn.execute("SELECT COUNT(*) FROM conversation_fts")
         return cursor.fetchone()[0]
+
+    # =========================================================================
+    # Orphaned embedding cleanup
+    # =========================================================================
+
+    def count_orphaned_analysis_embeddings(self) -> int:
+        """Count analysis embeddings without matching analysis_cache entries.
+
+        Orphaned embeddings are:
+        1. Analysis embeddings with empty cache_key (legacy, pre-cache_key era)
+        2. Analysis embeddings with a cache_key that doesn't exist in analysis_cache
+
+        Returns:
+            Number of orphaned analysis embeddings
+        """
+        cursor = self.conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM embeddings e
+            WHERE e.embed_type = 'analysis'
+              AND (
+                e.cache_key = ''
+                OR NOT EXISTS (
+                  SELECT 1 FROM analysis_cache ac
+                  WHERE ac.conversation_id = e.conversation_id
+                    AND ac.cache_key = e.cache_key
+                )
+              )
+            """
+        )
+        return cursor.fetchone()[0]
+
+    def delete_orphaned_analysis_embeddings(self) -> int:
+        """Delete analysis embeddings without matching analysis_cache entries.
+
+        Removes:
+        1. Analysis embeddings with empty cache_key (legacy, pre-cache_key era)
+        2. Analysis embeddings with a cache_key that doesn't exist in analysis_cache
+
+        Returns:
+            Number of embeddings deleted
+        """
+        cursor = self.conn.execute(
+            """
+            DELETE FROM embeddings
+            WHERE embed_type = 'analysis'
+              AND (
+                cache_key = ''
+                OR NOT EXISTS (
+                  SELECT 1 FROM analysis_cache ac
+                  WHERE ac.conversation_id = embeddings.conversation_id
+                    AND ac.cache_key = embeddings.cache_key
+                )
+              )
+            """
+        )
+        return cursor.rowcount

--- a/tests/unit/db/stores/test_embedding_store.py
+++ b/tests/unit/db/stores/test_embedding_store.py
@@ -792,3 +792,208 @@ class TestCacheKeyValidation:
         # Verify list returns the correct pairs
         missing_list = embedding_store.list_cached_missing_embeddings()
         assert set(missing_list) == {("conv1", "key2"), ("conv2", "key4")}
+
+
+class TestOrphanedEmbeddingCleanup:
+    """Tests for orphaned analysis embedding cleanup."""
+    
+    def test_count_orphaned_no_orphans(self, embedding_store, conversation_store, db_conn):
+        """Test counting when there are no orphaned embeddings."""
+        from ohtv.db.stores import AnalysisCacheStore
+        from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry
+        
+        cache_store = AnalysisCacheStore(db_conn)
+        
+        # Create conversation
+        _create_conversation(conversation_store, "conv1")
+        
+        # Create cache entry with key1
+        cache_store.upsert_cache(AnalysisCacheEntry(
+            conversation_id="conv1", cache_key="key1",
+            event_count=10, content_hash="hash1", analyzed_at=datetime.now(timezone.utc)
+        ))
+        
+        # Create matching embedding with same key
+        embedding_store.upsert(
+            "conv1", [0.1, 0.2], "model",
+            embed_type="analysis", cache_key="key1"
+        )
+        db_conn.commit()
+        
+        # No orphans - the embedding matches the cache entry
+        assert embedding_store.count_orphaned_analysis_embeddings() == 0
+    
+    def test_count_orphaned_with_empty_cache_key(self, embedding_store, conversation_store, db_conn):
+        """Test counting legacy embeddings with empty cache_key (pre-migration 010)."""
+        # Create conversation
+        _create_conversation(conversation_store, "conv1")
+        
+        # Create embedding with empty cache_key (legacy - default after migration 010)
+        embedding_store.upsert(
+            "conv1", [0.1, 0.2], "model",
+            embed_type="analysis", cache_key=""
+        )
+        db_conn.commit()
+        
+        # Should count as orphaned (empty cache_key can't match any cache entry)
+        assert embedding_store.count_orphaned_analysis_embeddings() == 1
+    
+    def test_count_orphaned_with_unmatched_cache_key(self, embedding_store, conversation_store, db_conn):
+        """Test counting embeddings whose cache_key doesn't exist in analysis_cache."""
+        from ohtv.db.stores import AnalysisCacheStore
+        from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry
+        
+        cache_store = AnalysisCacheStore(db_conn)
+        
+        # Create conversation
+        _create_conversation(conversation_store, "conv1")
+        
+        # Create cache entry with key1
+        cache_store.upsert_cache(AnalysisCacheEntry(
+            conversation_id="conv1", cache_key="key1",
+            event_count=10, content_hash="hash1", analyzed_at=datetime.now(timezone.utc)
+        ))
+        
+        # Create embedding with key2 (doesn't match any cache entry)
+        embedding_store.upsert(
+            "conv1", [0.1, 0.2], "model",
+            embed_type="analysis", cache_key="key2"
+        )
+        db_conn.commit()
+        
+        # Should count as orphaned (key2 doesn't exist in analysis_cache)
+        assert embedding_store.count_orphaned_analysis_embeddings() == 1
+    
+    def test_count_orphaned_mixed_scenarios(self, embedding_store, conversation_store, db_conn):
+        """Test counting with mix of valid, empty, and unmatched embeddings."""
+        from ohtv.db.stores import AnalysisCacheStore
+        from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry
+        
+        cache_store = AnalysisCacheStore(db_conn)
+        
+        # Create conversations
+        _create_conversation(conversation_store, "conv1")
+        _create_conversation(conversation_store, "conv2")
+        
+        # Create cache entries
+        cache_store.upsert_cache(AnalysisCacheEntry(
+            conversation_id="conv1", cache_key="key1",
+            event_count=10, content_hash="hash1", analyzed_at=datetime.now(timezone.utc)
+        ))
+        cache_store.upsert_cache(AnalysisCacheEntry(
+            conversation_id="conv2", cache_key="key2",
+            event_count=10, content_hash="hash2", analyzed_at=datetime.now(timezone.utc)
+        ))
+        
+        # Valid embedding (matches cache)
+        embedding_store.upsert(
+            "conv1", [0.1, 0.2], "model",
+            embed_type="analysis", cache_key="key1"
+        )
+        # Orphaned: empty cache_key (legacy)
+        embedding_store.upsert(
+            "conv1", [0.3, 0.4], "model",
+            embed_type="analysis", cache_key="", chunk_index=1
+        )
+        # Orphaned: unmatched cache_key
+        embedding_store.upsert(
+            "conv2", [0.5, 0.6], "model",
+            embed_type="analysis", cache_key="key_nonexistent"
+        )
+        # Non-analysis embedding (should not be counted)
+        embedding_store.upsert(
+            "conv2", [0.7, 0.8], "model",
+            embed_type="summary"
+        )
+        db_conn.commit()
+        
+        # Should count 2 orphaned analysis embeddings
+        assert embedding_store.count_orphaned_analysis_embeddings() == 2
+    
+    def test_delete_orphaned_embeddings(self, embedding_store, conversation_store, db_conn):
+        """Test deleting orphaned analysis embeddings."""
+        from ohtv.db.stores import AnalysisCacheStore
+        from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry
+        
+        cache_store = AnalysisCacheStore(db_conn)
+        
+        # Create conversation
+        _create_conversation(conversation_store, "conv1")
+        
+        # Create cache entry
+        cache_store.upsert_cache(AnalysisCacheEntry(
+            conversation_id="conv1", cache_key="key1",
+            event_count=10, content_hash="hash1", analyzed_at=datetime.now(timezone.utc)
+        ))
+        
+        # Valid embedding
+        embedding_store.upsert(
+            "conv1", [0.1, 0.2], "model",
+            embed_type="analysis", cache_key="key1"
+        )
+        # Orphaned: empty cache_key (legacy)
+        embedding_store.upsert(
+            "conv1", [0.3, 0.4], "model",
+            embed_type="analysis", cache_key="", chunk_index=1
+        )
+        # Orphaned: unmatched cache_key
+        embedding_store.upsert(
+            "conv1", [0.5, 0.6], "model",
+            embed_type="analysis", cache_key="orphan_key", chunk_index=2
+        )
+        # Non-analysis (should not be deleted)
+        embedding_store.upsert(
+            "conv1", [0.7, 0.8], "model",
+            embed_type="summary"
+        )
+        db_conn.commit()
+        
+        # Should have 4 total embeddings
+        assert embedding_store.count() == 4
+        
+        # Delete orphaned
+        deleted = embedding_store.delete_orphaned_analysis_embeddings()
+        assert deleted == 2
+        
+        # Should have 2 remaining (valid analysis + summary)
+        assert embedding_store.count() == 2
+        
+        # Valid analysis embedding should still exist
+        assert embedding_store.has_embedding("conv1", embed_type="analysis", cache_key="key1")
+        
+        # Summary embedding should still exist
+        assert embedding_store.has_embedding("conv1", embed_type="summary")
+        
+        # Orphaned embeddings should be gone
+        assert not embedding_store.has_embedding("conv1", embed_type="analysis", chunk_index=1)
+        assert not embedding_store.has_embedding("conv1", embed_type="analysis", cache_key="orphan_key")
+    
+    def test_delete_orphaned_returns_zero_when_none(self, embedding_store, conversation_store, db_conn):
+        """Test delete returns 0 when there are no orphaned embeddings."""
+        from ohtv.db.stores import AnalysisCacheStore
+        from ohtv.db.stores.analysis_cache_store import AnalysisCacheEntry
+        
+        cache_store = AnalysisCacheStore(db_conn)
+        
+        # Create conversation
+        _create_conversation(conversation_store, "conv1")
+        
+        # Create cache entry
+        cache_store.upsert_cache(AnalysisCacheEntry(
+            conversation_id="conv1", cache_key="key1",
+            event_count=10, content_hash="hash1", analyzed_at=datetime.now(timezone.utc)
+        ))
+        
+        # Valid embedding only
+        embedding_store.upsert(
+            "conv1", [0.1, 0.2], "model",
+            embed_type="analysis", cache_key="key1"
+        )
+        db_conn.commit()
+        
+        # No orphans to delete
+        deleted = embedding_store.delete_orphaned_analysis_embeddings()
+        assert deleted == 0
+        
+        # Embedding should still exist
+        assert embedding_store.count() == 1


### PR DESCRIPTION
## Summary

Fixes two database consistency issues that caused incorrect counts and orphaned data:

1. **Orphaned analysis embeddings** - Legacy embeddings (empty `cache_key`) left after migration 010 could not be matched to `analysis_cache` entries
2. **Duplicate conversations** - Dashed IDs from `base_state.json` created ghost entries when directory names use non-dashed format

---

## Changes

### Orphaned Embeddings Cleanup (Migration 010 follow-up)

**Problem**: After migration 010 added `cache_key` to embeddings, legacy embeddings became unmatchable orphans.

**Solution**:
- Added `EmbeddingStore.count_orphaned_analysis_embeddings()` and `delete_orphaned_analysis_embeddings()`
- Added automatic maintenance task (`orphaned_embeddings_cleanup_010`) that runs on database access
- Updated `db status` to show orphaned embedding count with actionable message

### Conversation ID Normalization (Migration 011 + 012)

**Problem**: Scanner uses directory names (no dashes), but `_get_conversation_info()` read IDs from `base_state.json` (with dashes), creating duplicate conversation entries.

**Solution**:
- Migration 011: Normalizes dashed IDs in `analysis_cache` table
- Migration 012: Normalizes dashed IDs in `conversations` table and all child tables
- `_get_conversation_info()`: Now normalizes IDs from both sources
- `AnalysisCacheStore`: All write methods normalize IDs before storing

---

## Key Decisions

- Automatic cleanup via maintenance task: No manual intervention required
- Careful FK handling: Migration 012 temporarily disables FK constraints, handles all child tables
- Conservative strategy: For duplicates, keep scanner-created entry (has full metadata), delete ghost entry

---

## Test Coverage

- **6 new unit tests** for orphaned embedding detection/cleanup
- **919 unit tests pass** (existing test suite)
- **Manual testing verified**:
  - `db status` shows orphaned count correctly
  - Maintenance task auto-runs on database access
  - All CLI commands work after migrations

---
*This PR was created by an AI agent (OpenHands) on behalf of jpshackelford.*
