### PR TITLE
Include conversation ID and URL in RAG context

### DIFF
--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -483,7 +483,7 @@ class RAGAnswerer:
         header += f" - relevance: {chunk.score:.0%}]"
         header += f"\nConversation ID: {chunk.conversation_id}"
         if chunk.display_url:
-            header += f"\nURL: {chunk.cloud_url}"
+            header += f"\nURL: {chunk.display_url}"
         return header
     
     def _format_chunk_refs(self, chunk: ContextChunk) -> str | None:

--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -35,12 +35,14 @@ DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant that answers questions ab
 
 You have been provided with context from relevant conversation history. Each source includes:
 - Title and date
+- Conversation ID and URL (when available)
 - Summary (when available)
 - Related refs (PRs, issues, repos) - use these to disambiguate references like "#42"
 
 Guidelines:
 - Base your answer on the provided context
 - When citing information, reference the specific conversation by title (e.g., "In the conversation 'Configure MCP secrets' from 3 days ago...")
+- When citing specific conversations, include the conversation ID and/or URL when available
 - Use the provided refs to accurately cite PRs/issues (e.g., "jpshackelford/ohtv#42" not just "#42")
 - If multiple conversations are relevant, mention them
 - If the context doesn't contain enough information, say so clearly
@@ -479,6 +481,9 @@ class RAGAnswerer:
         if chunk.created_at:
             header += f" ({self._format_age(chunk.created_at)})"
         header += f" - relevance: {chunk.score:.0%}]"
+        header += f"\nConversation ID: {chunk.conversation_id}"
+        if chunk.display_url:
+            header += f"\nURL: {chunk.cloud_url}"
         return header
     
     def _format_chunk_refs(self, chunk: ContextChunk) -> str | None:


### PR DESCRIPTION
## Summary

This PR fixes the issue where the LLM cannot cite conversation IDs/URLs in `ohtv ask` responses because they were not included in the context sent to the LLM.

Fixes #49

## Changes

### 1. Updated `_format_chunk_header()` in `src/ohtv/analysis/rag.py`

Added conversation ID and URL to the context header sent to the LLM:

```python
header += f"\nConversation ID: {chunk.conversation_id}"
if chunk.display_url:
    header += f"\nURL: {chunk.display_url}"
```

**Before:**
```
[Source 1: 🔧 Draft HappyFox Ticket Reply on PR Feature (today) - relevance: 76%]
Summary: ...
```

**After:**
```
[Source 1: 🔧 Draft HappyFox Ticket Reply on PR Feature (today) - relevance: 76%]
Conversation ID: abc123
URL: https://app.all-hands.dev/conversations/abc123
Summary: ...
```

### 2. Updated system prompt

- Added "Conversation ID and URL (when available)" to the list of source information
- Added guideline: "When citing specific conversations, include the conversation ID and/or URL when available"

## Key Review Decision

Per code review feedback, changed from `chunk.cloud_url` to `chunk.display_url` for consistency. The `display_url` property validates URL availability (cloud source, within 14-day retention window) before returning the URL, making the code more semantically correct.

## Test Coverage

- **Unit tests**: Verified all embed types (`analysis`, `summary`, `content`) include conversation IDs via the shared `_format_chunk_header()` method
- **Edge cases**: Confirmed expired URLs (>14 days) and local conversations properly omit URLs while still including conversation IDs
- **End-to-end**: Verified LLM responses now include conversation URLs when citing sources

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._