### PR TITLE
feat: add numeric lookback for -D and -W options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,23 @@ ohtv list --day
 # Show conversations from a specific day
 ohtv list --day 2024-03-15
 
+# Show last 3 days of conversations
+ohtv list -D 3
+
+# Show last 7 days of conversations
+ohtv list -D 7
+
 # Show this week's conversations (weeks start Sunday)
 ohtv list --week
 
 # Show conversations from a specific week
 ohtv list --week 2024-03-15
+
+# Show last 2 weeks of conversations
+ohtv list -W 2
+
+# Show last 4 weeks of conversations
+ohtv list -W 4
 
 # Filter by PR (requires indexed database)
 ohtv list --pr OpenPaw#17           # Short name
@@ -136,8 +148,8 @@ ohtv list --no-refs               # Refs shown by default
 | `-o, --output FILE` | Write output to file |
 | `-S, --since DATE` | Show conversations from DATE onwards |
 | `-U, --until DATE` | Show conversations up to DATE |
-| `-D, --day [DATE]` | Show conversations from a single day (default: today) |
-| `-W, --week [DATE]` | Show conversations from the week containing DATE (default: today, weeks start Sunday) |
+| `-D, --day [VALUE]` | Filter by day: `-D` (today), `-D DATE` (specific date), or `-D N` (last N days) |
+| `-W, --week [VALUE]` | Filter by week: `-W` (this week), `-W DATE` (week of date), or `-W N` (last N weeks) |
 | `--pr PATTERN` | Filter by PR reference (URL, `owner/repo#N`, or `repo#N`) |
 | `--repo PATTERN` | Filter by repository (URL, `owner/repo`, or name) |
 | `--action TYPE` | Filter by action type (e.g., `pushed`, `open-pr`, `git-commit`) |
@@ -308,8 +320,8 @@ ohtv refs -D --format json
 | `-k, --offset N` | Skip first N conversations |
 | `-S, --since DATE` | Process conversations from DATE onwards |
 | `-U, --until DATE` | Process conversations up to DATE |
-| `-D, --day [DATE]` | Process conversations from a single day (default: today) |
-| `-W, --week [DATE]` | Process conversations from the week containing DATE |
+| `-D, --day [VALUE]` | Filter by day: `-D` (today), `-D DATE` (specific date), or `-D N` (last N days) |
+| `-W, --week [VALUE]` | Filter by week: `-W` (this week), `-W DATE` (week of date), or `-W N` (last N weeks) |
 | `--pr PATTERN` | Filter by PR reference |
 | `--repo PATTERN` | Filter by repository |
 | `--action TYPE` | Filter by action type |
@@ -432,8 +444,14 @@ ohtv gen objs
 # Analyze today's conversations
 ohtv gen objs --day
 
+# Analyze last 7 days of conversations
+ohtv gen objs -D 7
+
 # Analyze this week's conversations
 ohtv gen objs --week
+
+# Analyze last 4 weeks of conversations
+ohtv gen objs -W 4
 
 # Analyze with date range
 ohtv gen objs --since 2024-01-01 --until 2024-01-31
@@ -587,8 +605,8 @@ Showing 2 of 150 (2/2 cached)
 | `-k, --offset N` | Skip first N conversations |
 | `-S, --since DATE` | Analyze conversations from DATE onwards |
 | `-U, --until DATE` | Analyze conversations up to DATE |
-| `-D, --day [DATE]` | Analyze conversations from a single day (default: today) |
-| `-W, --week [DATE]` | Analyze conversations from the week containing DATE |
+| `-D, --day [VALUE]` | Filter by day: `-D` (today), `-D DATE` (specific date), or `-D N` (last N days) |
+| `-W, --week [VALUE]` | Filter by week: `-W` (this week), `-W DATE` (week of date), or `-W N` (last N weeks) |
 | `--pr PATTERN` | Filter by PR reference (URL, `owner/repo#N`, or `repo#N`) |
 | `--repo PATTERN` | Filter by repository (URL, `owner/repo`, or name) |
 | `--action TYPE` | Filter by action type (e.g., `pushed`, `open-pr`) |

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1570,6 +1570,48 @@ def _parse_date_option(value: str | None) -> datetime | None:
         raise click.BadParameter(f"Invalid date format: {value}")
 
 
