### PR TITLE
feat: add --agent flag for multi-turn investigation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ ohtv search "fix authentication bugs"
 # Ask questions about your conversations (RAG)
 ohtv ask "how did we fix the auth bug?"
 
+# Deep investigation with agent mode
+ohtv ask "explain the auth fix in detail" --agent
+
 # Customize prompts
 ohtv prompts init              # Copy prompts to ~/.ohtv/prompts/
 ohtv prompts show brief        # View a prompt
@@ -1088,6 +1091,12 @@ ohtv ask "what PRs did we create?" --model openai/gpt-4
 
 # Lower minimum score to get more context
 ohtv ask "testing strategies" --min-score 0.2
+
+# Enable multi-turn investigation mode for deeper analysis
+ohtv ask "explain the auth fix in detail" --agent
+
+# Investigation with more steps for complex questions
+ohtv ask "what went wrong with the deployment?" --agent --max-steps 10
 ```
 
 **Example Output:**
@@ -1120,9 +1129,56 @@ Search: 0.15s | Generation: 2.34s | Model: openai/gpt-4o-mini
 | `-s, --min-score N` | Minimum similarity score 0-1 (default: 0.3) |
 | `-m, --model MODEL` | LLM model for answer generation |
 | `--show-context` | Show retrieved context chunks |
+| `--agent` | Enable multi-turn investigation mode (see below) |
+| `--max-steps N` | Maximum investigation steps with `--agent` (default: 5) |
 | `-v, --verbose` | Show debug output |
 
 **Note:** Requires embeddings. Run `ohtv db embed` first.
+
+#### Investigation Mode (`--agent`)
+
+When `--agent` is enabled, the answer is enhanced through multi-turn investigation. An AI agent can use tools to examine specific conversations in detail, search for related context, and retrieve git references (PRs, issues, repos).
+
+**Available tools in investigation mode:**
+- `show_conversation` - Load and examine a specific conversation transcript
+- `search_conversations` - Search for related conversations by query
+- `get_refs` - Get git references (repos, PRs, issues) for a conversation
+
+**Example with investigation:**
+```bash
+$ ohtv ask "what specific changes were made to fix the auth bug?" --agent
+
+Searching for relevant context...
+Generating answer...
+
+🔍 Starting investigation mode...
+[Agent examines conversation abc123...]
+[Agent searches for "JWT token validation"...]
+
+Investigation complete: 3 steps, 2 conversations examined
+
+Answer (after investigation):
+
+The auth bug was fixed in conversation abc123 with these specific changes:
+
+1. In `src/auth/jwt.py` line 45: Added `if token.exp < time.time()` check
+2. Changed the exception handler to return 401 instead of re-raising as 500
+3. Added tests in `tests/auth/test_jwt.py` covering expired token scenarios
+
+The fix was pushed in PR owner/repo#42.
+
+─────────────────────────────────────────────────
+Sources (2 conversations):
+  • [abc12345] Fix JWT token validation
+  • [def56789] Debug login flow
+
+Search: 0.15s | Generation: 2.34s | Investigation: 8.52s | 🔍 agent
+```
+
+Investigation mode is useful for:
+- Questions requiring specific code details from conversations
+- Understanding the relationship between multiple conversations
+- Finding which PRs or repos were involved in a fix
 
 ---
 

--- a/src/ohtv/analysis/agent_tools.py
+++ b/src/ohtv/analysis/agent_tools.py
@@ -65,6 +65,10 @@ class ShowConversationObservation(Observation):
     transcript: str = Field(description="The conversation transcript")
     error: str | None = Field(default=None, description="Error message if any")
 
+    def to_text(self) -> str:
+        """Return the observation content as plain text for LLM context."""
+        return self.transcript or self.error or "No result"
+
     @property
     def visualize(self) -> Text:
         content = Text()
@@ -282,6 +286,10 @@ class SearchConversationsObservation(Observation):
     results: str = Field(description="Formatted search results")
     error: str | None = Field(default=None, description="Error message if any")
 
+    def to_text(self) -> str:
+        """Return the observation content as plain text for LLM context."""
+        return self.results or self.error or "No result"
+
     @property
     def visualize(self) -> Text:
         content = Text()
@@ -415,6 +423,10 @@ class GetRefsObservation(Observation):
     conversation_id: str = Field(description="The conversation ID")
     refs_summary: str = Field(description="Summary of git references (PRs, issues, repos)")
     error: str | None = Field(default=None, description="Error message if any")
+
+    def to_text(self) -> str:
+        """Return the observation content as plain text for LLM context."""
+        return self.refs_summary or self.error or "No result"
 
     @property
     def visualize(self) -> Text:

--- a/src/ohtv/analysis/agent_tools.py
+++ b/src/ohtv/analysis/agent_tools.py
@@ -1,0 +1,534 @@
+"""Custom tools for the investigation agent.
+
+Provides tools that allow the agent to:
+1. Load and examine specific conversation trajectories
+2. Search for related conversations
+3. Get git references (PRs, issues, repos) for conversations
+"""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Self
+
+from pydantic import Field
+from rich.text import Text
+
+from openhands.sdk.tool.schema import Action, Observation
+from openhands.sdk.tool.tool import ToolAnnotations, ToolDefinition, ToolExecutor
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation import LocalConversation
+
+    from ohtv.db.stores import (
+        ConversationStore,
+        EmbeddingStore,
+        LinkStore,
+        ReferenceStore,
+        RepoStore,
+    )
+
+
+# ============================================================================
+# ShowConversation Tool
+# ============================================================================
+
+
+class ShowConversationAction(Action):
+    """Action to load and examine a specific conversation transcript."""
+
+    conversation_id: str = Field(
+        description="The conversation ID to examine (first 8 characters are sufficient)"
+    )
+    show_details: bool = Field(
+        default=False,
+        description="Whether to include detailed tool call information",
+    )
+    max_messages: int = Field(
+        default=50,
+        description="Maximum number of messages to return (default: 50)",
+    )
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        content.append("Show conversation: ", style="bold blue")
+        content.append(self.conversation_id)
+        return content
+
+
+class ShowConversationObservation(Observation):
+    """Observation containing the conversation transcript."""
+
+    conversation_id: str = Field(description="The full conversation ID")
+    title: str | None = Field(default=None, description="Conversation title")
+    message_count: int = Field(description="Number of messages retrieved")
+    transcript: str = Field(description="The conversation transcript")
+    error: str | None = Field(default=None, description="Error message if any")
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        if self.error:
+            content.append(f"Error: {self.error}", style="red")
+        else:
+            content.append(f"Transcript ({self.message_count} messages):\n", style="dim")
+            # Show truncated preview
+            preview = self.transcript[:500] + "..." if len(self.transcript) > 500 else self.transcript
+            content.append(preview)
+        return content
+
+
+class ShowConversationExecutor(ToolExecutor[ShowConversationAction, ShowConversationObservation]):
+    """Executor that loads conversation transcripts from the database."""
+
+    def __init__(
+        self,
+        conv_store: "ConversationStore",
+        conversation_dirs: list[str] | None = None,
+    ):
+        self.conv_store = conv_store
+        self.conversation_dirs = conversation_dirs or []
+
+    def _find_conversation_dir(self, conv_id: str):
+        """Find conversation directory by prefix match."""
+        from pathlib import Path
+
+        normalized_id = conv_id.replace("-", "")
+
+        for base_dir_str in self.conversation_dirs:
+            base_dir = Path(base_dir_str)
+            if not base_dir.exists():
+                continue
+
+            # Try exact match first
+            exact = base_dir / normalized_id
+            if exact.exists():
+                return exact
+
+            # Prefix match
+            for d in base_dir.iterdir():
+                if d.is_dir() and d.name.startswith(normalized_id):
+                    return d
+
+        return None
+
+    def _load_events(self, conv_dir) -> list[dict]:
+        """Load events from conversation directory."""
+        import json
+        from pathlib import Path
+
+        events = []
+        events_dir = conv_dir / "events"
+
+        if not events_dir.exists():
+            # Try loading from single file
+            events_file = conv_dir / "events.json"
+            if events_file.exists():
+                with open(events_file) as f:
+                    events = json.load(f)
+            return events
+
+        # Load individual event files
+        for event_file in sorted(events_dir.glob("*.json")):
+            try:
+                with open(event_file) as f:
+                    events.append(json.load(f))
+            except (json.JSONDecodeError, OSError):
+                continue
+
+        return events
+
+    def _build_simple_transcript(self, events: list[dict], max_messages: int, show_details: bool) -> str:
+        """Build a simple transcript from events."""
+        from ohtv.analysis.transcript import extract_message_content, extract_action_summary
+
+        lines = []
+        count = 0
+
+        for event in events:
+            if count >= max_messages:
+                lines.append(f"\n... (truncated, {len(events) - count} more events)")
+                break
+
+            kind = event.get("kind", "")
+            source = event.get("source", "")
+
+            if kind == "MessageEvent":
+                content = extract_message_content(event)
+                if content:
+                    role = "USER" if source == "user" else "ASSISTANT"
+                    # Truncate long messages
+                    if len(content) > 1000 and not show_details:
+                        content = content[:1000] + "..."
+                    lines.append(f"[{role}]: {content}")
+                    count += 1
+
+            elif kind == "ActionEvent" and show_details:
+                summary = extract_action_summary(event)
+                lines.append(f"[ACTION]: {summary}")
+                count += 1
+
+        return "\n\n".join(lines)
+
+    def __call__(
+        self,
+        action: ShowConversationAction,
+        conversation: "LocalConversation | None" = None,
+    ) -> ShowConversationObservation:
+        try:
+            conv_id = action.conversation_id.replace("-", "")
+
+            # Find conversation directory
+            conv_dir = self._find_conversation_dir(conv_id)
+            if conv_dir is None:
+                return ShowConversationObservation(
+                    conversation_id=conv_id,
+                    title=None,
+                    message_count=0,
+                    transcript="",
+                    error=f"Conversation not found: {action.conversation_id}",
+                )
+
+            # Get title from database
+            full_id = conv_dir.name.replace("-", "")
+            conv = self.conv_store.get(full_id)
+            title = conv.title if conv else None
+
+            # Load and build transcript
+            events = self._load_events(conv_dir)
+            transcript = self._build_simple_transcript(events, action.max_messages, action.show_details)
+
+            return ShowConversationObservation(
+                conversation_id=full_id,
+                title=title,
+                message_count=len([e for e in events if e.get("kind") == "MessageEvent"]),
+                transcript=transcript,
+            )
+
+        except Exception as e:
+            return ShowConversationObservation(
+                conversation_id=action.conversation_id,
+                title=None,
+                message_count=0,
+                transcript="",
+                error=str(e),
+            )
+
+
+class ShowConversationTool(ToolDefinition[ShowConversationAction, ShowConversationObservation]):
+    """Tool for loading and examining a specific conversation trajectory."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: Any = None,
+        conv_store: "ConversationStore | None" = None,
+        conversation_dirs: list[str] | None = None,
+        **params,
+    ) -> Sequence[Self]:
+        if conv_store is None:
+            raise ValueError("conv_store is required for ShowConversationTool")
+
+        return [
+            cls(
+                action_type=ShowConversationAction,
+                observation_type=ShowConversationObservation,
+                description=(
+                    "Load and examine a specific conversation trajectory. "
+                    "Use this to get detailed information about a conversation mentioned in the initial answer. "
+                    "Provide the conversation ID (first 8 characters are sufficient)."
+                ),
+                executor=ShowConversationExecutor(conv_store, conversation_dirs),
+                annotations=ToolAnnotations(
+                    title="show_conversation",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=False,
+                ),
+            )
+        ]
+
+
+# ============================================================================
+# SearchConversations Tool
+# ============================================================================
+
+
+class SearchConversationsAction(Action):
+    """Action to search for related conversations."""
+
+    query: str = Field(
+        description="Search query to find related conversations"
+    )
+    max_results: int = Field(
+        default=5,
+        description="Maximum number of results to return (default: 5)",
+    )
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        content.append("Search: ", style="bold blue")
+        content.append(self.query)
+        return content
+
+
+class SearchConversationsObservation(Observation):
+    """Observation containing search results."""
+
+    query: str = Field(description="The search query used")
+    result_count: int = Field(description="Number of results found")
+    results: str = Field(description="Formatted search results")
+    error: str | None = Field(default=None, description="Error message if any")
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        if self.error:
+            content.append(f"Error: {self.error}", style="red")
+        else:
+            content.append(f"Found {self.result_count} results:\n", style="dim")
+            content.append(self.results)
+        return content
+
+
+class SearchConversationsExecutor(ToolExecutor[SearchConversationsAction, SearchConversationsObservation]):
+    """Executor that searches conversations using embeddings."""
+
+    def __init__(
+        self,
+        embed_store: "EmbeddingStore",
+        conv_store: "ConversationStore",
+    ):
+        self.embed_store = embed_store
+        self.conv_store = conv_store
+
+    def __call__(
+        self,
+        action: SearchConversationsAction,
+        conversation: "LocalConversation | None" = None,
+    ) -> SearchConversationsObservation:
+        try:
+            # Search using embeddings
+            results = self.embed_store.search_conversations(
+                query=action.query,
+                limit=action.max_results,
+            )
+
+            if not results:
+                return SearchConversationsObservation(
+                    query=action.query,
+                    result_count=0,
+                    results="No matching conversations found.",
+                )
+
+            # Format results
+            formatted = []
+            for r in results:
+                conv = self.conv_store.get(r.conversation_id)
+                title = conv.title if conv else f"Conversation {r.conversation_id[:8]}"
+                date_str = conv.created_at.strftime("%Y-%m-%d") if conv and conv.created_at else "unknown"
+                summary = conv.summary if conv and conv.summary else "No summary available"
+                
+                formatted.append(
+                    f"- [{r.conversation_id[:8]}] {title} ({date_str})\n"
+                    f"  Score: {r.score:.3f}\n"
+                    f"  Summary: {summary[:150]}{'...' if len(summary) > 150 else ''}"
+                )
+
+            return SearchConversationsObservation(
+                query=action.query,
+                result_count=len(results),
+                results="\n\n".join(formatted),
+            )
+
+        except Exception as e:
+            return SearchConversationsObservation(
+                query=action.query,
+                result_count=0,
+                results="",
+                error=str(e),
+            )
+
+
+class SearchConversationsTool(ToolDefinition[SearchConversationsAction, SearchConversationsObservation]):
+    """Tool for searching related conversations using semantic search."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: Any = None,
+        embed_store: "EmbeddingStore | None" = None,
+        conv_store: "ConversationStore | None" = None,
+        **params,
+    ) -> Sequence[Self]:
+        if embed_store is None:
+            raise ValueError("embed_store is required for SearchConversationsTool")
+        if conv_store is None:
+            raise ValueError("conv_store is required for SearchConversationsTool")
+
+        return [
+            cls(
+                action_type=SearchConversationsAction,
+                observation_type=SearchConversationsObservation,
+                description=(
+                    "Search for related conversations using semantic search. "
+                    "Use this to find additional conversations that might be relevant to the question. "
+                    "The query can be natural language describing what you're looking for."
+                ),
+                executor=SearchConversationsExecutor(embed_store, conv_store),
+                annotations=ToolAnnotations(
+                    title="search_conversations",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=False,
+                ),
+            )
+        ]
+
+
+# ============================================================================
+# GetRefs Tool
+# ============================================================================
+
+
+class GetRefsAction(Action):
+    """Action to get git references for a conversation."""
+
+    conversation_id: str = Field(
+        description="The conversation ID to get refs for (first 8 characters are sufficient)"
+    )
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        content.append("Get refs for: ", style="bold blue")
+        content.append(self.conversation_id)
+        return content
+
+
+class GetRefsObservation(Observation):
+    """Observation containing git references."""
+
+    conversation_id: str = Field(description="The conversation ID")
+    refs_summary: str = Field(description="Summary of git references (PRs, issues, repos)")
+    error: str | None = Field(default=None, description="Error message if any")
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        if self.error:
+            content.append(f"Error: {self.error}", style="red")
+        else:
+            content.append("Git References:\n", style="dim")
+            content.append(self.refs_summary)
+        return content
+
+
+class GetRefsExecutor(ToolExecutor[GetRefsAction, GetRefsObservation]):
+    """Executor that retrieves git references for a conversation."""
+
+    def __init__(
+        self,
+        link_store: "LinkStore",
+        ref_store: "ReferenceStore",
+        repo_store: "RepoStore",
+    ):
+        self.link_store = link_store
+        self.ref_store = ref_store
+        self.repo_store = repo_store
+
+    def __call__(
+        self,
+        action: GetRefsAction,
+        conversation: "LocalConversation | None" = None,
+    ) -> GetRefsObservation:
+        try:
+            conv_id = action.conversation_id.replace("-", "")
+
+            # Get repositories
+            repos = []
+            for repo_id, link_type in self.link_store.get_repos_for_conversation(conv_id):
+                repo = self.repo_store.get_by_id(repo_id)
+                if repo:
+                    repos.append(f"  - {repo.fqn} ({link_type.value})")
+
+            # Get refs (PRs and issues)
+            prs = []
+            issues = []
+            for ref_id, link_type in self.link_store.get_refs_for_conversation(conv_id):
+                ref = self.ref_store.get_by_id(ref_id)
+                if ref:
+                    entry = f"  - {ref.fqn} ({link_type.value}): {ref.url}"
+                    if ref.ref_type.value == "pr":
+                        prs.append(entry)
+                    elif ref.ref_type.value == "issue":
+                        issues.append(entry)
+
+            # Format output
+            parts = []
+            if repos:
+                parts.append("Repositories:\n" + "\n".join(repos))
+            if prs:
+                parts.append("Pull Requests:\n" + "\n".join(prs))
+            if issues:
+                parts.append("Issues:\n" + "\n".join(issues))
+
+            if not parts:
+                summary = "No git references found for this conversation."
+            else:
+                summary = "\n\n".join(parts)
+
+            return GetRefsObservation(
+                conversation_id=conv_id,
+                refs_summary=summary,
+            )
+
+        except Exception as e:
+            return GetRefsObservation(
+                conversation_id=action.conversation_id,
+                refs_summary="",
+                error=str(e),
+            )
+
+
+class GetRefsTool(ToolDefinition[GetRefsAction, GetRefsObservation]):
+    """Tool for getting git references (PRs, issues, repos) for a conversation."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: Any = None,
+        link_store: "LinkStore | None" = None,
+        ref_store: "ReferenceStore | None" = None,
+        repo_store: "RepoStore | None" = None,
+        **params,
+    ) -> Sequence[Self]:
+        if link_store is None:
+            raise ValueError("link_store is required for GetRefsTool")
+        if ref_store is None:
+            raise ValueError("ref_store is required for GetRefsTool")
+        if repo_store is None:
+            raise ValueError("repo_store is required for GetRefsTool")
+
+        return [
+            cls(
+                action_type=GetRefsAction,
+                observation_type=GetRefsObservation,
+                description=(
+                    "Get git references (PRs, issues, repositories) for a conversation. "
+                    "Use this to find related code changes and issues. "
+                    "Provide the conversation ID (first 8 characters are sufficient)."
+                ),
+                executor=GetRefsExecutor(link_store, ref_store, repo_store),
+                annotations=ToolAnnotations(
+                    title="get_refs",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=False,
+                ),
+            )
+        ]

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -1,0 +1,509 @@
+"""Multi-turn investigation agent for RAG follow-up.
+
+This module provides an agent that can perform multi-turn investigation
+to answer questions about conversation history more thoroughly than
+single-turn RAG.
+"""
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import SecretStr
+from rich.console import Console
+
+# Suppress openhands-sdk banner before import
+os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
+
+from openhands.sdk import Agent, LocalConversation
+from openhands.sdk.llm import LLM
+from openhands.sdk.tool import FinishTool, ThinkTool, ToolDefinition
+
+from ohtv.analysis.agent_tools import (
+    GetRefsTool,
+    SearchConversationsTool,
+    ShowConversationTool,
+)
+from ohtv.analysis.rag import RAGAnswer
+
+if TYPE_CHECKING:
+    from ohtv.db.stores import (
+        ConversationStore,
+        EmbeddingStore,
+        LinkStore,
+        ReferenceStore,
+        RepoStore,
+    )
+
+log = logging.getLogger("ohtv")
+
+DEFAULT_MAX_ITERATIONS = 5
+
+
+@dataclass
+class InvestigationResult:
+    """Result of a multi-turn investigation."""
+
+    final_answer: str
+    initial_answer: str
+    investigation_steps: list[str]
+    conversations_examined: set[str]
+    total_iterations: int
+    total_cost: float
+    total_tokens: int
+    model: str
+    elapsed_seconds: float
+    finished_normally: bool = True
+    error: str | None = None
+
+
+def get_investigation_system_prompt() -> str:
+    """Get the system prompt for the investigation agent."""
+    return """You are an investigation agent that helps answer questions about software development conversations and coding sessions.
+
+You have been given an initial answer to a question, along with source citations. Your job is to:
+
+1. **Assess the initial answer**: Is it complete? Are there gaps or areas that need more detail?
+2. **Investigate if needed**: Use your tools to gather more information:
+   - `show_conversation`: Load the full transcript of a specific conversation to get more detail
+   - `search_conversations`: Find additional related conversations that might help
+   - `get_refs`: Get git references (PRs, issues, repos) for a conversation
+3. **Synthesize findings**: Produce a final comprehensive answer with citations
+
+## Guidelines
+
+- Start by reviewing the initial answer and identifying what additional information would be helpful
+- Use the `think` tool to reason about what to investigate next
+- Be efficient - don't examine conversations that won't add new information
+- When you have a satisfactory answer, use the `finish` tool with your final response
+- Include conversation IDs in your citations (e.g., "In conversation abc123...")
+- If the initial answer is already complete and accurate, say so and finish quickly
+
+## When to investigate more
+
+- The initial answer mentions conversations but lacks detail
+- The question asks for specifics that aren't in the initial answer
+- There are multiple relevant conversations and they might have conflicting or complementary information
+- The answer would benefit from examining actual code changes or PR details
+
+## When to finish quickly
+
+- The initial answer fully addresses the question
+- No additional context would significantly improve the answer
+- The question is simple and the initial answer is sufficient"""
+
+
+def format_initial_context(question: str, rag_answer: RAGAnswer) -> str:
+    """Format the initial RAG answer as context for the agent."""
+    parts = [
+        f"## Question\n{question}",
+        f"\n## Initial Answer\n{rag_answer.answer}",
+        f"\n## Sources ({len(rag_answer.source_conversation_ids)} conversations)",
+    ]
+
+    # Add source information
+    for chunk in rag_answer.context_chunks:
+        source = chunk.source
+        if source:
+            date_str = source.created_at.strftime("%Y-%m-%d") if source.created_at else "unknown"
+            parts.append(f"\n### Conversation: {chunk.conversation_id[:8]} ({date_str})")
+            parts.append(f"Title: {source.title}")
+            if source.summary:
+                parts.append(f"Summary: {source.summary}")
+            if source.prs:
+                pr_list = ", ".join(pr.fqn for pr in source.prs[:3])
+                parts.append(f"PRs: {pr_list}")
+            if source.repos:
+                repo_list = ", ".join(r.fqn for r in source.repos[:3])
+                parts.append(f"Repos: {repo_list}")
+        else:
+            parts.append(f"\n### Conversation: {chunk.conversation_id[:8]}")
+            parts.append(f"Title: {chunk.title}")
+
+    parts.append("\n## Your Task")
+    parts.append(
+        "Review the initial answer and sources above. "
+        "Determine if additional investigation is needed to fully answer the question. "
+        "Use the available tools to gather more information if helpful, "
+        "then provide a final comprehensive answer."
+    )
+
+    return "\n".join(parts)
+
+
+class InvestigationAgent:
+    """Multi-turn investigation agent for RAG follow-up.
+
+    This agent takes an initial RAG answer and can use tools to
+    investigate further, examining specific conversations and
+    searching for additional context.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        embed_store: "EmbeddingStore",
+        conv_store: "ConversationStore",
+        link_store: "LinkStore | None" = None,
+        ref_store: "ReferenceStore | None" = None,
+        repo_store: "RepoStore | None" = None,
+        conversation_dirs: list[str] | None = None,
+        max_iterations: int = DEFAULT_MAX_ITERATIONS,
+        console: Console | None = None,
+    ):
+        """Initialize the investigation agent.
+
+        Args:
+            model: LLM model for the agent
+            embed_store: EmbeddingStore for searching conversations
+            conv_store: ConversationStore for conversation metadata
+            link_store: LinkStore for conversation-ref relationships
+            ref_store: ReferenceStore for ref details
+            repo_store: RepoStore for repository details
+            conversation_dirs: List of directories containing conversations
+            max_iterations: Maximum number of agent iterations
+            console: Rich console for output (optional)
+        """
+        self.model = model
+        self.embed_store = embed_store
+        self.conv_store = conv_store
+        self.link_store = link_store
+        self.ref_store = ref_store
+        self.repo_store = repo_store
+        self.conversation_dirs = conversation_dirs or []
+        self.max_iterations = max_iterations
+        self.console = console or Console()
+
+        # Verify API key is available
+        api_key = os.environ.get("LLM_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "LLM_API_KEY environment variable not set. "
+                "This is required for the investigation agent."
+            )
+
+    def _create_tools(self) -> list[ToolDefinition]:
+        """Create the tools available to the investigation agent."""
+        tools = []
+
+        # ShowConversation tool
+        show_tools = ShowConversationTool.create(
+            conv_store=self.conv_store,
+            conversation_dirs=self.conversation_dirs,
+        )
+        tools.extend(show_tools)
+
+        # SearchConversations tool
+        search_tools = SearchConversationsTool.create(
+            embed_store=self.embed_store,
+            conv_store=self.conv_store,
+        )
+        tools.extend(search_tools)
+
+        # GetRefs tool (only if ref stores are available)
+        if self.link_store and self.ref_store and self.repo_store:
+            ref_tools = GetRefsTool.create(
+                link_store=self.link_store,
+                ref_store=self.ref_store,
+                repo_store=self.repo_store,
+            )
+            tools.extend(ref_tools)
+
+        return tools
+
+    def investigate(
+        self,
+        question: str,
+        initial_answer: RAGAnswer,
+    ) -> InvestigationResult:
+        """Run multi-turn investigation starting from initial RAG answer.
+
+        Args:
+            question: The original question
+            initial_answer: The initial RAG answer with context
+
+        Returns:
+            InvestigationResult with final answer and metrics
+        """
+        import time
+
+        start_time = time.time()
+
+        # Create LLM instance
+        api_key = os.environ.get("LLM_API_KEY")
+        llm = LLM(
+            model=self.model,
+            api_key=SecretStr(api_key) if api_key else None,
+            base_url=os.environ.get("LLM_BASE_URL"),
+        )
+
+        # Create agent with custom tools
+        custom_tools = self._create_tools()
+        agent = Agent(
+            llm=llm,
+            tools=[],  # We'll pass tools differently
+            include_default_tools=["think", "finish"],  # Include built-in tools
+        )
+
+        # Create a temporary workspace for the conversation
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create conversation with custom tools
+            conversation = LocalConversation(
+                agent=agent,
+                workspace=temp_dir,
+                max_iteration_per_run=self.max_iterations,
+                visualizer=None,  # Disable visualizer for non-interactive mode
+            )
+
+            # Register custom tools with the conversation's tool registry
+            for tool in custom_tools:
+                # Tools need to be added to the agent's tool list
+                pass  # Tools are already in the agent
+
+            # Actually, we need to pass tools to the Agent constructor
+            # Let me refactor this
+
+        # Re-create with proper tool setup
+        agent = Agent(
+            llm=llm,
+            tools=[],
+            include_default_tools=["think", "finish"],
+        )
+
+        # Add custom tools to the agent's tools list
+        # The Agent expects Tool specs, not ToolDefinition instances
+        # We need to use a different approach - use the ToolDefinition directly
+
+        # Track investigation state
+        investigation_steps = []
+        conversations_examined = set()
+        total_tokens = 0
+        total_cost = 0.0
+        final_answer = ""
+        finished_normally = False
+        error = None
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # Build the initial message
+                initial_context = format_initial_context(question, initial_answer)
+
+                # Create a simpler approach using direct LLM calls with tools
+                result = self._run_investigation_loop(
+                    llm=llm,
+                    initial_context=initial_context,
+                    custom_tools=custom_tools,
+                    investigation_steps=investigation_steps,
+                    conversations_examined=conversations_examined,
+                )
+
+                final_answer = result["answer"]
+                total_tokens = result["total_tokens"]
+                total_cost = result["total_cost"]
+                finished_normally = result["finished"]
+
+        except Exception as e:
+            log.exception("Investigation failed")
+            error = str(e)
+            final_answer = initial_answer.answer  # Fall back to initial answer
+
+        elapsed = time.time() - start_time
+
+        return InvestigationResult(
+            final_answer=final_answer,
+            initial_answer=initial_answer.answer,
+            investigation_steps=investigation_steps,
+            conversations_examined=conversations_examined,
+            total_iterations=len(investigation_steps),
+            total_cost=total_cost,
+            total_tokens=total_tokens,
+            model=self.model,
+            elapsed_seconds=elapsed,
+            finished_normally=finished_normally,
+            error=error,
+        )
+
+    def _run_investigation_loop(
+        self,
+        llm: LLM,
+        initial_context: str,
+        custom_tools: list[ToolDefinition],
+        investigation_steps: list[str],
+        conversations_examined: set[str],
+    ) -> dict:
+        """Run the investigation loop using direct LLM calls with tools.
+
+        This is a simpler approach than using the full Agent/LocalConversation
+        infrastructure, which is better suited for autonomous agent tasks.
+        """
+        from openhands.sdk.llm.message import Message
+
+        # Build tool definitions for the LLM
+        tool_definitions = []
+        tool_map = {}
+
+        # Add custom tools
+        for tool in custom_tools:
+            tool_definitions.append(tool.to_openai_tool())
+            tool_map[tool.name] = tool
+
+        # Add finish tool manually
+        finish_tools = FinishTool.create()
+        for ft in finish_tools:
+            tool_definitions.append(ft.to_openai_tool())
+            tool_map[ft.name] = ft
+
+        # Add think tool manually
+        think_tools = ThinkTool.create()
+        for tt in think_tools:
+            tool_definitions.append(tt.to_openai_tool())
+            tool_map[tt.name] = tt
+
+        # Initialize conversation
+        messages = [
+            Message(role="system", content=get_investigation_system_prompt()),
+            Message(role="user", content=initial_context),
+        ]
+
+        total_tokens = 0
+        total_cost = 0.0
+        finished = False
+        final_answer = ""
+        iteration = 0
+
+        while not finished and iteration < self.max_iterations:
+            iteration += 1
+            self.console.print(f"[dim]Investigation step {iteration}...[/dim]")
+
+            try:
+                # Call LLM with tools
+                response = llm.completion(messages, tools=tool_definitions)
+
+                # Track metrics
+                if response.metrics:
+                    if response.metrics.accumulated_token_usage:
+                        usage = response.metrics.accumulated_token_usage
+                        total_tokens += usage.prompt_tokens + usage.completion_tokens
+                    total_cost += response.metrics.accumulated_cost or 0.0
+
+                # Process response
+                message = response.message
+                tool_calls = message.tool_calls or []
+
+                if not tool_calls:
+                    # No tool calls - extract text response as final answer
+                    if message.content:
+                        text_parts = []
+                        for part in message.content:
+                            if hasattr(part, 'text') and part.text:
+                                text_parts.append(part.text)
+                        if text_parts:
+                            final_answer = "".join(text_parts)
+                            finished = True
+                            investigation_steps.append(f"Finished with direct response")
+                    break
+
+                # Process tool calls
+                for tool_call in tool_calls:
+                    tool_name = tool_call.function.name
+                    arguments = tool_call.function.arguments
+
+                    # Parse arguments (might be string or dict)
+                    if isinstance(arguments, str):
+                        import json
+                        try:
+                            arguments = json.loads(arguments)
+                        except json.JSONDecodeError:
+                            arguments = {}
+
+                    investigation_steps.append(f"Called {tool_name}: {arguments}")
+
+                    # Handle finish tool
+                    if tool_name == "finish":
+                        final_answer = arguments.get("message", "")
+                        finished = True
+                        break
+
+                    # Handle think tool
+                    if tool_name == "think":
+                        thought = arguments.get("thought", "")
+                        investigation_steps.append(f"Thinking: {thought[:100]}...")
+                        # Add tool result to messages
+                        messages.append(Message(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[tool_call],
+                        ))
+                        messages.append(Message(
+                            role="tool",
+                            content=f"Thought recorded: {thought}",
+                            tool_call_id=tool_call.id,
+                        ))
+                        continue
+
+                    # Handle custom tools
+                    tool = tool_map.get(tool_name)
+                    if tool and tool.executor:
+                        try:
+                            # Create action from arguments
+                            action = tool.action_from_arguments(arguments)
+                            observation = tool(action)
+
+                            # Track conversations examined
+                            if tool_name == "show_conversation" and hasattr(observation, "conversation_id"):
+                                conversations_examined.add(observation.conversation_id)
+
+                            # Format observation for message
+                            if hasattr(observation, "transcript"):
+                                result_text = observation.transcript or observation.error or "No result"
+                            elif hasattr(observation, "results"):
+                                result_text = observation.results or observation.error or "No result"
+                            elif hasattr(observation, "refs_summary"):
+                                result_text = observation.refs_summary or observation.error or "No result"
+                            else:
+                                result_text = str(observation)
+
+                            # Truncate if too long
+                            if len(result_text) > 4000:
+                                result_text = result_text[:4000] + "\n... [truncated]"
+
+                        except Exception as e:
+                            result_text = f"Error executing tool: {e}"
+
+                        # Add tool result to messages
+                        messages.append(Message(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[tool_call],
+                        ))
+                        messages.append(Message(
+                            role="tool",
+                            content=result_text,
+                            tool_call_id=tool_call.id,
+                        ))
+
+                if finished:
+                    break
+
+            except Exception as e:
+                log.exception("Error in investigation step")
+                investigation_steps.append(f"Error: {e}")
+                break
+
+        if not final_answer and not finished:
+            # If we didn't finish normally, provide a summary
+            final_answer = (
+                "Investigation reached iteration limit without a final answer. "
+                "Please review the investigation steps for partial findings."
+            )
+
+        return {
+            "answer": final_answer,
+            "total_tokens": total_tokens,
+            "total_cost": total_cost,
+            "finished": finished,
+        }

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -7,7 +7,6 @@ single-turn RAG.
 
 import logging
 import os
-import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -253,23 +252,22 @@ class InvestigationAgent:
         error = None
 
         try:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                # Build the initial message
-                initial_context = format_initial_context(question, initial_answer)
+            # Build the initial message
+            initial_context = format_initial_context(question, initial_answer)
 
-                # Create a simpler approach using direct LLM calls with tools
-                result = self._run_investigation_loop(
-                    llm=llm,
-                    initial_context=initial_context,
-                    custom_tools=custom_tools,
-                    investigation_steps=investigation_steps,
-                    conversations_examined=conversations_examined,
-                )
+            # Create a simpler approach using direct LLM calls with tools
+            result = self._run_investigation_loop(
+                llm=llm,
+                initial_context=initial_context,
+                custom_tools=custom_tools,
+                investigation_steps=investigation_steps,
+                conversations_examined=conversations_examined,
+            )
 
-                final_answer = result["answer"]
-                total_tokens = result["total_tokens"]
-                total_cost = result["total_cost"]
-                finished_normally = result["finished"]
+            final_answer = result["answer"]
+            total_tokens = result["total_tokens"]
+            total_cost = result["total_cost"]
+            finished_normally = result["finished"]
 
         except Exception as e:
             log.exception("Investigation failed")

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -7,7 +7,6 @@ single-turn RAG.
 
 import logging
 import os
-import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -19,7 +18,6 @@ from rich.console import Console
 # Suppress openhands-sdk banner before import
 os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
 
-from openhands.sdk import Agent, LocalConversation
 from openhands.sdk.llm import LLM
 from openhands.sdk.tool import FinishTool, ThinkTool, ToolDefinition
 
@@ -241,42 +239,8 @@ class InvestigationAgent:
             base_url=os.environ.get("LLM_BASE_URL"),
         )
 
-        # Create agent with custom tools
+        # Create custom tools for the investigation
         custom_tools = self._create_tools()
-        agent = Agent(
-            llm=llm,
-            tools=[],  # We'll pass tools differently
-            include_default_tools=["think", "finish"],  # Include built-in tools
-        )
-
-        # Create a temporary workspace for the conversation
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Create conversation with custom tools
-            conversation = LocalConversation(
-                agent=agent,
-                workspace=temp_dir,
-                max_iteration_per_run=self.max_iterations,
-                visualizer=None,  # Disable visualizer for non-interactive mode
-            )
-
-            # Register custom tools with the conversation's tool registry
-            for tool in custom_tools:
-                # Tools need to be added to the agent's tool list
-                pass  # Tools are already in the agent
-
-            # Actually, we need to pass tools to the Agent constructor
-            # Let me refactor this
-
-        # Re-create with proper tool setup
-        agent = Agent(
-            llm=llm,
-            tools=[],
-            include_default_tools=["think", "finish"],
-        )
-
-        # Add custom tools to the agent's tools list
-        # The Agent expects Tool specs, not ToolDefinition instances
-        # We need to use a different approach - use the ToolDefinition directly
 
         # Track investigation state
         investigation_steps = []
@@ -343,24 +307,25 @@ class InvestigationAgent:
         from openhands.sdk.llm.message import Message
 
         # Build tool definitions for the LLM
-        tool_definitions = []
-        tool_map = {}
+        # llm.completion() expects ToolDefinition objects, not dicts
+        tool_definitions: list[ToolDefinition] = []
+        tool_map: dict[str, ToolDefinition] = {}
 
         # Add custom tools
         for tool in custom_tools:
-            tool_definitions.append(tool.to_openai_tool())
+            tool_definitions.append(tool)
             tool_map[tool.name] = tool
 
-        # Add finish tool manually
+        # Add finish tool
         finish_tools = FinishTool.create()
         for ft in finish_tools:
-            tool_definitions.append(ft.to_openai_tool())
+            tool_definitions.append(ft)
             tool_map[ft.name] = ft
 
-        # Add think tool manually
+        # Add think tool
         think_tools = ThinkTool.create()
         for tt in think_tools:
-            tool_definitions.append(tt.to_openai_tool())
+            tool_definitions.append(tt)
             tool_map[tt.name] = tt
 
         # Initialize conversation

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -7,6 +7,7 @@ single-turn RAG.
 
 import logging
 import os
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -422,13 +422,9 @@ class InvestigationAgent:
                             if tool_name == "show_conversation" and hasattr(observation, "conversation_id"):
                                 conversations_examined.add(observation.conversation_id)
 
-                            # Format observation for message
-                            if hasattr(observation, "transcript"):
-                                result_text = observation.transcript or observation.error or "No result"
-                            elif hasattr(observation, "results"):
-                                result_text = observation.results or observation.error or "No result"
-                            elif hasattr(observation, "refs_summary"):
-                                result_text = observation.refs_summary or observation.error or "No result"
+                            # Format observation for message using to_text() method
+                            if hasattr(observation, "to_text"):
+                                result_text = observation.to_text()
                             else:
                                 result_text = str(observation)
 

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -373,11 +373,8 @@ class InvestigationAgent:
                 if tool_name == "show_conversation" and hasattr(observation, "conversation_id"):
                     conversations_examined.add(observation.conversation_id)
 
-                # Format observation using to_text() method
-                if hasattr(observation, "to_text"):
-                    result_text = observation.to_text()
-                else:
-                    result_text = str(observation)
+                # Format observation using to_text() method (guaranteed on all observations)
+                result_text = observation.to_text()
 
                 # Truncate if too long
                 if len(result_text) > 4000:
@@ -410,6 +407,23 @@ class InvestigationAgent:
             content=result_text,
             tool_call_id=tool_call.id,
         ))
+
+    def _extract_final_answer_from_message(self, message) -> str | None:
+        """Extract final answer from message content.
+
+        Args:
+            message: The LLM response message
+
+        Returns:
+            Extracted text content or None if no text found
+        """
+        if not message.content:
+            return None
+        text_parts = []
+        for part in message.content:
+            if hasattr(part, 'text') and part.text:
+                text_parts.append(part.text)
+        return "".join(text_parts) if text_parts else None
 
     def _run_investigation_loop(
         self,
@@ -460,15 +474,10 @@ class InvestigationAgent:
 
                 if not tool_calls:
                     # No tool calls - extract text response as final answer
-                    if message.content:
-                        text_parts = []
-                        for part in message.content:
-                            if hasattr(part, 'text') and part.text:
-                                text_parts.append(part.text)
-                        if text_parts:
-                            final_answer = "".join(text_parts)
-                            finished = True
-                            investigation_steps.append("Finished with direct response")
+                    final_answer = self._extract_final_answer_from_message(message)
+                    if final_answer:
+                        finished = True
+                        investigation_steps.append("Finished with direct response")
                     break
 
                 # Process each tool call

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -291,6 +291,127 @@ class InvestigationAgent:
             error=error,
         )
 
+    def _build_tool_map(
+        self,
+        custom_tools: list[ToolDefinition],
+    ) -> tuple[list[ToolDefinition], dict[str, ToolDefinition]]:
+        """Build tool definitions list and name-to-tool mapping.
+
+        Args:
+            custom_tools: Custom tools to include
+
+        Returns:
+            Tuple of (tool_definitions list, tool_map dict)
+        """
+        tool_definitions: list[ToolDefinition] = []
+        tool_map: dict[str, ToolDefinition] = {}
+
+        # Add custom tools
+        for tool in custom_tools:
+            tool_definitions.append(tool)
+            tool_map[tool.name] = tool
+
+        # Add finish tool
+        for ft in FinishTool.create():
+            tool_definitions.append(ft)
+            tool_map[ft.name] = ft
+
+        # Add think tool
+        for tt in ThinkTool.create():
+            tool_definitions.append(tt)
+            tool_map[tt.name] = tt
+
+        return tool_definitions, tool_map
+
+    def _process_tool_call(
+        self,
+        tool_call,
+        tool_map: dict[str, ToolDefinition],
+        conversations_examined: set[str],
+    ) -> tuple[str | None, str | None, bool]:
+        """Process a single tool call and return the result.
+
+        Args:
+            tool_call: The tool call to process
+            tool_map: Mapping from tool names to ToolDefinition
+            conversations_examined: Set to track examined conversations
+
+        Returns:
+            Tuple of (result_text, final_answer, is_finished)
+            - result_text: Text to add as tool response (None for finish)
+            - final_answer: The final answer if finish was called
+            - is_finished: Whether the investigation is complete
+        """
+        import json
+
+        tool_name = tool_call.function.name
+        arguments = tool_call.function.arguments
+
+        # Parse arguments (might be string or dict)
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                arguments = {}
+
+        # Handle finish tool
+        if tool_name == "finish":
+            return None, arguments.get("message", ""), True
+
+        # Handle think tool
+        if tool_name == "think":
+            thought = arguments.get("thought", "")
+            return f"Thought recorded: {thought}", None, False
+
+        # Handle custom tools
+        tool = tool_map.get(tool_name)
+        if tool and tool.executor:
+            try:
+                action = tool.action_from_arguments(arguments)
+                observation = tool(action)
+
+                # Track conversations examined
+                if tool_name == "show_conversation" and hasattr(observation, "conversation_id"):
+                    conversations_examined.add(observation.conversation_id)
+
+                # Format observation using to_text() method
+                if hasattr(observation, "to_text"):
+                    result_text = observation.to_text()
+                else:
+                    result_text = str(observation)
+
+                # Truncate if too long
+                if len(result_text) > 4000:
+                    result_text = result_text[:4000] + "\n... [truncated]"
+
+                return result_text, None, False
+
+            except Exception as e:
+                return f"Error executing tool: {e}", None, False
+
+        return f"Unknown tool: {tool_name}", None, False
+
+    def _add_tool_response(self, messages: list, tool_call, result_text: str) -> None:
+        """Add assistant tool call and tool response messages.
+
+        Args:
+            messages: Message list to append to
+            tool_call: The tool call being responded to
+            result_text: The text result of the tool execution
+        """
+        from openhands.sdk.llm.message import Message
+
+        messages.append(Message(
+            role="assistant",
+            content=None,
+            tool_calls=[tool_call],
+        ))
+        messages.append(Message(
+            role="tool",
+            content=result_text,
+            tool_call_id=tool_call.id,
+        ))
+
     def _run_investigation_loop(
         self,
         llm: LLM,
@@ -306,27 +427,8 @@ class InvestigationAgent:
         """
         from openhands.sdk.llm.message import Message
 
-        # Build tool definitions for the LLM
-        # llm.completion() expects ToolDefinition objects, not dicts
-        tool_definitions: list[ToolDefinition] = []
-        tool_map: dict[str, ToolDefinition] = {}
-
-        # Add custom tools
-        for tool in custom_tools:
-            tool_definitions.append(tool)
-            tool_map[tool.name] = tool
-
-        # Add finish tool
-        finish_tools = FinishTool.create()
-        for ft in finish_tools:
-            tool_definitions.append(ft)
-            tool_map[ft.name] = ft
-
-        # Add think tool
-        think_tools = ThinkTool.create()
-        for tt in think_tools:
-            tool_definitions.append(tt)
-            tool_map[tt.name] = tt
+        # Build tool definitions and mapping
+        tool_definitions, tool_map = self._build_tool_map(custom_tools)
 
         # Initialize conversation
         messages = [
@@ -345,7 +447,6 @@ class InvestigationAgent:
             self.console.print(f"[dim]Investigation step {iteration}...[/dim]")
 
             try:
-                # Call LLM with tools
                 response = llm.completion(messages, tools=tool_definitions)
 
                 # Track metrics
@@ -355,7 +456,6 @@ class InvestigationAgent:
                         total_tokens += usage.prompt_tokens + usage.completion_tokens
                     total_cost += response.metrics.accumulated_cost or 0.0
 
-                # Process response
                 message = response.message
                 tool_calls = message.tool_calls or []
 
@@ -369,83 +469,28 @@ class InvestigationAgent:
                         if text_parts:
                             final_answer = "".join(text_parts)
                             finished = True
-                            investigation_steps.append(f"Finished with direct response")
+                            investigation_steps.append("Finished with direct response")
                     break
 
-                # Process tool calls
+                # Process each tool call
                 for tool_call in tool_calls:
                     tool_name = tool_call.function.name
-                    arguments = tool_call.function.arguments
+                    investigation_steps.append(f"Called {tool_name}: {tool_call.function.arguments}")
 
-                    # Parse arguments (might be string or dict)
-                    if isinstance(arguments, str):
-                        import json
-                        try:
-                            arguments = json.loads(arguments)
-                        except json.JSONDecodeError:
-                            arguments = {}
+                    result_text, answer, is_finished = self._process_tool_call(
+                        tool_call, tool_map, conversations_examined
+                    )
 
-                    investigation_steps.append(f"Called {tool_name}: {arguments}")
-
-                    # Handle finish tool
-                    if tool_name == "finish":
-                        final_answer = arguments.get("message", "")
+                    if is_finished:
+                        final_answer = answer or ""
                         finished = True
                         break
 
-                    # Handle think tool
-                    if tool_name == "think":
-                        thought = arguments.get("thought", "")
-                        investigation_steps.append(f"Thinking: {thought[:100]}...")
-                        # Add tool result to messages
-                        messages.append(Message(
-                            role="assistant",
-                            content=None,
-                            tool_calls=[tool_call],
-                        ))
-                        messages.append(Message(
-                            role="tool",
-                            content=f"Thought recorded: {thought}",
-                            tool_call_id=tool_call.id,
-                        ))
-                        continue
-
-                    # Handle custom tools
-                    tool = tool_map.get(tool_name)
-                    if tool and tool.executor:
-                        try:
-                            # Create action from arguments
-                            action = tool.action_from_arguments(arguments)
-                            observation = tool(action)
-
-                            # Track conversations examined
-                            if tool_name == "show_conversation" and hasattr(observation, "conversation_id"):
-                                conversations_examined.add(observation.conversation_id)
-
-                            # Format observation for message using to_text() method
-                            if hasattr(observation, "to_text"):
-                                result_text = observation.to_text()
-                            else:
-                                result_text = str(observation)
-
-                            # Truncate if too long
-                            if len(result_text) > 4000:
-                                result_text = result_text[:4000] + "\n... [truncated]"
-
-                        except Exception as e:
-                            result_text = f"Error executing tool: {e}"
-
-                        # Add tool result to messages
-                        messages.append(Message(
-                            role="assistant",
-                            content=None,
-                            tool_calls=[tool_call],
-                        ))
-                        messages.append(Message(
-                            role="tool",
-                            content=result_text,
-                            tool_call_id=tool_call.id,
-                        ))
+                    if result_text:
+                        if tool_name == "think":
+                            thought = result_text.replace("Thought recorded: ", "")
+                            investigation_steps.append(f"Thinking: {thought[:100]}...")
+                        self._add_tool_response(messages, tool_call, result_text)
 
                 if finished:
                     break
@@ -456,7 +501,6 @@ class InvestigationAgent:
                 break
 
         if not final_answer and not finished:
-            # If we didn't finish normally, provide a summary
             final_answer = (
                 "Investigation reached iteration limit without a final answer. "
                 "Please review the investigation steps for partial findings."

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -2372,6 +2372,8 @@ def _print_search_json(
 @click.option("--since", type=str, help="Only search conversations from this date (YYYY-MM-DD or relative: 7d, 2w, 1m)")
 @click.option("--until", type=str, help="Only search conversations until this date (YYYY-MM-DD)")
 @click.option("--no-temporal", is_flag=True, help="Disable automatic temporal filtering from question")
+@click.option("--agent", is_flag=True, help="Enable multi-turn investigation mode")
+@click.option("--max-steps", type=int, default=5, help="Max investigation steps (with --agent)")
 @click.option("--verbose", "-v", is_flag=True, help="Show debug output")
 def ask(
     question: str,
@@ -2382,6 +2384,8 @@ def ask(
     since: str | None,
     until: str | None,
     no_temporal: bool,
+    agent: bool,
+    max_steps: int,
     verbose: bool,
 ) -> None:
     """Ask a question about your conversations (RAG).
@@ -2392,6 +2396,10 @@ def ask(
     
     Temporal filtering is automatic - questions like "what did we work on
     yesterday?" will only search conversations from that time period.
+    
+    With --agent, enables multi-turn investigation mode where an agent can
+    examine specific conversations and search for additional context to
+    provide a more thorough answer.
     
     \b
     Before asking, build embeddings with:
@@ -2405,6 +2413,8 @@ def ask(
       ohtv ask "summarize deployment work" --since 7d    # Last 7 days
       ohtv ask "show me API changes" --since 2026-04-01 --until 2026-04-15
       ohtv ask "recent issues" --no-temporal             # Disable auto-filter
+      ohtv ask "explain the auth fix in detail" --agent  # Multi-turn investigation
+      ohtv ask "what PRs were created?" --agent --max-steps 10  # More investigation steps
     """
     from ohtv.db import get_connection, get_db_path, migrate
     from ohtv.db.stores import ConversationStore, EmbeddingStore, LinkStore, ReferenceStore, RepoStore
@@ -2496,6 +2506,49 @@ def ask(
             console.print("[dim]Make sure LLM_API_KEY is set.[/dim]")
             raise SystemExit(1)
         
+        # Agent mode: run multi-turn investigation
+        investigation_result = None
+        if agent:
+            from ohtv.analysis.investigator import InvestigationAgent
+            
+            console.print(f"\n[bold cyan]🔍 Starting investigation mode...[/bold cyan]")
+            
+            # Build list of conversation directories
+            conversation_dirs = [
+                str(config.local_conversations_dir),
+                str(config.synced_conversations_dir),
+            ]
+            for extra_path in config.extra_conversation_paths:
+                conversation_dirs.append(str(extra_path))
+            
+            try:
+                investigator = InvestigationAgent(
+                    model=model or answerer.model,
+                    embed_store=embed_store,
+                    conv_store=conv_store,
+                    link_store=link_store,
+                    ref_store=ref_store,
+                    repo_store=repo_store,
+                    conversation_dirs=conversation_dirs,
+                    max_iterations=max_steps,
+                    console=console,
+                )
+                
+                investigation_result = investigator.investigate(question, result)
+                
+                if investigation_result.error:
+                    console.print(f"[yellow]Investigation error: {investigation_result.error}[/yellow]")
+                    console.print("[dim]Falling back to initial answer.[/dim]")
+                else:
+                    # Show investigation summary
+                    console.print(f"\n[dim]Investigation complete: {investigation_result.total_iterations} steps, "
+                                  f"{len(investigation_result.conversations_examined)} conversations examined[/dim]")
+                    
+            except Exception as e:
+                console.print(f"[yellow]Investigation failed: {e}[/yellow]")
+                console.print("[dim]Falling back to initial answer.[/dim]")
+                investigation_result = None
+        
         # Show temporal filter info if applied
         if result.temporal_filter_applied and result.date_range:
             start, end = result.date_range
@@ -2526,8 +2579,13 @@ def ask(
             console.print("-" * 60)
         
         # Display answer
-        console.print(f"\n[bold]Answer:[/bold]\n")
-        console.print(result.answer)
+        if investigation_result and not investigation_result.error:
+            # Show investigation result
+            console.print(f"\n[bold]Answer (after investigation):[/bold]\n")
+            console.print(investigation_result.final_answer)
+        else:
+            console.print(f"\n[bold]Answer:[/bold]\n")
+            console.print(result.answer)
         
         # Show sources with enhanced citations
         console.print(f"\n[dim]─────────────────────────────────────────────────[/dim]")
@@ -2664,10 +2722,21 @@ def ask(
             f"Generation: {result.generation_time_seconds:.2f}s",
             f"Model: {result.model}",
         ]
-        if result.total_tokens > 0:
-            timing_parts.append(f"Tokens: {result.total_tokens:,} (${result.cost:.4f})")
+        
+        # Calculate total tokens and cost (including investigation if applicable)
+        total_tokens = result.total_tokens
+        total_cost = result.cost
+        if investigation_result and not investigation_result.error:
+            total_tokens += investigation_result.total_tokens
+            total_cost += investigation_result.total_cost
+            timing_parts.append(f"Investigation: {investigation_result.elapsed_seconds:.2f}s")
+        
+        if total_tokens > 0:
+            timing_parts.append(f"Tokens: {total_tokens:,} (${total_cost:.4f})")
         if result.temporal_filter_applied:
             timing_parts.append("📅 auto-filtered")
+        if investigation_result and not investigation_result.error:
+            timing_parts.append("🔍 agent")
         console.print(f"\n[dim]{' | '.join(timing_parts)}[/dim]")
 
 

--- a/src/ohtv/prompts/investigation/system.md
+++ b/src/ohtv/prompts/investigation/system.md
@@ -1,0 +1,37 @@
+---
+name: investigation_system
+description: System prompt for the investigation agent
+---
+
+You are an investigation agent that helps answer questions about software development conversations and coding sessions.
+
+You have been given an initial answer to a question, along with source citations. Your job is to:
+
+1. **Assess the initial answer**: Is it complete? Are there gaps or areas that need more detail?
+2. **Investigate if needed**: Use your tools to gather more information:
+   - `show_conversation`: Load the full transcript of a specific conversation to get more detail
+   - `search_conversations`: Find additional related conversations that might help
+   - `get_refs`: Get git references (PRs, issues, repos) for a conversation
+3. **Synthesize findings**: Produce a final comprehensive answer with citations
+
+## Guidelines
+
+- Start by reviewing the initial answer and identifying what additional information would be helpful
+- Use the `think` tool to reason about what to investigate next
+- Be efficient - don't examine conversations that won't add new information
+- When you have a satisfactory answer, use the `finish` tool with your final response
+- Include conversation IDs in your citations (e.g., "In conversation abc123...")
+- If the initial answer is already complete and accurate, say so and finish quickly
+
+## When to investigate more
+
+- The initial answer mentions conversations but lacks detail
+- The question asks for specifics that aren't in the initial answer
+- There are multiple relevant conversations and they might have conflicting or complementary information
+- The answer would benefit from examining actual code changes or PR details
+
+## When to finish quickly
+
+- The initial answer fully addresses the question
+- No additional context would significantly improve the answer
+- The question is simple and the initial answer is sufficient

--- a/tests/unit/analysis/test_agent_tools.py
+++ b/tests/unit/analysis/test_agent_tools.py
@@ -1,0 +1,343 @@
+"""Tests for the agent tools module."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ohtv.analysis.agent_tools import (
+    GetRefsAction,
+    GetRefsExecutor,
+    GetRefsObservation,
+    GetRefsTool,
+    SearchConversationsAction,
+    SearchConversationsExecutor,
+    SearchConversationsObservation,
+    SearchConversationsTool,
+    ShowConversationAction,
+    ShowConversationExecutor,
+    ShowConversationObservation,
+    ShowConversationTool,
+)
+
+
+class TestShowConversationAction:
+    """Tests for ShowConversationAction."""
+
+    def test_create_action(self):
+        """Test creating a ShowConversationAction."""
+        action = ShowConversationAction(
+            conversation_id="abc12345",
+            show_details=True,
+            max_messages=100,
+        )
+        assert action.conversation_id == "abc12345"
+        assert action.show_details is True
+        assert action.max_messages == 100
+
+    def test_action_defaults(self):
+        """Test default values for ShowConversationAction."""
+        action = ShowConversationAction(conversation_id="test123")
+        assert action.show_details is False
+        assert action.max_messages == 50
+
+
+class TestShowConversationObservation:
+    """Tests for ShowConversationObservation."""
+
+    def test_create_observation(self):
+        """Test creating a ShowConversationObservation."""
+        obs = ShowConversationObservation(
+            conversation_id="abc12345",
+            title="Test Conversation",
+            message_count=10,
+            transcript="[USER]: Hello\n\n[ASSISTANT]: Hi there",
+        )
+        assert obs.conversation_id == "abc12345"
+        assert obs.title == "Test Conversation"
+        assert obs.message_count == 10
+        assert "Hello" in obs.transcript
+        assert obs.error is None
+
+    def test_observation_with_error(self):
+        """Test observation with error."""
+        obs = ShowConversationObservation(
+            conversation_id="notfound",
+            title=None,
+            message_count=0,
+            transcript="",
+            error="Conversation not found: notfound",
+        )
+        assert obs.error is not None
+        assert "not found" in obs.error
+
+
+class TestShowConversationExecutor:
+    """Tests for ShowConversationExecutor."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_conv_store = MagicMock()
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        """Clean up temp directory."""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_find_conversation_not_found(self):
+        """Test when conversation is not found."""
+        executor = ShowConversationExecutor(
+            conv_store=self.mock_conv_store,
+            conversation_dirs=[self.temp_dir],
+        )
+        action = ShowConversationAction(conversation_id="notfound123")
+        result = executor(action)
+
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+
+    def test_find_conversation_by_prefix(self):
+        """Test finding conversation by prefix."""
+        # Create a test conversation directory
+        conv_id = "abc123def456789"
+        conv_dir = Path(self.temp_dir) / conv_id
+        conv_dir.mkdir()
+
+        # Create events directory with a simple event
+        events_dir = conv_dir / "events"
+        events_dir.mkdir()
+        event = {
+            "kind": "MessageEvent",
+            "source": "user",
+            "llm_message": {"content": [{"type": "text", "text": "Hello world"}]},
+        }
+        with open(events_dir / "0001.json", "w") as f:
+            json.dump(event, f)
+
+        # Mock conversation store
+        mock_conv = MagicMock()
+        mock_conv.title = "Test Title"
+        self.mock_conv_store.get.return_value = mock_conv
+
+        executor = ShowConversationExecutor(
+            conv_store=self.mock_conv_store,
+            conversation_dirs=[self.temp_dir],
+        )
+        action = ShowConversationAction(conversation_id="abc123")
+        result = executor(action)
+
+        assert result.error is None
+        assert result.conversation_id == conv_id
+        assert result.title == "Test Title"
+        assert result.message_count == 1
+        assert "Hello world" in result.transcript
+
+
+class TestSearchConversationsAction:
+    """Tests for SearchConversationsAction."""
+
+    def test_create_action(self):
+        """Test creating a SearchConversationsAction."""
+        action = SearchConversationsAction(
+            query="authentication bug",
+            max_results=10,
+        )
+        assert action.query == "authentication bug"
+        assert action.max_results == 10
+
+    def test_action_defaults(self):
+        """Test default values for SearchConversationsAction."""
+        action = SearchConversationsAction(query="test query")
+        assert action.max_results == 5
+
+
+class TestSearchConversationsObservation:
+    """Tests for SearchConversationsObservation."""
+
+    def test_create_observation(self):
+        """Test creating a SearchConversationsObservation."""
+        obs = SearchConversationsObservation(
+            query="test",
+            result_count=2,
+            results="- [abc123] Test (2024-01-01)\n- [def456] Another (2024-01-02)",
+        )
+        assert obs.query == "test"
+        assert obs.result_count == 2
+        assert "abc123" in obs.results
+
+
+class TestSearchConversationsExecutor:
+    """Tests for SearchConversationsExecutor."""
+
+    def test_no_results(self):
+        """Test search with no results."""
+        mock_embed_store = MagicMock()
+        mock_embed_store.search_conversations.return_value = []
+        mock_conv_store = MagicMock()
+
+        executor = SearchConversationsExecutor(
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+        )
+        action = SearchConversationsAction(query="nonexistent")
+        result = executor(action)
+
+        assert result.result_count == 0
+        assert "No matching" in result.results
+
+    def test_search_with_results(self):
+        """Test search with results."""
+        from datetime import datetime
+        
+        mock_embed_store = MagicMock()
+        mock_result = MagicMock()
+        mock_result.conversation_id = "abc12345"
+        mock_result.score = 0.85
+        mock_embed_store.search_conversations.return_value = [mock_result]
+
+        mock_conv_store = MagicMock()
+        mock_conv = MagicMock()
+        mock_conv.title = "Test Conversation"
+        mock_conv.created_at = datetime(2024, 1, 15)
+        mock_conv.summary = "This is a test summary"
+        mock_conv_store.get.return_value = mock_conv
+
+        executor = SearchConversationsExecutor(
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+        )
+        action = SearchConversationsAction(query="test")
+        result = executor(action)
+
+        assert result.result_count == 1
+        assert "abc12345" in result.results
+        assert "Test Conversation" in result.results
+        assert "0.850" in result.results
+
+
+class TestGetRefsAction:
+    """Tests for GetRefsAction."""
+
+    def test_create_action(self):
+        """Test creating a GetRefsAction."""
+        action = GetRefsAction(conversation_id="abc12345")
+        assert action.conversation_id == "abc12345"
+
+
+class TestGetRefsObservation:
+    """Tests for GetRefsObservation."""
+
+    def test_create_observation(self):
+        """Test creating a GetRefsObservation."""
+        obs = GetRefsObservation(
+            conversation_id="abc12345",
+            refs_summary="Repositories:\n  - owner/repo (read)\n\nPull Requests:\n  - owner/repo#42 (write)",
+        )
+        assert obs.conversation_id == "abc12345"
+        assert "owner/repo" in obs.refs_summary
+        assert obs.error is None
+
+
+class TestGetRefsExecutor:
+    """Tests for GetRefsExecutor."""
+
+    def test_no_refs(self):
+        """Test when conversation has no refs."""
+        mock_link_store = MagicMock()
+        mock_link_store.get_repos_for_conversation.return_value = []
+        mock_link_store.get_refs_for_conversation.return_value = []
+        mock_ref_store = MagicMock()
+        mock_repo_store = MagicMock()
+
+        executor = GetRefsExecutor(
+            link_store=mock_link_store,
+            ref_store=mock_ref_store,
+            repo_store=mock_repo_store,
+        )
+        action = GetRefsAction(conversation_id="abc12345")
+        result = executor(action)
+
+        assert "No git references" in result.refs_summary
+
+    def test_with_refs(self):
+        """Test when conversation has refs."""
+        from ohtv.db.models import LinkType, RefType
+
+        mock_link_store = MagicMock()
+        mock_link_store.get_repos_for_conversation.return_value = [(1, LinkType.READ)]
+        mock_link_store.get_refs_for_conversation.return_value = [(2, LinkType.WRITE)]
+
+        mock_repo_store = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.fqn = "owner/repo"
+        mock_repo_store.get_by_id.return_value = mock_repo
+
+        mock_ref_store = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.fqn = "owner/repo#42"
+        mock_ref.ref_type = RefType.PR
+        mock_ref.url = "https://github.com/owner/repo/pull/42"
+        mock_ref_store.get_by_id.return_value = mock_ref
+
+        executor = GetRefsExecutor(
+            link_store=mock_link_store,
+            ref_store=mock_ref_store,
+            repo_store=mock_repo_store,
+        )
+        action = GetRefsAction(conversation_id="abc12345")
+        result = executor(action)
+
+        assert "owner/repo" in result.refs_summary
+        assert "Pull Requests" in result.refs_summary
+
+
+class TestToolCreation:
+    """Tests for tool creation methods."""
+
+    def test_show_conversation_tool_create(self):
+        """Test ShowConversationTool.create()."""
+        mock_conv_store = MagicMock()
+        tools = ShowConversationTool.create(
+            conv_store=mock_conv_store,
+            conversation_dirs=["/tmp/convs"],
+        )
+        assert len(tools) == 1
+        assert tools[0].name == "show_conversation"
+        assert tools[0].executor is not None
+
+    def test_show_conversation_tool_missing_store(self):
+        """Test ShowConversationTool.create() without conv_store."""
+        with pytest.raises(ValueError, match="conv_store is required"):
+            ShowConversationTool.create()
+
+    def test_search_conversations_tool_create(self):
+        """Test SearchConversationsTool.create()."""
+        mock_embed_store = MagicMock()
+        mock_conv_store = MagicMock()
+        tools = SearchConversationsTool.create(
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+        )
+        assert len(tools) == 1
+        assert tools[0].name == "search_conversations"
+
+    def test_get_refs_tool_create(self):
+        """Test GetRefsTool.create()."""
+        mock_link_store = MagicMock()
+        mock_ref_store = MagicMock()
+        mock_repo_store = MagicMock()
+        tools = GetRefsTool.create(
+            link_store=mock_link_store,
+            ref_store=mock_ref_store,
+            repo_store=mock_repo_store,
+        )
+        assert len(tools) == 1
+        assert tools[0].name == "get_refs"
+
+    def test_get_refs_tool_missing_stores(self):
+        """Test GetRefsTool.create() without required stores."""
+        with pytest.raises(ValueError, match="link_store is required"):
+            GetRefsTool.create()

--- a/tests/unit/analysis/test_investigator.py
+++ b/tests/unit/analysis/test_investigator.py
@@ -207,3 +207,111 @@ class TestInvestigationAgentCreateTools:
         assert "show_conversation" in tool_names
         assert "search_conversations" in tool_names
         assert "get_refs" in tool_names
+
+
+class TestInvestigationAgentInvestigate:
+    """Integration tests for InvestigationAgent.investigate() method."""
+
+    @patch.dict('os.environ', {'LLM_API_KEY': 'test-key'})
+    @patch('ohtv.analysis.investigator.LLM')
+    def test_investigate_basic_flow_finishes_immediately(self, mock_llm_class):
+        """Test that investigate() completes successfully when LLM calls finish immediately."""
+        from ohtv.analysis.investigator import InvestigationAgent
+        
+        # Set up mock stores
+        mock_embed_store = MagicMock()
+        mock_conv_store = MagicMock()
+        
+        # Create mock LLM response with finish tool call
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "finish"
+        mock_tool_call.function.arguments = '{"message": "The auth bug was fixed by updating token validation."}'
+        mock_tool_call.id = "call_123"
+        
+        mock_response = MagicMock()
+        mock_response.message.tool_calls = [mock_tool_call]
+        mock_response.message.content = None
+        mock_response.metrics = MagicMock()
+        mock_response.metrics.accumulated_token_usage = MagicMock()
+        mock_response.metrics.accumulated_token_usage.prompt_tokens = 100
+        mock_response.metrics.accumulated_token_usage.completion_tokens = 50
+        mock_response.metrics.accumulated_cost = 0.002
+        
+        # Configure mock LLM instance
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.completion.return_value = mock_response
+        mock_llm_class.return_value = mock_llm_instance
+        
+        # Create mock RAG answer
+        mock_rag_answer = MagicMock()
+        mock_rag_answer.answer = "Initial answer about auth bug"
+        mock_rag_answer.source_conversation_ids = set()
+        mock_rag_answer.context_chunks = []
+        
+        # Create agent and run investigation
+        agent = InvestigationAgent(
+            model="gpt-4o-mini",
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+        )
+        
+        result = agent.investigate(
+            question="How did we fix the auth bug?",
+            initial_answer=mock_rag_answer,
+        )
+        
+        # Verify result
+        assert result.finished_normally is True
+        assert result.total_iterations == 1  # finish tool call counts as 1 step
+        assert "token validation" in result.final_answer
+        assert result.total_tokens == 150  # 100 + 50
+        assert result.total_cost == 0.002
+        assert result.error is None
+        assert result.initial_answer == "Initial answer about auth bug"
+        
+        # Verify LLM was called
+        mock_llm_instance.completion.assert_called_once()
+
+    @patch.dict('os.environ', {'LLM_API_KEY': 'test-key'})
+    @patch('ohtv.analysis.investigator.LLM')
+    def test_investigate_handles_loop_error_gracefully(self, mock_llm_class):
+        """Test that investigate() handles LLM errors within the loop gracefully.
+        
+        Errors within the investigation loop are logged and break the loop,
+        but don't bubble up to the outer try/except.
+        """
+        from ohtv.analysis.investigator import InvestigationAgent
+        
+        # Set up mock stores
+        mock_embed_store = MagicMock()
+        mock_conv_store = MagicMock()
+        
+        # Configure mock LLM to raise an exception
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.completion.side_effect = RuntimeError("LLM API error")
+        mock_llm_class.return_value = mock_llm_instance
+        
+        # Create mock RAG answer
+        mock_rag_answer = MagicMock()
+        mock_rag_answer.answer = "Initial answer about auth bug"
+        mock_rag_answer.source_conversation_ids = set()
+        mock_rag_answer.context_chunks = []
+        
+        # Create agent and run investigation
+        agent = InvestigationAgent(
+            model="gpt-4o-mini",
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+        )
+        
+        result = agent.investigate(
+            question="How did we fix the auth bug?",
+            initial_answer=mock_rag_answer,
+        )
+        
+        # Verify the investigation didn't finish normally
+        assert result.finished_normally is False
+        # Error is logged in investigation_steps, not in error field
+        assert any("Error: LLM API error" in step for step in result.investigation_steps)
+        # Investigation returned the fallback message (not a real answer)
+        assert "iteration limit" in result.final_answer.lower() or "partial findings" in result.final_answer.lower()

--- a/tests/unit/analysis/test_investigator.py
+++ b/tests/unit/analysis/test_investigator.py
@@ -1,0 +1,209 @@
+"""Tests for the investigator module."""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ohtv.analysis.investigator import (
+    InvestigationResult,
+    format_initial_context,
+    get_investigation_system_prompt,
+)
+
+
+class TestInvestigationResult:
+    """Tests for InvestigationResult dataclass."""
+
+    def test_create_result(self):
+        """Test creating an InvestigationResult."""
+        result = InvestigationResult(
+            final_answer="The bug was fixed by updating the auth module.",
+            initial_answer="There was a bug in auth.",
+            investigation_steps=["Called show_conversation: abc123"],
+            conversations_examined={"abc123", "def456"},
+            total_iterations=2,
+            total_cost=0.0123,
+            total_tokens=1500,
+            model="gpt-4o-mini",
+            elapsed_seconds=5.5,
+            finished_normally=True,
+            error=None,
+        )
+        assert "bug was fixed" in result.final_answer
+        assert result.total_iterations == 2
+        assert len(result.conversations_examined) == 2
+        assert result.finished_normally is True
+
+    def test_result_with_error(self):
+        """Test result with error."""
+        result = InvestigationResult(
+            final_answer="",
+            initial_answer="Initial answer",
+            investigation_steps=[],
+            conversations_examined=set(),
+            total_iterations=0,
+            total_cost=0.0,
+            total_tokens=0,
+            model="gpt-4o-mini",
+            elapsed_seconds=0.5,
+            finished_normally=False,
+            error="LLM API call failed",
+        )
+        assert result.error is not None
+        assert result.finished_normally is False
+
+
+class TestGetInvestigationSystemPrompt:
+    """Tests for get_investigation_system_prompt."""
+
+    def test_prompt_content(self):
+        """Test that system prompt contains expected content."""
+        prompt = get_investigation_system_prompt()
+        
+        # Should mention the available tools
+        assert "show_conversation" in prompt
+        assert "search_conversations" in prompt
+        assert "get_refs" in prompt
+        
+        # Should mention the finish tool
+        assert "finish" in prompt
+        
+        # Should have guidelines
+        assert "Guidelines" in prompt
+
+
+class TestFormatInitialContext:
+    """Tests for format_initial_context."""
+
+    def test_basic_formatting(self):
+        """Test basic context formatting."""
+        # Create mock RAG answer
+        mock_answer = MagicMock()
+        mock_answer.answer = "The auth bug was fixed."
+        mock_answer.source_conversation_ids = {"abc123"}
+        mock_answer.context_chunks = []
+        
+        context = format_initial_context(
+            question="How did we fix the auth bug?",
+            rag_answer=mock_answer,
+        )
+        
+        assert "How did we fix the auth bug?" in context
+        assert "The auth bug was fixed" in context
+        assert "Question" in context
+        assert "Initial Answer" in context
+
+    def test_formatting_with_sources(self):
+        """Test formatting with source chunks."""
+        # Create mock source
+        mock_source = MagicMock()
+        mock_source.title = "Fix auth bug"
+        mock_source.summary = "Fixed the authentication issue"
+        mock_source.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        mock_source.prs = [MagicMock(fqn="owner/repo#42")]
+        mock_source.repos = [MagicMock(fqn="owner/repo")]
+        
+        mock_chunk = MagicMock()
+        mock_chunk.conversation_id = "abc123def456"
+        mock_chunk.source = mock_source
+        
+        mock_answer = MagicMock()
+        mock_answer.answer = "The bug was fixed."
+        mock_answer.source_conversation_ids = {"abc123def456"}
+        mock_answer.context_chunks = [mock_chunk]
+        
+        context = format_initial_context(
+            question="Test question",
+            rag_answer=mock_answer,
+        )
+        
+        assert "abc123de" in context  # First 8 chars
+        assert "Fix auth bug" in context
+        assert "owner/repo#42" in context
+
+
+class TestInvestigationAgentInit:
+    """Tests for InvestigationAgent initialization."""
+
+    def test_missing_api_key(self):
+        """Test that missing API key raises error."""
+        from ohtv.analysis.investigator import InvestigationAgent
+        
+        mock_embed_store = MagicMock()
+        mock_conv_store = MagicMock()
+        
+        # Ensure LLM_API_KEY is not set
+        with patch.dict('os.environ', {'LLM_API_KEY': ''}, clear=False):
+            # Remove the key if it exists
+            import os
+            old_key = os.environ.pop('LLM_API_KEY', None)
+            try:
+                with pytest.raises(RuntimeError, match="LLM_API_KEY"):
+                    InvestigationAgent(
+                        model="gpt-4o-mini",
+                        embed_store=mock_embed_store,
+                        conv_store=mock_conv_store,
+                    )
+            finally:
+                if old_key:
+                    os.environ['LLM_API_KEY'] = old_key
+
+
+class TestInvestigationAgentCreateTools:
+    """Tests for InvestigationAgent tool creation."""
+
+    @patch.dict('os.environ', {'LLM_API_KEY': 'test-key'})
+    def test_create_tools_without_ref_stores(self):
+        """Test creating tools without ref stores."""
+        from ohtv.analysis.investigator import InvestigationAgent
+        
+        mock_embed_store = MagicMock()
+        mock_conv_store = MagicMock()
+        
+        agent = InvestigationAgent(
+            model="gpt-4o-mini",
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+            link_store=None,
+            ref_store=None,
+            repo_store=None,
+        )
+        
+        tools = agent._create_tools()
+        
+        # Should have show_conversation and search_conversations
+        tool_names = [t.name for t in tools]
+        assert "show_conversation" in tool_names
+        assert "search_conversations" in tool_names
+        # get_refs should NOT be included without ref stores
+        assert "get_refs" not in tool_names
+
+    @patch.dict('os.environ', {'LLM_API_KEY': 'test-key'})
+    def test_create_tools_with_ref_stores(self):
+        """Test creating tools with ref stores."""
+        from ohtv.analysis.investigator import InvestigationAgent
+        
+        mock_embed_store = MagicMock()
+        mock_conv_store = MagicMock()
+        mock_link_store = MagicMock()
+        mock_ref_store = MagicMock()
+        mock_repo_store = MagicMock()
+        
+        agent = InvestigationAgent(
+            model="gpt-4o-mini",
+            embed_store=mock_embed_store,
+            conv_store=mock_conv_store,
+            link_store=mock_link_store,
+            ref_store=mock_ref_store,
+            repo_store=mock_repo_store,
+        )
+        
+        tools = agent._create_tools()
+        
+        # Should have all tools including get_refs
+        tool_names = [t.name for t in tools]
+        assert "show_conversation" in tool_names
+        assert "search_conversations" in tool_names
+        assert "get_refs" in tool_names


### PR DESCRIPTION
## Summary

Adds multi-turn investigation mode to `ohtv ask` command that uses an OpenHands SDK agent to perform deeper investigation of questions about conversation history.

Fixes #51

## Changes

### New CLI Options
- `--agent` flag enables investigation mode
- `--max-steps` controls maximum investigation iterations (default: 5)

### New Features
- Agent can examine specific conversations via `show_conversation` tool
- Agent can search for additional context via `search_conversations` tool  
- Agent can get git refs (PRs, issues, repos) via `get_refs` tool
- Progress shown during investigation with step counter
- Cost and token tracking includes investigation overhead
- Graceful fallback to initial RAG answer on errors

### New Modules
- `src/ohtv/analysis/agent_tools.py` - Custom tools for investigation agent (ShowConversation, SearchConversations, GetRefs)
- `src/ohtv/analysis/investigator.py` - InvestigationAgent class with direct LLM calls
- `src/ohtv/prompts/investigation/system.md` - Agent system prompt

## Usage

```bash
# Basic investigation mode
ohtv ask "explain the auth fix in detail" --agent

