### PR TITLE
Add start time, duration, and step count to gen objs display

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,17 +510,57 @@ LLM cost: $0.0089
 
 **Multi-Conversation Example Output (table):**
 ```
-┏━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ ID      ┃ Date       ┃ Summary                                             ┃
-┡━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ abc1234 │ 2024-03-15 │ Refactor authentication module to use OAuth2 with   │
-│         │            │ refresh token support for improved security.        │
-│         │            │ → created user/repo/pull/42, pushed user/repo       │
-├─────────┼────────────┼─────────────────────────────────────────────────────┤
-│ def5678 │ 2024-03-14 │ Fix pagination bug in search results component that │
-│         │            │ caused duplicate entries on page boundaries.        │
-└─────────┴────────────┴─────────────────────────────────────────────────────┘
+┏━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ ID      ┃ Date         ┃ Duration    ┃ Summary                               ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ abc1234 │ 2024-03-15   │ 35 mins     │ Refactor authentication module to use │
+│ cloud   │ 10:42 AM     │ 46 steps    │ OAuth2 with refresh token support.    │
+│         │              │             │ → created user/repo/pull/42           │
+├─────────┼──────────────┼─────────────┼───────────────────────────────────────┤
+│ def5678 │ 2024-03-14   │ 1h 20m      │ Fix pagination bug in search results  │
+│ local   │ 2:15 PM      │ 128 steps   │ component that caused duplicate...    │
+└─────────┴──────────────┴─────────────┴───────────────────────────────────────┘
 Showing 2 of 150 (2/2 cached)
+```
+
+**Column Descriptions:**
+| Column | First Line | Second Line |
+|--------|------------|-------------|
+| ID | Short conversation ID | Source (`cloud` or `local`) |
+| Date | Date (YYYY-MM-DD) | Start time (HH:MM AM/PM) |
+| Duration | Duration (e.g., "35 mins", "1h 20m") | Event/step count (e.g., "46 steps") |
+| Summary | Goal description | Git refs (PRs, repos modified) |
+
+**JSON Output Fields (`-F json`):**
+```json
+[
+  {
+    "id": "abc12345def67890",
+    "source": "cloud",
+    "created_at": "2024-03-15T10:42:00+00:00",
+    "start_time": "10:42",
+    "duration_seconds": 2100,
+    "event_count": 46,
+    "goal": "Refactor authentication module..."
+  }
+]
+```
+
+| Field | Description |
+|-------|-------------|
+| `id` | Full conversation ID |
+| `source` | Source location (`cloud` or `local`) |
+| `created_at` | ISO 8601 timestamp |
+| `start_time` | Start time in HH:MM format |
+| `duration_seconds` | Duration in seconds (or `null` if unknown) |
+| `event_count` | Number of events/steps in the conversation |
+| `goal` | Extracted goal description |
+
+**Markdown Output (`-F markdown`):**
+```markdown
+- **abc1234** (2024-03-15, 10:42 AM, 35 mins, 46 steps): Refactor authentication...
+  - created user/repo/pull/42
+  - pushed user/repo
 ```
 
 **Options (Single-Conversation Mode):**

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -4841,12 +4841,40 @@ def _format_summary_markdown(results: list[dict], *, include_outputs: bool = Tru
 
     for r in results:
         date_str = ""
+        time_str = ""
         if r["created_at"]:
             local_time = r["created_at"].astimezone()
             date_str = local_time.strftime("%Y-%m-%d")
+            time_str = local_time.strftime("%I:%M %p").lstrip("0")
+        
+        # Format duration
+        duration_str = ""
+        duration = r.get("duration")
+        if duration:
+            total_minutes = int(duration.total_seconds()) // 60
+            if total_minutes < 60:
+                duration_str = f"{total_minutes} mins"
+            else:
+                hours = total_minutes // 60
+                minutes = total_minutes % 60
+                duration_str = f"{hours}h {minutes}m" if minutes else f"{hours}h"
+        
+        # Format step count
+        event_count = r.get("event_count")
+        steps_str = f"{event_count} steps" if event_count else ""
+        
+        # Build metadata parts
+        meta_parts = [date_str]
+        if time_str:
+            meta_parts.append(time_str)
+        if duration_str:
+            meta_parts.append(duration_str)
+        if steps_str:
+            meta_parts.append(steps_str)
+        meta = ", ".join(meta_parts)
 
-        # Format as a list item with date and goal
-        lines.append(f"- **{r['short_id']}** ({date_str}): {r['goal']}")
+        # Format as a list item with metadata and goal
+        lines.append(f"- **{r['short_id']}** ({meta}): {r['goal']}")
 
         # Add refs/outputs as sub-items if present
         if include_outputs and r.get("outputs"):
@@ -7491,6 +7519,9 @@ def _run_batch_objectives_analysis(
                 "short_id": conv.short_id,
                 "source": conv.source,
                 "created_at": conv.created_at,
+                "updated_at": conv.updated_at,
+                "duration": conv.duration,  # timedelta for display formatting
+                "event_count": conv.event_count,
                 "goal": display_goal or "(no goal identified)",
                 "cached": analysis_result.from_cache,
                 "conv_dir": conv_dir,
@@ -7651,10 +7682,17 @@ def _run_batch_objectives_analysis(
     if fmt == "json":
         json_results = []
         for r in results:
+            # Calculate duration_seconds from timedelta
+            duration = r.get("duration")
+            duration_seconds = int(duration.total_seconds()) if duration else None
+            
             item = {
                 "id": r["id"],
                 "source": r["source"],
                 "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                "start_time": r["created_at"].astimezone().strftime("%H:%M") if r.get("created_at") else None,
+                "duration_seconds": duration_seconds,
+                "event_count": r.get("event_count"),
                 "goal": r["goal"],
             }
             if not no_outputs and r.get("outputs"):

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -4837,32 +4837,22 @@ def _format_refs_for_markdown(outputs: dict | None) -> list[str]:
 
 def _format_summary_markdown(results: list[dict], *, include_outputs: bool = True) -> str:
     """Format summary results as markdown."""
+    from ohtv.prompts.formatters import (
+        format_date,
+        format_duration_minutes,
+        format_step_count,
+        format_time,
+    )
+
     lines = []
 
     for r in results:
-        date_str = ""
-        time_str = ""
-        if r["created_at"]:
-            local_time = r["created_at"].astimezone()
-            date_str = local_time.strftime("%Y-%m-%d")
-            time_str = local_time.strftime("%I:%M %p").lstrip("0")
-        
-        # Format duration
-        duration_str = ""
-        duration = r.get("duration")
-        if duration:
-            total_minutes = int(duration.total_seconds()) // 60
-            if total_minutes < 60:
-                duration_str = f"{total_minutes} mins"
-            else:
-                hours = total_minutes // 60
-                minutes = total_minutes % 60
-                duration_str = f"{hours}h {minutes}m" if minutes else f"{hours}h"
-        
-        # Format step count
-        event_count = r.get("event_count")
-        steps_str = f"{event_count} steps" if event_count else ""
-        
+        # Use formatters from formatters.py for consistent formatting
+        date_str = format_date(r.get("created_at"))
+        time_str = format_time(r.get("created_at"))
+        duration_str = format_duration_minutes(r.get("duration"))
+        steps_str = format_step_count(r.get("event_count"))
+
         # Build metadata parts
         meta_parts = [date_str]
         if time_str:

--- a/src/ohtv/prompts/formatters.py
+++ b/src/ohtv/prompts/formatters.py
@@ -5,7 +5,7 @@ Each formatter is a function that takes a value and optional args, returning a s
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable
 
 
@@ -109,9 +109,91 @@ def format_plain(value: Any, args: str | None = None) -> str:
     return str(value)
 
 
+def format_time(value: Any, args: str | None = None) -> str:
+    """Format a datetime value as HH:MM AM/PM.
+    
+    Args:
+        value: A datetime object or ISO format string
+        args: Unused
+        
+    Returns:
+        Formatted time string (e.g., "10:42 AM"), or empty string if value is None
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    if isinstance(value, datetime):
+        local_time = value.astimezone()
+        return local_time.strftime("%I:%M %p").lstrip("0")
+    return str(value)
+
+
+def format_duration_minutes(value: Any, args: str | None = None) -> str:
+    """Format a timedelta as 'N mins' or 'Nh Mm'.
+    
+    Args:
+        value: A timedelta object or number of seconds
+        args: Unused
+        
+    Returns:
+        Human-readable duration string (e.g., "35 mins", "1h 20m")
+    """
+    if value is None:
+        return ""
+    
+    # Convert to total seconds
+    if isinstance(value, timedelta):
+        total_seconds = int(value.total_seconds())
+    elif isinstance(value, (int, float)):
+        total_seconds = int(value)
+    else:
+        return str(value)
+    
+    if total_seconds < 0:
+        return ""
+    
+    total_minutes = total_seconds // 60
+    
+    if total_minutes < 60:
+        return f"{total_minutes} mins"
+    
+    hours = total_minutes // 60
+    minutes = total_minutes % 60
+    
+    if minutes == 0:
+        return f"{hours}h"
+    return f"{hours}h {minutes}m"
+
+
+def format_step_count(value: Any, args: str | None = None) -> str:
+    """Format integer as 'N steps'.
+    
+    Args:
+        value: An integer event count
+        args: Unused
+        
+    Returns:
+        Formatted string (e.g., "46 steps"), or empty string if value is None/0
+    """
+    if value is None or value == 0:
+        return ""
+    try:
+        count = int(value)
+        return f"{count} steps"
+    except (TypeError, ValueError):
+        return str(value)
+
+
 # Registry of available formatters
 FORMATTERS: dict[str, Callable[[Any, str | None], str]] = {
     "date": format_date,
+    "time": format_time,
+    "duration_minutes": format_duration_minutes,
+    "step_count": format_step_count,
     "status_badge": format_status_badge,
     "bullet_list": format_bullet_list,
     "truncate": format_truncate,

--- a/src/ohtv/prompts/renderer.py
+++ b/src/ohtv/prompts/renderer.py
@@ -192,18 +192,32 @@ class TableRenderer:
 def get_default_display_schema() -> DisplaySchema:
     """Get the default display schema for backward compatibility.
     
-    This matches the original hardcoded table format.
+    This matches the original hardcoded table format with enhanced columns for:
+    - ID + source on second line
+    - Date + time on second line  
+    - Duration + step count
+    - Summary + refs
     
     Returns:
-        DisplaySchema with ID, Date, and Summary columns
+        DisplaySchema with ID, Date, Duration, and Summary columns
     """
     # Import here to avoid circular dependency - cli.py imports from prompts/__init__.py
     # which re-exports this function, and metadata.py is part of the same package
     from ohtv.prompts.metadata import ColumnDef, FieldRef
     
     return DisplaySchema(columns=[
-        ColumnDef(name="ID", field="short_id", width=7),
-        ColumnDef(name="Date", field="created_at", format="date", width=10),
+        ColumnDef(name="ID", fields=[
+            FieldRef(field_name="short_id"),
+            FieldRef(field_name="source"),
+        ], combine="newline", width=9),
+        ColumnDef(name="Date", fields=[
+            FieldRef(field_name="created_at", format="date"),
+            FieldRef(field_name="created_at", format="time"),
+        ], combine="newline", width=12),
+        ColumnDef(name="Duration", fields=[
+            FieldRef(field_name="duration", format="duration_minutes"),
+            FieldRef(field_name="event_count", format="step_count"),
+        ], combine="newline", width=10),
         ColumnDef(name="Summary", fields=[
             FieldRef(field_name="goal"),
             FieldRef(field_name="refs_display"),

--- a/tests/unit/prompts/test_formatters.py
+++ b/tests/unit/prompts/test_formatters.py
@@ -1,0 +1,344 @@
+"""Tests for formatters module, specifically new time/duration/step_count formatters."""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from ohtv.prompts.formatters import (
+    format_time,
+    format_duration_minutes,
+    format_step_count,
+    format_value,
+    get_formatter,
+    FORMATTERS,
+)
+
+
+class TestFormatTime:
+    """Tests for format_time function."""
+    
+    def test_format_time_datetime_morning(self):
+        """Test formatting morning time from datetime."""
+        # 10:42 AM UTC
+        dt = datetime(2024, 3, 15, 10, 42, 0, tzinfo=timezone.utc)
+        result = format_time(dt)
+        # Should contain AM and reasonable time format
+        assert "AM" in result or "PM" in result
+        # The exact time depends on local timezone, but format should be consistent
+        assert ":" in result
+    
+    def test_format_time_datetime_afternoon(self):
+        """Test formatting afternoon time from datetime."""
+        # 2:15 PM UTC
+        dt = datetime(2024, 3, 15, 14, 15, 0, tzinfo=timezone.utc)
+        result = format_time(dt)
+        assert "AM" in result or "PM" in result
+        assert ":" in result
+    
+    def test_format_time_midnight(self):
+        """Test formatting midnight."""
+        dt = datetime(2024, 3, 15, 0, 0, 0, tzinfo=timezone.utc)
+        result = format_time(dt)
+        assert result  # Should produce non-empty result
+    
+    def test_format_time_leading_zero_stripped(self):
+        """Test that leading zero is stripped from hour."""
+        # Use a fixed offset timezone for predictable output
+        from datetime import timezone as tz
+        # Create a datetime that will show 9:30 AM when interpreted as local
+        dt = datetime(2024, 3, 15, 9, 30, 0, tzinfo=tz(timedelta(hours=0)))
+        result = format_time(dt)
+        # Should not start with "09:", but "9:"
+        # Note: this depends on the local timezone, so we check the format is valid
+        assert ":" in result
+        assert (result.startswith("9:") or "AM" in result or "PM" in result)
+    
+    def test_format_time_iso_string(self):
+        """Test formatting from ISO string."""
+        result = format_time("2024-03-15T10:42:00Z")
+        assert "AM" in result or "PM" in result
+        assert ":" in result
+    
+    def test_format_time_iso_string_with_offset(self):
+        """Test formatting from ISO string with offset."""
+        result = format_time("2024-03-15T10:42:00+00:00")
+        assert ":" in result
+    
+    def test_format_time_none(self):
+        """Test formatting None returns empty string."""
+        result = format_time(None)
+        assert result == ""
+    
+    def test_format_time_invalid_string(self):
+        """Test formatting invalid string returns the string."""
+        result = format_time("not-a-date")
+        assert result == "not-a-date"
+    
+    def test_format_time_registered(self):
+        """Test that time formatter is registered."""
+        assert "time" in FORMATTERS
+        assert FORMATTERS["time"] is format_time
+
+
+class TestFormatDurationMinutes:
+    """Tests for format_duration_minutes function."""
+    
+    def test_format_duration_minutes_short(self):
+        """Test formatting duration under an hour."""
+        result = format_duration_minutes(timedelta(minutes=35))
+        assert result == "35 mins"
+    
+    def test_format_duration_minutes_zero(self):
+        """Test formatting zero duration."""
+        result = format_duration_minutes(timedelta(minutes=0))
+        assert result == "0 mins"
+    
+    def test_format_duration_minutes_one_minute(self):
+        """Test formatting one minute."""
+        result = format_duration_minutes(timedelta(minutes=1))
+        assert result == "1 mins"
+    
+    def test_format_duration_minutes_exact_hour(self):
+        """Test formatting exactly one hour."""
+        result = format_duration_minutes(timedelta(hours=1))
+        assert result == "1h"
+    
+    def test_format_duration_minutes_hours_and_minutes(self):
+        """Test formatting hours and minutes."""
+        result = format_duration_minutes(timedelta(hours=1, minutes=20))
+        assert result == "1h 20m"
+    
+    def test_format_duration_minutes_multiple_hours(self):
+        """Test formatting multiple hours."""
+        result = format_duration_minutes(timedelta(hours=2, minutes=45))
+        assert result == "2h 45m"
+    
+    def test_format_duration_minutes_multiple_hours_exact(self):
+        """Test formatting exact multiple hours."""
+        result = format_duration_minutes(timedelta(hours=3))
+        assert result == "3h"
+    
+    def test_format_duration_minutes_from_seconds_int(self):
+        """Test formatting from seconds as integer."""
+        result = format_duration_minutes(35 * 60)  # 35 minutes in seconds
+        assert result == "35 mins"
+    
+    def test_format_duration_minutes_from_seconds_float(self):
+        """Test formatting from seconds as float."""
+        result = format_duration_minutes(90.5 * 60)  # 90.5 minutes
+        assert result == "1h 30m"
+    
+    def test_format_duration_minutes_none(self):
+        """Test formatting None returns empty string."""
+        result = format_duration_minutes(None)
+        assert result == ""
+    
+    def test_format_duration_minutes_negative(self):
+        """Test formatting negative duration returns empty string."""
+        result = format_duration_minutes(timedelta(minutes=-5))
+        assert result == ""
+    
+    def test_format_duration_minutes_non_numeric(self):
+        """Test formatting non-numeric value returns string representation."""
+        result = format_duration_minutes("not-a-duration")
+        assert result == "not-a-duration"
+    
+    def test_format_duration_minutes_registered(self):
+        """Test that duration_minutes formatter is registered."""
+        assert "duration_minutes" in FORMATTERS
+        assert FORMATTERS["duration_minutes"] is format_duration_minutes
+
+
+class TestFormatStepCount:
+    """Tests for format_step_count function."""
+    
+    def test_format_step_count_normal(self):
+        """Test formatting normal step count."""
+        result = format_step_count(46)
+        assert result == "46 steps"
+    
+    def test_format_step_count_one(self):
+        """Test formatting single step."""
+        result = format_step_count(1)
+        assert result == "1 steps"
+    
+    def test_format_step_count_large(self):
+        """Test formatting large step count."""
+        result = format_step_count(128)
+        assert result == "128 steps"
+    
+    def test_format_step_count_zero(self):
+        """Test formatting zero returns empty string."""
+        result = format_step_count(0)
+        assert result == ""
+    
+    def test_format_step_count_none(self):
+        """Test formatting None returns empty string."""
+        result = format_step_count(None)
+        assert result == ""
+    
+    def test_format_step_count_from_string(self):
+        """Test formatting from string number."""
+        result = format_step_count("42")
+        assert result == "42 steps"
+    
+    def test_format_step_count_invalid(self):
+        """Test formatting invalid value returns string."""
+        result = format_step_count("not-a-number")
+        assert result == "not-a-number"
+    
+    def test_format_step_count_registered(self):
+        """Test that step_count formatter is registered."""
+        assert "step_count" in FORMATTERS
+        assert FORMATTERS["step_count"] is format_step_count
+
+
+class TestFormatterIntegration:
+    """Integration tests for formatters with format_value and get_formatter."""
+    
+    def test_format_value_time(self):
+        """Test format_value with time formatter."""
+        dt = datetime(2024, 3, 15, 10, 42, 0, tzinfo=timezone.utc)
+        result = format_value(dt, "time")
+        assert ":" in result
+    
+    def test_format_value_duration_minutes(self):
+        """Test format_value with duration_minutes formatter."""
+        result = format_value(timedelta(hours=1, minutes=30), "duration_minutes")
+        assert result == "1h 30m"
+    
+    def test_format_value_step_count(self):
+        """Test format_value with step_count formatter."""
+        result = format_value(50, "step_count")
+        assert result == "50 steps"
+    
+    def test_get_formatter_time(self):
+        """Test get_formatter returns time formatter."""
+        formatter = get_formatter("time")
+        dt = datetime(2024, 3, 15, 10, 42, 0, tzinfo=timezone.utc)
+        result = formatter(dt)
+        assert ":" in result
+    
+    def test_get_formatter_duration_minutes(self):
+        """Test get_formatter returns duration_minutes formatter."""
+        formatter = get_formatter("duration_minutes")
+        result = formatter(timedelta(minutes=45))
+        assert result == "45 mins"
+    
+    def test_get_formatter_step_count(self):
+        """Test get_formatter returns step_count formatter."""
+        formatter = get_formatter("step_count")
+        result = formatter(100)
+        assert result == "100 steps"
+
+
+class TestDefaultDisplaySchema:
+    """Tests for the default display schema with new columns."""
+    
+    def test_default_schema_has_four_columns(self):
+        """Test default schema has ID, Date, Duration, Summary columns."""
+        from ohtv.prompts.renderer import get_default_display_schema
+        
+        schema = get_default_display_schema()
+        assert len(schema.columns) == 4
+        
+        col_names = [col.name for col in schema.columns]
+        assert col_names == ["ID", "Date", "Duration", "Summary"]
+    
+    def test_id_column_has_short_id_and_source(self):
+        """Test ID column has short_id and source fields."""
+        from ohtv.prompts.renderer import get_default_display_schema
+        
+        schema = get_default_display_schema()
+        id_col = schema.get_column("ID")
+        
+        assert id_col is not None
+        field_refs = id_col.get_field_refs()
+        assert len(field_refs) == 2
+        assert field_refs[0].field_name == "short_id"
+        assert field_refs[1].field_name == "source"
+        assert id_col.combine == "newline"
+    
+    def test_date_column_has_date_and_time(self):
+        """Test Date column has date and time formats."""
+        from ohtv.prompts.renderer import get_default_display_schema
+        
+        schema = get_default_display_schema()
+        date_col = schema.get_column("Date")
+        
+        assert date_col is not None
+        field_refs = date_col.get_field_refs()
+        assert len(field_refs) == 2
+        assert field_refs[0].field_name == "created_at"
+        assert field_refs[0].format == "date"
+        assert field_refs[1].field_name == "created_at"
+        assert field_refs[1].format == "time"
+        assert date_col.combine == "newline"
+    
+    def test_duration_column_has_duration_and_steps(self):
+        """Test Duration column has duration and event_count fields."""
+        from ohtv.prompts.renderer import get_default_display_schema
+        
+        schema = get_default_display_schema()
+        duration_col = schema.get_column("Duration")
+        
+        assert duration_col is not None
+        field_refs = duration_col.get_field_refs()
+        assert len(field_refs) == 2
+        assert field_refs[0].field_name == "duration"
+        assert field_refs[0].format == "duration_minutes"
+        assert field_refs[1].field_name == "event_count"
+        assert field_refs[1].format == "step_count"
+        assert duration_col.combine == "newline"
+    
+    def test_summary_column_has_goal_and_refs(self):
+        """Test Summary column has goal and refs_display fields."""
+        from ohtv.prompts.renderer import get_default_display_schema
+        
+        schema = get_default_display_schema()
+        summary_col = schema.get_column("Summary")
+        
+        assert summary_col is not None
+        field_refs = summary_col.get_field_refs()
+        assert len(field_refs) == 2
+        assert field_refs[0].field_name == "goal"
+        assert field_refs[1].field_name == "refs_display"
+    
+    def test_table_renderer_with_new_schema(self):
+        """Test TableRenderer can render with the new schema."""
+        from ohtv.prompts.renderer import get_default_display_schema, TableRenderer
+        from io import StringIO
+        from rich.console import Console
+        
+        schema = get_default_display_schema()
+        
+        # Create a console with string output for testing
+        string_io = StringIO()
+        test_console = Console(file=string_io, force_terminal=True, width=120)
+        
+        renderer = TableRenderer(schema, console=test_console)
+        
+        # Create test data matching the new result dict structure
+        results = [{
+            "id": "abc12345def67890",
+            "short_id": "abc1234",
+            "source": "cloud",
+            "created_at": datetime(2024, 3, 15, 10, 42, 0, tzinfo=timezone.utc),
+            "updated_at": datetime(2024, 3, 15, 11, 17, 0, tzinfo=timezone.utc),
+            "duration": timedelta(minutes=35),
+            "event_count": 46,
+            "goal": "Test objective analysis",
+            "refs_display": "",
+            "cached": True,
+        }]
+        
+        # Render the table - should not raise any errors
+        renderer.render(results, show_summary=True, total_count=1, error_count=0)
+        
+        output = string_io.getvalue()
+        
+        # Verify key data appears in output
+        assert "abc1234" in output  # short_id
+        assert "cloud" in output  # source
+        assert "35 mins" in output  # duration
+        assert "46 steps" in output  # event_count
+        assert "Test objective analysis" in output  # goal


### PR DESCRIPTION
## Summary

Enhances the `gen objs` batch mode display with additional metadata (start time, duration, step count) to help users understand their workflow patterns.

## Changes

### New Formatters (`src/ohtv/prompts/formatters.py`)
- `format_time`: Formats datetime as "HH:MM AM/PM"
- `format_duration_minutes`: Formats timedelta as "N mins" or "Nh Mm"  
- `format_step_count`: Formats integer as "N steps"

### Enhanced Display Schema (`src/ohtv/prompts/renderer.py`)
- **ID column**: Shows `short_id` + `source` (cloud/local) on second line
- **Date column**: Shows date + time on second line
- **New Duration column**: Shows duration + event count (step count)
- **Summary column**: Unchanged (goal + refs)

### Updated CLI (`src/ohtv/cli.py`)
- Added `duration`, `event_count`, and `updated_at` fields to batch analysis result dict
- JSON output now includes `start_time`, `duration_seconds`, and `event_count` fields
- Markdown output uses centralized formatters from `formatters.py`

### Documentation (`README.md`)
- Updated table example showing new 4-column layout
- Added Column Descriptions table for multi-line cells
- Added JSON Output Fields section with field descriptions
- Added Markdown Output example

## Example Output

```
┏━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ ID      ┃ Date         ┃ Duration    ┃ Summary                               ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 3e1c9f6 │ 2026-05-14   │ 35 mins     │ Test whether the OpenHands plugin... │
│ cloud   │ 10:42 AM     │ 46 steps    │                                       │
├─────────┼──────────────┼─────────────┼───────────────────────────────────────┤
│ 8fccc38 │ 2026-05-14   │ 1h 20m      │ Create a comprehensive document...    │
│ local   │ 2:15 PM      │ 128 steps   │                                       │
```

## Review Decisions

During review, the following decisions were made:
- **Centralized formatters**: Refactored markdown output to reuse formatters from `formatters.py` instead of duplicating formatting logic (commit 729d412)
- **Edge case handling**: All formatters return empty strings for None/0 values, allowing graceful degradation

## Test Coverage

- **42 new unit tests** covering all formatter functions with various inputs and edge cases
- **Integration test** for TableRenderer with new display schema
- **1008 total tests** passing (no regressions)
- **Manual testing** verified all output formats (table, JSON, markdown)

Fixes #52

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*