+def _parse_numeric_lookback(value: str | None) -> int | None:
+    """Return integer if value is purely numeric and positive, None otherwise."""
+    if value is None:
+        return None
+    try:
+        n = int(value)
+        return n if n > 0 else None
+    except ValueError:
+        return None
+
+
+def _get_day_lookback_bounds(n: int) -> tuple[datetime, datetime]:
+    """Get bounds for last N days (including today).
+    
+    Args:
+        n: Number of days to look back (1 = today only)
+    
+    Returns:
+        Tuple of (start, end) datetime objects
+    """
+    now = datetime.now()
+    end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
+    start = (now - timedelta(days=n - 1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return start, end
+
+
+def _get_week_lookback_bounds(n: int) -> tuple[datetime, datetime]:
+    """Get bounds for last N weeks (including current week).
+    
+    Args:
+        n: Number of weeks to look back (1 = current week only)
+    
+    Returns:
+        Tuple of (start, end) datetime objects
+    """
+    now = datetime.now()
+    end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
+    # Go back n-1 weeks to get start of week n weeks ago
+    week_start, _ = _get_week_bounds(now - timedelta(weeks=n - 1))
+    return week_start, end
+
+
 def _get_week_bounds(date: datetime) -> tuple[datetime, datetime]:
     """Get the start (Sunday) and end (Saturday) of the week containing the date."""
     # weekday() returns 0=Monday, 6=Sunday
@@ -1653,27 +1695,45 @@ def _parse_date_filters(
 ) -> tuple[datetime | None, datetime | None]:
     """Parse date filter options and apply shortcuts.
     
+    Supports numeric lookback for --day and --week:
+        -D 3  -> last 3 days (today + 2 days back)
+        -W 2  -> last 2 weeks (this week + last week)
+    
     Returns:
         Tuple of (since, until) datetime objects
     """
     since = _parse_date_option(since_date)
     until = _parse_date_option(until_date)
     
-    # Handle --day shortcut
+    # Handle --day shortcut: check for numeric lookback first
     if day_date is not None:
-        day = _parse_date_option(day_date)
-        if day:
-            day_start, day_end = _get_day_bounds(day)
+        n = _parse_numeric_lookback(day_date)
+        if n is not None:
+            day_start, day_end = _get_day_lookback_bounds(n)
             since = since or day_start
             until = until or day_end
+        else:
+            # Existing behavior: parse as date
+            day = _parse_date_option(day_date)
+            if day:
+                day_start, day_end = _get_day_bounds(day)
+                since = since or day_start
+                until = until or day_end
     
-    # Handle --week shortcut
+    # Handle --week shortcut: check for numeric lookback first
     if week_date is not None:
-        week = _parse_date_option(week_date)
-        if week:
-            week_start, week_end = _get_week_bounds(week)
+        n = _parse_numeric_lookback(week_date)
+        if n is not None:
+            week_start, week_end = _get_week_lookback_bounds(n)
             since = since or week_start
             until = until or week_end
+        else:
+            # Existing behavior: parse as date
+            week = _parse_date_option(week_date)
+            if week:
+                week_start, week_end = _get_week_bounds(week)
+                since = since or week_start
+                until = until or week_end
     
     return since, until
 
@@ -2056,9 +2116,9 @@ def _populate_error_info(
 @click.option("--since", "-S", "since_date", help="Show conversations from DATE onwards")
 @click.option("--until", "-U", "until_date", help="Show conversations up to DATE")
 @click.option("--day", "-D", "day_date", is_flag=False, flag_value="today", default=None,
-              help="Show conversations from a single day (default: today)")
+              help="Filter by day: -D (today), -D DATE (specific date), or -D N (last N days)")
 @click.option("--week", "-W", "week_date", is_flag=False, flag_value="today", default=None,
-              help="Show conversations from the week containing DATE (default: today, weeks start Sunday)")
+              help="Filter by week: -W (this week), -W DATE (week of date), or -W N (last N weeks)")
 @click.option("--pr", "pr_filter", help="Filter by PR (URL, owner/repo#N, or repo#N)")
 @click.option("--repo", "repo_filter", help="Filter by repo (URL, owner/repo, or repo name)")
 @click.option("--action", "action_filter", help="Filter by action type (e.g., git-push, pushed, open-pr)")
@@ -4137,9 +4197,9 @@ def _print_error_detail(err) -> None:
 @click.option("--since", "-S", "since_date", help="Process conversations from DATE onwards")
 @click.option("--until", "-U", "until_date", help="Process conversations up to DATE")
 @click.option("--day", "-D", "day_date", is_flag=False, flag_value="today", default=None,
-              help="Process conversations from a single day (default: today)")
+              help="Filter by day: -D (today), -D DATE (specific date), or -D N (last N days)")
 @click.option("--week", "-W", "week_date", is_flag=False, flag_value="today", default=None,
-              help="Process conversations from the week containing DATE (default: today)")
+              help="Filter by week: -W (this week), -W DATE (week of date), or -W N (last N weeks)")
 @click.option("--pr", "pr_filter", help="Filter by PR (URL, owner/repo#N, or repo#N)")
 @click.option("--repo", "repo_filter", help="Filter by repo (URL, owner/repo, or repo name)")
 @click.option("--action", "action_filter", help="Filter by action type (e.g., git-push, pushed, open-pr)")
