### PR TITLE
Fix PR #56: Update prompt display schemas to 4-column layout

### DIFF
--- a/src/ohtv/prompts/objs/brief.md
+++ b/src/ohtv/prompts/objs/brief.md
@@ -44,11 +44,26 @@ display:
   table:
     columns:
       - name: ID
-        field: short_id
-        width: 7
+        fields:
+          - short_id
+          - source
+        combine: newline
+        width: 9
       - name: Date
-        field: created_at
-        format: date
+        fields:
+          - field: created_at
+            format: date
+          - field: created_at
+            format: time
+        combine: newline
+        width: 12
+      - name: Duration
+        fields:
+          - field: duration
+            format: duration_minutes
+          - field: event_count
+            format: step_count
+        combine: newline
         width: 10
       - name: Summary
         fields:

--- a/src/ohtv/prompts/objs/standard_assess.md
+++ b/src/ohtv/prompts/objs/standard_assess.md
@@ -52,11 +52,26 @@ display:
   table:
     columns:
       - name: ID
-        field: short_id
-        width: 7
+        fields:
+          - short_id
+          - source
+        combine: newline
+        width: 9
       - name: Date
-        field: created_at
-        format: date
+        fields:
+          - field: created_at
+            format: date
+          - field: created_at
+            format: time
+        combine: newline
+        width: 12
+      - name: Duration
+        fields:
+          - field: duration
+            format: duration_minutes
+          - field: event_count
+            format: step_count
+        combine: newline
         width: 10
       - name: Status
         field: status


### PR DESCRIPTION
## Problem

PR #56 added the 4-column display logic to `renderer.py` and `formatters.py` but did not update the prompt files with the new display schema.

This caused `gen objs` batch mode to show only 3 columns (ID, Date, Summary) instead of the expected 4 columns (ID+source, Date+time, Duration+steps, Summary).

## Solution

Updated display schemas in prompt files to match the 4-column layout:

### Changes to `brief.md` and `standard_assess.md`:
- **ID column** (width 9): `short_id` + `source` with newline combine
- **Date column** (width 12): `created_at` formatted as date + time with newline combine
- **Duration column** (width 10): `duration` with `duration_minutes` formatter + `event_count` with `step_count` formatter
- **Summary column**: No changes

## Review Decisions

- Code review assessed as 🟢 LOW risk - changes only affect presentation formatting, not data processing
- All formatters (`duration_minutes`, `step_count`, `time`) were already implemented and tested in PR #56

## Test Coverage

**Manual Tests (6/6 pass):**
1. ✅ Parse `brief.md` schema - 4 columns with correct widths
2. ✅ Parse `standard_assess.md` schema - 5 columns (includes Status)
3. ✅ `gen objs -W -n 3` batch mode - 4-column headers display
4. ✅ `gen objs -v standard_assess` - multi-line cells render correctly
5. ✅ Single conversation analysis - goal extraction works
6. ✅ Unit tests - 1038 tests pass

**Verified behavior:**
- Multi-line cell rendering works (ID/source, Date/time, Duration/steps)
- Duration formatters render properly (`5 mins` / `95 steps`)
- No regressions in existing columns

---
*This PR was created by an AI agent (OpenHands) on behalf of jpshackelford.*