### PR TITLE
fix(investigator): update tool_call attribute access for SDK v1.21

### DIFF
--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -343,8 +343,8 @@ class InvestigationAgent:
         """
         import json
 
-        tool_name = tool_call.function.name
-        arguments = tool_call.function.arguments
+        tool_name = tool_call.name
+        arguments = tool_call.arguments
 
         # Parse arguments (might be string or dict)
         if isinstance(arguments, str):
@@ -482,8 +482,8 @@ class InvestigationAgent:
 
                 # Process each tool call
                 for tool_call in tool_calls:
-                    tool_name = tool_call.function.name
-                    investigation_steps.append(f"Called {tool_name}: {tool_call.function.arguments}")
+                    tool_name = tool_call.name
+                    investigation_steps.append(f"Called {tool_name}: {tool_call.arguments}")
 
                     result_text, answer, is_finished = self._process_tool_call(
                         tool_call, tool_map, conversations_examined


### PR DESCRIPTION
## Summary

The `ohtv ask --agent` command was failing with:

```
AttributeError: 'MessageToolCall' object has no attribute 'function'
```

## Root Cause

The OpenHands SDK v1.21 changed the structure of `MessageToolCall`. The class now has `name` and `arguments` as direct attributes instead of nesting them under a `function` object (which matched the raw OpenAI API format).

## Changes

Updated `src/ohtv/analysis/investigator.py`:
- `tool_call.function.name` → `tool_call.name`
- `tool_call.function.arguments` → `tool_call.arguments`

Fixed in 2 locations (lines 346-347 and 485-486).

## Testing

After the fix, `ohtv ask --agent` commands work correctly with the investigation agent.

---
*This PR was created by an AI agent (OpenHands) on behalf of jpshackelford.*