@@ -7258,9 +7318,9 @@ def gen() -> None:
 @click.option("--since", "-S", "since_date", help="Analyze conversations from DATE onwards")
 @click.option("--until", "-U", "until_date", help="Analyze conversations up to DATE")
 @click.option("--day", "-D", "day_date", is_flag=False, flag_value="today", default=None,
-              help="Analyze conversations from a single day (default: today)")
+              help="Filter by day: -D (today), -D DATE (specific date), or -D N (last N days)")
 @click.option("--week", "-W", "week_date", is_flag=False, flag_value="today", default=None,
-              help="Analyze conversations from the week containing DATE (default: today)")
+              help="Filter by week: -W (this week), -W DATE (week of date), or -W N (last N weeks)")
 @click.option("--pr", "pr_filter", help="Filter by PR (URL, owner/repo#N, or repo#N)")
 @click.option("--repo", "repo_filter", help="Filter by repo (URL, owner/repo, or repo name)")
 @click.option("--action", "action_filter", help="Filter by action type (e.g., git-push, pushed, open-pr)")
@@ -8005,9 +8065,9 @@ def _run_objectives_analysis(
 @click.option("--since", "-S", "since_date", help="Start date (YYYY-MM-DD)")
 @click.option("--until", "-U", "until_date", help="End date (YYYY-MM-DD)")
 @click.option("--day", "-D", "day_date", is_flag=False, flag_value="today", default=None,
-              help="Single day (default: today)")
+              help="Filter by day: -D (today), -D DATE (specific date), or -D N (last N days)")
 @click.option("--week", "-W", "week_date", is_flag=False, flag_value="today", default=None,
-              help="Week containing DATE (default: this week)")
+              help="Filter by week: -W (this week), -W DATE (week of date), or -W N (last N weeks)")
 # Period iteration options (for aggregate jobs)
 @click.option("--per", "period_override", type=click.Choice(["week", "day", "month"]),
               help="Override/specify iteration granularity for aggregate jobs")