# With more investigation steps
ohtv ask "what PRs were created?" --agent --max-steps 10

# Combine with other options
ohtv ask "summarize this week's work" --agent --since 7d
```

## Testing

- 30 new unit tests covering:
  - ShowConversationTool (action, observation, executor, tool creation)
  - SearchConversationsTool (action, observation, executor, tool creation)
  - GetRefsTool (action, observation, executor, tool creation)
  - InvestigationResult dataclass
  - InvestigationAgent initialization, tool creation, and investigate() flow
  - Context formatting functions

All 1038 tests pass.

## Review Decisions

During code review, several issues were addressed:

1. **Dead code removed**: Removed unused `Agent`/`LocalConversation` imports and block that was leftover from initial exploration
2. **Bug fixed**: Fixed `AttributeError: 'dict' object has no attribute 'to_openai_tool'` - now passes `ToolDefinition` objects directly to `llm.completion()` instead of pre-converted dicts
3. **Observation formatting**: Added `to_text()` method to all observation classes for uniform result formatting
4. **Code structure**: Split 175-line `_run_investigation_loop` into focused helpers: `_build_tool_map()`, `_process_tool_call()`, `_add_tool_response()`
5. **Reduced nesting**: Refactored to reduce if/else nesting and remove unnecessary hasattr checks

## Technical Notes

The implementation uses direct LLM calls with tool definitions rather than the full Agent/LocalConversation infrastructure from the SDK. This approach:
- Provides better control over the investigation loop
- Avoids the complexity of setting up a full workspace for read-only operations
- Allows graceful handling of tool errors without crashing the investigation

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._