--- a/tests/unit/test_numeric_lookback.py
+++ b/tests/unit/test_numeric_lookback.py
@@ -1,0 +1,307 @@
+"""Tests for numeric lookback parsing in -D and -W options."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from ohtv.cli import (
+    _get_day_lookback_bounds,
+    _get_week_bounds,
+    _get_week_lookback_bounds,
+    _parse_date_filters,
+    _parse_numeric_lookback,
+)
+
+
+class TestParseNumericLookback:
+    """Tests for _parse_numeric_lookback function."""
+    
+    def test_positive_integer(self):
+        """Positive integers return the integer."""
+        assert _parse_numeric_lookback("1") == 1
+        assert _parse_numeric_lookback("3") == 3
+        assert _parse_numeric_lookback("7") == 7
+        assert _parse_numeric_lookback("100") == 100
+    
+    def test_zero_returns_none(self):
+        """Zero is not a valid lookback period."""
+        assert _parse_numeric_lookback("0") is None
+    
+    def test_negative_returns_none(self):
+        """Negative numbers are not valid."""
+        assert _parse_numeric_lookback("-1") is None
+        assert _parse_numeric_lookback("-5") is None
+    
+    def test_none_returns_none(self):
+        """None input returns None."""
+        assert _parse_numeric_lookback(None) is None
+    
+    def test_non_numeric_returns_none(self):
+        """Non-numeric strings return None."""
+        assert _parse_numeric_lookback("today") is None
+        assert _parse_numeric_lookback("2026-05-15") is None
+        assert _parse_numeric_lookback("abc") is None
+        assert _parse_numeric_lookback("3d") is None  # This is for --since, not -D
+    
+    def test_leading_zeros_parsed(self):
+        """Leading zeros are parsed as numbers, not dates."""
+        assert _parse_numeric_lookback("07") == 7
+        assert _parse_numeric_lookback("03") == 3
+    
+    def test_float_returns_none(self):
+        """Floating point strings are not valid."""
+        assert _parse_numeric_lookback("3.5") is None
+        assert _parse_numeric_lookback("1.0") is None
+
+
+class TestGetDayLookbackBounds:
+    """Tests for _get_day_lookback_bounds function."""
+    
+    @patch("ohtv.cli.datetime")
+    def test_one_day_is_today(self, mock_dt):
+        """N=1 should return today only."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        start, end = _get_day_lookback_bounds(1)
+        
+        assert start.date() == mock_now.date()
+        assert start.hour == 0
+        assert start.minute == 0
+        assert start.second == 0
+        
+        assert end.date() == mock_now.date()
+        assert end.hour == 23
+        assert end.minute == 59
+        assert end.second == 59
+    
+    @patch("ohtv.cli.datetime")
+    def test_three_days(self, mock_dt):
+        """N=3 should return today and 2 days back."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        start, end = _get_day_lookback_bounds(3)
+        
+        # Start should be May 13 at midnight
+        expected_start = datetime(2026, 5, 13, 0, 0, 0, 0)
+        assert start == expected_start
+        
+        # End should be May 15 at 23:59:59
+        assert end.date() == mock_now.date()
+        assert end.hour == 23
+    
+    @patch("ohtv.cli.datetime")
+    def test_seven_days(self, mock_dt):
+        """N=7 should return a full week of days."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        start, end = _get_day_lookback_bounds(7)
+        
+        # Start should be May 9 at midnight (6 days back from May 15)
+        expected_start = datetime(2026, 5, 9, 0, 0, 0, 0)
+        assert start == expected_start
+        
+        # Check the range spans exactly 7 days
+        days_diff = (end.date() - start.date()).days
+        assert days_diff == 6  # 7 days = 6 full days between start and end
+
+
+class TestGetWeekLookbackBounds:
+    """Tests for _get_week_lookback_bounds function."""
+    
+    @patch("ohtv.cli.datetime")
+    def test_one_week_is_current_week(self, mock_dt):
+        """N=1 should return only the current week."""
+        # Thursday, May 15, 2026
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        start, end = _get_week_lookback_bounds(1)
+        
+        # Current week starts on Sunday, May 10, 2026
+        expected_week_start = datetime(2026, 5, 10, 0, 0, 0, 0)
+        assert start == expected_week_start
+        
+        # End should be today (May 15) at 23:59:59
+        assert end.date() == mock_now.date()
+        assert end.hour == 23
+    
+    @patch("ohtv.cli.datetime")
+    def test_two_weeks(self, mock_dt):
+        """N=2 should return this week and last week."""
+        # Thursday, May 15, 2026
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        start, end = _get_week_lookback_bounds(2)
+        
+        # Should start at Sunday, May 3, 2026 (one week back from current week)
+        expected_start = datetime(2026, 5, 3, 0, 0, 0, 0)
+        assert start == expected_start
+        
+        # End should still be today
+        assert end.date() == mock_now.date()
+    
+    @patch("ohtv.cli.datetime")
+    def test_four_weeks(self, mock_dt):
+        """N=4 should return the last 4 weeks."""
+        # Thursday, May 15, 2026
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        start, end = _get_week_lookback_bounds(4)
+        
+        # Should start at Sunday, April 19, 2026 (3 weeks back from current week start)
+        expected_start = datetime(2026, 4, 19, 0, 0, 0, 0)
+        assert start == expected_start
+
+
+class TestParseDateFiltersNumericLookback:
+    """Tests for _parse_date_filters with numeric lookback."""
+    
+    @patch("ohtv.cli.datetime")
+    def test_day_numeric_lookback(self, mock_dt):
+        """Numeric value for day should use lookback."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        since, until = _parse_date_filters(None, None, "3", None)
+        
+        # Should span 3 days: May 13-15
+        assert since.date() == datetime(2026, 5, 13).date()
+        assert until.date() == datetime(2026, 5, 15).date()
+    
+    @patch("ohtv.cli.datetime")
+    def test_week_numeric_lookback(self, mock_dt):
+        """Numeric value for week should use lookback."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        since, until = _parse_date_filters(None, None, None, "2")
+        
+        # Should span 2 weeks: May 3 - May 15
+        assert since.date() == datetime(2026, 5, 3).date()
+        assert until.date() == datetime(2026, 5, 15).date()
+    
+    @patch("ohtv.cli.datetime")
+    def test_day_one_same_as_today_flag(self, mock_dt):
+        """Day=1 should behave like -D (today)."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        since1, until1 = _parse_date_filters(None, None, "1", None)
+        since2, until2 = _parse_date_filters(None, None, "today", None)
+        
+        assert since1.date() == since2.date()
+        assert until1.date() == until2.date()
+    
+    @patch("ohtv.cli.datetime")
+    def test_week_one_same_as_week_flag(self, mock_dt):
+        """Week=1 should behave like -W (this week)."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        since1, until1 = _parse_date_filters(None, None, None, "1")
+        since2, until2 = _parse_date_filters(None, None, None, "today")
+        
+        # Both should start at the same week start
+        assert since1.date() == since2.date()
+    
+    def test_day_date_still_works(self):
+        """Specific date values should still parse correctly."""
+        since, until = _parse_date_filters(None, None, "2026-05-15", None)
+        
+        assert since.date() == datetime(2026, 5, 15).date()
+        assert until.date() == datetime(2026, 5, 15).date()
+    
+    def test_week_date_still_works(self):
+        """Week containing specific date should still work."""
+        since, until = _parse_date_filters(None, None, None, "2026-05-15")
+        
+        # May 15, 2026 is Thursday, week starts Sunday May 10
+        assert since.date() == datetime(2026, 5, 10).date()
+        # Week ends Saturday May 16
+        assert until.date() == datetime(2026, 5, 16).date()
+    
+    @patch("ohtv.cli.datetime")
+    def test_zero_ignored(self, mock_dt):
+        """Zero should be ignored (not a valid lookback)."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        # Zero is not a valid lookback - will be passed to _parse_date_option
+        # which will fail to parse it
+        import click
+        with pytest.raises(click.BadParameter):
+            _parse_date_filters(None, None, "0", None)
+    
+    @patch("ohtv.cli.datetime")
+    def test_negative_ignored(self, mock_dt):
+        """Negative numbers should be ignored (not a valid lookback)."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        # Negative is not a valid lookback - will be passed to _parse_date_option
+        import click
+        with pytest.raises(click.BadParameter):
+            _parse_date_filters(None, None, "-5", None)
+    
+    @patch("ohtv.cli.datetime")
+    def test_explicit_since_until_not_overridden(self, mock_dt):
+        """Explicit --since/--until should not be overridden by numeric lookback."""
+        mock_now = datetime(2026, 5, 15, 14, 30, 0)
+        mock_dt.now.return_value = mock_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        
+        # If since_date is provided, day lookback shouldn't override it
+        since, until = _parse_date_filters("2026-05-10", None, "3", None)
+        
+        # Since should be explicitly set date, not lookback
+        assert since.date() == datetime(2026, 5, 10).date()
+        # Until should be from lookback
+        assert until.date() == datetime(2026, 5, 15).date()
+
+
+class TestGetWeekBoundsHelper:
+    """Tests for _get_week_bounds helper (used by week lookback)."""
+    
+    def test_sunday_is_week_start(self):
+        """Sunday should be the start of its own week."""
+        sunday = datetime(2026, 5, 10, 12, 0, 0)  # Sunday
+        start, end = _get_week_bounds(sunday)
+        
+        assert start.date() == sunday.date()
+        assert start.hour == 0
+        assert start.minute == 0
+        assert end.date() == datetime(2026, 5, 16).date()  # Saturday
+    
+    def test_saturday_is_week_end(self):
+        """Saturday should be the end of its week."""
+        saturday = datetime(2026, 5, 16, 12, 0, 0)  # Saturday
+        start, end = _get_week_bounds(saturday)
+        
+        assert start.date() == datetime(2026, 5, 10).date()  # Sunday
+        assert end.date() == saturday.date()
+    
+    def test_midweek_day(self):
+        """Midweek day should be in correct week."""
+        thursday = datetime(2026, 5, 14, 12, 0, 0)  # Thursday
+        start, end = _get_week_bounds(thursday)
+        
+        assert start.date() == datetime(2026, 5, 10).date()  # Sunday
+        assert end.date() == datetime(2026, 5, 16).date()  # Saturday


### PR DESCRIPTION
## Summary

Implements numeric lookback for `-D` and `-W` options, allowing users to specify how many days or weeks to look back with a single command.

Fixes #57

## Changes

### New Functionality
- `-D 3` shows last 3 days of conversations (today + 2 days back)
- `-W 2` shows last 2 weeks of conversations (this week + last week)
- Works consistently across `list`, `refs`, `gen objs`, and `gen run` commands

### Implementation
- Added `_parse_numeric_lookback()` helper to detect positive integer values
- Added `_get_day_lookback_bounds()` for multi-day range calculation
- Added `_get_week_lookback_bounds()` for multi-week range calculation
- Modified `_parse_date_filters()` to check for numeric lookback before falling back to date parsing

### Updated Help Text
```
-D, --day TEXT   Filter by day: -D (today), -D DATE (specific date), or -D N (last N days)
-W, --week TEXT  Filter by week: -W (this week), -W DATE (week of date), or -W N (last N weeks)
```

## Edge Cases Handled
| Input | Result |
|-------|--------|
| `-D 1` | Same as `-D` (today only) |
| `-W 1` | Same as `-W` (current week only) |
| `-D 0` | Rejected (falls through to date parser, produces error) |
| `-D -5` | Rejected (CLI interprets as option flag, produces error) |
| `-D 07` | Parsed as number 7 (leading zeros handled correctly) |

## Test Coverage

- **25 new unit tests** for numeric parsing:
  - `TestParseNumericLookback` (8 tests): positive/zero/negative/leading zeros
  - `TestGetDayLookbackBounds` (3 tests): 1/3/7 day lookback
  - `TestGetWeekLookbackBounds` (3 tests): 1/2/4 week lookback
  - `TestParseDateFiltersNumericLookback` (9 tests): integration with date filters
  - `TestGetWeekBoundsHelper` (3 tests): Sunday/Saturday/midweek edge cases
- **All 1090 tests pass** with no regressions
- **14 manual test cases verified** (see comments for detailed results)

## Key Decisions

1. **Check-then-fallback pattern**: Numeric lookback is checked first, then falls through to existing date parsing. This preserves backward compatibility with date strings.
2. **Inclusive counting**: `-D 3` means "today + 2 days back" (3 total days), matching user mental model of "last N days"
3. **Zero/negative rejection**: Invalid values fall through to date parser which rejects them with clear error messages
4. **Leading zeros handled**: `07` parses as integer 7, not ambiguous date component

## Documentation

- README updated with numeric lookback examples in `list` and `gen objs` sections
- Options tables updated to show new three-mode usage pattern