### PR TITLE
fix: add context_level to skip cache for proper retry at higher levels

### DIFF
--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -555,14 +555,23 @@ class AnalysisCacheManager:
             # - OSError: I/O errors (database access issues)
             log.debug("Failed to update analysis embedding (non-fatal): %s", e)
 
-    def is_skipped(self, conv_dir: Path, event_count: int) -> str | None:
+    def is_skipped(
+        self,
+        conv_dir: Path,
+        event_count: int,
+        context_level: str = "minimal",
+    ) -> str | None:
         """Check if conversation is marked as skipped.
 
         Checks the new location first, then falls back to legacy location.
+        
+        Context-aware: A skip at 'minimal' allows retry at 'full' because
+        full context includes more content that might make analysis possible.
 
         Args:
             conv_dir: Conversation directory
             event_count: Current event count (for invalidation check)
+            context_level: Requested context level (minimal, default, full)
 
         Returns:
             Skip reason if skipped and still valid, None otherwise.
@@ -585,32 +594,87 @@ class AnalysisCacheManager:
             )
             return None
 
+        # Check if requested context level exceeds cached skip context level
+        cached_context = skipped.get("context_level", "minimal")
+        context_levels = ["minimal", "default", "full"]
+        try:
+            cached_idx = context_levels.index(cached_context)
+            requested_idx = context_levels.index(context_level)
+            if requested_idx > cached_idx:
+                log.debug(
+                    "Skip marker invalidated: higher context level requested (%s > %s)",
+                    context_level,
+                    cached_context,
+                )
+                return None
+        except ValueError:
+            # Unknown context level, treat cached as valid
+            pass
+
         return skipped.get("reason")
 
-    def mark_skipped(self, conv_dir: Path, event_count: int, reason: str) -> None:
+    def mark_skipped(
+        self,
+        conv_dir: Path,
+        event_count: int,
+        reason: str,
+        context_level: str = "minimal",
+    ) -> None:
         """Mark a conversation as skipped (cannot be analyzed).
 
         Args:
             conv_dir: Conversation directory
             event_count: Current event count
             reason: Why the conversation was skipped
+            context_level: The context level at which skip occurred
         """
         cache_file = self.get_cache_file(conv_dir)
         cache_data = self._load_cache_data(cache_file) or {"analyses": {}}
+
+        # Check if existing skip is at a higher context level
+        # If so, don't overwrite (higher context encompasses lower)
+        existing_skip = cache_data.get("skipped")
+        if existing_skip:
+            existing_context = existing_skip.get("context_level", "minimal")
+            context_levels = ["minimal", "default", "full"]
+            try:
+                existing_idx = context_levels.index(existing_context)
+                new_idx = context_levels.index(context_level)
+                if existing_idx > new_idx:
+                    log.debug(
+                        "Not overwriting skip: existing at %s > new at %s",
+                        existing_context,
+                        context_level,
+                    )
+                    return
+            except ValueError:
+                pass
 
         cache_data["event_count"] = event_count
         cache_data["skipped"] = {
             "reason": reason,
             "at": datetime.now(timezone.utc).isoformat(),
+            "context_level": context_level,
         }
 
         self._save_cache_data(cache_file, cache_data)
-        log.debug("Conversation marked as skipped: %s (reason: %s)", conv_dir.name, reason)
+        log.debug(
+            "Conversation marked as skipped: %s (reason: %s, context: %s)",
+            conv_dir.name,
+            reason,
+            context_level,
+        )
         
         # Sync to database if available
-        self._sync_skip_to_db(conv_dir.name, event_count, reason)
+        self._sync_skip_to_db(conv_dir.name, event_count, reason, context_level)
 
-    def _sync_skip_to_db(self, conversation_id: str, event_count: int, reason: str) -> None:
+    def _sync_skip_to_db(
+        self,
+        conversation_id: str,
+        event_count: int,
+        reason: str,
+        context_level: str = "minimal",
+    ) -> None:
         """Sync skip entry to database for fast lookup.
         
         This is optional - if database is not available, we just skip.
@@ -629,10 +693,16 @@ class AnalysisCacheManager:
                     event_count=event_count,
                     reason=reason,
                     skipped_at=datetime.now(timezone.utc),
+                    context_level=context_level,
                 )
                 store.upsert_skip(entry)
                 conn.commit()
-                log.debug("Synced skip to DB: %s (reason: %s)", conversation_id, reason)
+                log.debug(
+                    "Synced skip to DB: %s (reason: %s, context: %s)",
+                    conversation_id,
+                    reason,
+                    context_level,
+                )
         except Exception as e:
             # DB sync is optional, don't fail if it doesn't work
             log.debug("Failed to sync skip to DB (non-fatal): %s", e)

--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -31,6 +31,7 @@ from typing import Any, TypeVar
 from pydantic import BaseModel
 
 from ohtv.config import get_analysis_cache_dir
+from ohtv.db.stores.analysis_cache_store import CONTEXT_LEVELS, context_level_index
 
 log = logging.getLogger("ohtv")
 
@@ -596,20 +597,15 @@ class AnalysisCacheManager:
 
         # Check if requested context level exceeds cached skip context level
         cached_context = skipped.get("context_level", "minimal")
-        context_levels = ["minimal", "default", "full"]
-        try:
-            cached_idx = context_levels.index(cached_context)
-            requested_idx = context_levels.index(context_level)
-            if requested_idx > cached_idx:
-                log.debug(
-                    "Skip marker invalidated: higher context level requested (%s > %s)",
-                    context_level,
-                    cached_context,
-                )
-                return None
-        except ValueError:
-            # Unknown context level, treat cached as valid
-            pass
+        cached_idx = context_level_index(cached_context)
+        requested_idx = context_level_index(context_level)
+        if requested_idx > cached_idx:
+            log.debug(
+                "Skip marker invalidated: higher context level requested (%s > %s)",
+                context_level,
+                cached_context,
+            )
+            return None
 
         return skipped.get("reason")
 
@@ -632,23 +628,36 @@ class AnalysisCacheManager:
         cache_data = self._load_cache_data(cache_file) or {"analyses": {}}
 
         # Check if existing skip is at a higher context level
-        # If so, don't overwrite (higher context encompasses lower)
+        # If so, don't overwrite context (higher context encompasses lower)
+        # BUT we still need to update event_count to prevent infinite retry loops
         existing_skip = cache_data.get("skipped")
         if existing_skip:
             existing_context = existing_skip.get("context_level", "minimal")
-            context_levels = ["minimal", "default", "full"]
-            try:
-                existing_idx = context_levels.index(existing_context)
-                new_idx = context_levels.index(context_level)
-                if existing_idx > new_idx:
+            existing_idx = context_level_index(existing_context)
+            new_idx = context_level_index(context_level)
+            if existing_idx > new_idx:
+                # Don't downgrade context level, but update event_count if changed
+                existing_event_count = cache_data.get("event_count")
+                if existing_event_count != event_count:
+                    cache_data["event_count"] = event_count
+                    cache_data["skipped"]["at"] = datetime.now(timezone.utc).isoformat()
+                    self._save_cache_data(cache_file, cache_data)
+                    # Sync to DB with existing (higher) context level
+                    self._sync_skip_to_db(conv_dir.name, event_count, existing_skip.get("reason", reason), existing_context)
+                    log.debug(
+                        "Updated event_count for skip: %s (%d -> %d, context stays at %s)",
+                        conv_dir.name,
+                        existing_event_count,
+                        event_count,
+                        existing_context,
+                    )
+                else:
                     log.debug(
                         "Not overwriting skip: existing at %s > new at %s",
                         existing_context,
                         context_level,
                     )
-                    return
-            except ValueError:
-                pass
+                return
 
         cache_data["event_count"] = event_count
         cache_data["skipped"] = {

--- a/src/ohtv/analysis/objectives.py
+++ b/src/ohtv/analysis/objectives.py
@@ -458,12 +458,16 @@ def analyze_objectives(
     event_count = len(data.events)
 
     if not data.events:
-        # Check if already marked as skipped
+        # Check if already marked as skipped at this context level or higher
         if not force_refresh:
-            skip_reason = _cache_manager.is_skipped(conv_dir, event_count)
+            skip_reason = _cache_manager.is_skipped(
+                conv_dir, event_count, context_level=effective_context
+            )
             if skip_reason:
                 raise ValueError(f"Skipped (cached): {skip_reason}")
-        _cache_manager.mark_skipped(conv_dir, event_count, "no_events")
+        _cache_manager.mark_skipped(
+            conv_dir, event_count, "no_events", context_level=effective_context
+        )
         raise ValueError(f"No events found in conversation: {conv_id}")
 
     # Auto-promote context level if transcript is empty but events exist
@@ -485,12 +489,16 @@ def analyze_objectives(
 
     # Now check for empty content after promotion attempts
     if not data.items:
-        # Check if already marked as skipped
+        # Check if already marked as skipped at this context level or higher
         if not force_refresh:
-            skip_reason = _cache_manager.is_skipped(conv_dir, event_count)
+            skip_reason = _cache_manager.is_skipped(
+                conv_dir, event_count, context_level=effective_context
+            )
             if skip_reason:
                 raise ValueError(f"Skipped (cached): {skip_reason}")
-        _cache_manager.mark_skipped(conv_dir, event_count, "no_analyzable_content")
+        _cache_manager.mark_skipped(
+            conv_dir, event_count, "no_analyzable_content", context_level=effective_context
+        )
         raise ValueError(f"No content found in conversation: {conv_id}")
 
     with _timer("format_transcript"):

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1966,16 +1966,16 @@ def _count_uncached_conversations_fast(
             # Get cache status for all conversations in one query
             status_map = store.get_cache_status_batch(conv_ids, cache_key)
             
-            # Count those needing analysis
+            # Count those needing analysis (context-aware for skip cache)
             uncached_count = 0
             for conv_id in conv_ids:
                 status = status_map.get(conv_id)
-                if status is None or status.needs_analysis:
+                if status is None or status.needs_analysis_for_context(context):
                     uncached_count += 1
             
             log.debug(
-                "Fast cache check: %d of %d need analysis (key=%s)",
-                uncached_count, len(conversations), cache_key
+                "Fast cache check: %d of %d need analysis (key=%s, context=%s)",
+                uncached_count, len(conversations), cache_key, context
             )
             return uncached_count
             

--- a/src/ohtv/db/migrations/014_skip_cache_context_level.py
+++ b/src/ohtv/db/migrations/014_skip_cache_context_level.py
@@ -1,0 +1,25 @@
+"""Add context_level to analysis_skips table.
+
+The skip cache was previously keyed only by conversation_id, which meant
+that skipping a conversation at a lower context level (e.g., 'minimal')
+would prevent retry at a higher context level (e.g., 'full').
+
+This migration adds a context_level column to track the context level
+at which the skip occurred. Existing entries default to 'minimal' (the
+lowest context level).
+
+With this change:
+- Skip at 'minimal' allows retry at 'default' or 'full'
+- Skip at 'default' allows retry at 'full'
+- Skip at 'full' blocks all context levels (highest includes everything)
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Add context_level column to analysis_skips."""
+    conn.execute("""
+        ALTER TABLE analysis_skips
+        ADD COLUMN context_level TEXT NOT NULL DEFAULT 'minimal'
+    """)

--- a/src/ohtv/db/stores/analysis_cache_store.py
+++ b/src/ohtv/db/stores/analysis_cache_store.py
@@ -10,7 +10,7 @@ This table only stores metadata for fast lookup.
 
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 
 
 @dataclass
@@ -30,6 +30,20 @@ class AnalysisSkipEntry:
     event_count: int
     reason: str
     skipped_at: datetime
+    context_level: str = "minimal"  # The context level at which skip occurred
+
+
+# Context levels ordered from lowest to highest content inclusion
+CONTEXT_LEVELS = ["minimal", "default", "full"]
+
+
+def context_level_index(level: str) -> int:
+    """Get the numeric index of a context level (0=minimal, 1=default, 2=full)."""
+    try:
+        return CONTEXT_LEVELS.index(level)
+    except ValueError:
+        # Unknown level treated as minimal for safety
+        return 0
 
 
 @dataclass
@@ -44,6 +58,7 @@ class CacheStatus:
         is_skipped: Whether this conversation is marked as skipped
         skip_reason: Reason for skip (if skipped)
         skip_event_count: Event count when skip marker was set (None if not skipped)
+        skip_context_level: Context level at which skip occurred (if skipped)
     """
     conversation_id: str
     current_event_count: int
@@ -52,10 +67,15 @@ class CacheStatus:
     is_skipped: bool = False
     skip_reason: str | None = None
     skip_event_count: int | None = None
+    skip_context_level: str | None = None
     
     @property
     def needs_analysis(self) -> bool:
-        """True if this conversation needs (re)analysis."""
+        """True if this conversation needs (re)analysis.
+        
+        Note: This is a legacy property that doesn't consider context level.
+        For context-aware checks, use needs_analysis_for_context().
+        """
         # Skipped and event count unchanged = don't retry
         if self.is_skipped and self.skip_event_count == self.current_event_count:
             return False
@@ -63,6 +83,31 @@ class CacheStatus:
         if self.cached_event_count is not None and self.cached_event_count == self.current_event_count:
             return False
         # Otherwise needs analysis
+        return True
+    
+    def needs_analysis_for_context(self, requested_context: str) -> bool:
+        """True if this conversation needs (re)analysis at the requested context level.
+        
+        This is context-aware: a skip at 'minimal' allows retry at 'full'.
+        
+        Args:
+            requested_context: The context level being requested (minimal, default, full)
+        
+        Returns:
+            True if analysis should be attempted, False if cached/skipped result is valid
+        """
+        # Cached and event count unchanged = cache hit (cache_key already includes context)
+        if self.cached_event_count is not None and self.cached_event_count == self.current_event_count:
+            return False
+        
+        # Check skip with context awareness
+        if self.is_skipped and self.skip_event_count == self.current_event_count:
+            # If skip_context_level is None or matches/exceeds requested, skip is valid
+            skip_context = self.skip_context_level or "minimal"
+            if context_level_index(requested_context) <= context_level_index(skip_context):
+                return False
+            # Higher context level requested than skip - allow retry
+        
         return True
 
 
@@ -104,26 +149,45 @@ class AnalysisCacheStore:
         )
     
     def upsert_skip(self, entry: AnalysisSkipEntry) -> None:
-        """Insert or update a skip entry."""
+        """Insert or update a skip entry.
+        
+        Note: If a skip already exists at a HIGHER context level, we don't
+        update it. A skip at 'full' encompasses all lower levels.
+        """
         skipped_at_str = entry.skipped_at.isoformat()
         
         # Normalize conversation ID (remove dashes) for consistency
         normalized_id = entry.conversation_id.replace("-", "")
         
+        # Check if there's an existing skip at a higher context level
+        cursor = self.conn.execute(
+            "SELECT context_level FROM analysis_skips WHERE conversation_id = ?",
+            (normalized_id,),
+        )
+        row = cursor.fetchone()
+        if row:
+            existing_context = row[0] if row[0] else "minimal"
+            new_context = entry.context_level or "minimal"
+            # Don't downgrade: if existing skip is at higher context, keep it
+            if context_level_index(existing_context) > context_level_index(new_context):
+                return
+        
         self.conn.execute(
             """
-            INSERT INTO analysis_skips (conversation_id, event_count, reason, skipped_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO analysis_skips (conversation_id, event_count, reason, skipped_at, context_level)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(conversation_id) DO UPDATE SET
                 event_count = excluded.event_count,
                 reason = excluded.reason,
-                skipped_at = excluded.skipped_at
+                skipped_at = excluded.skipped_at,
+                context_level = excluded.context_level
             """,
             (
                 normalized_id,
                 entry.event_count,
                 entry.reason,
                 skipped_at_str,
+                entry.context_level,
             ),
         )
     
@@ -155,7 +219,8 @@ class AnalysisCacheStore:
                 ac.event_count as cached_event_count,
                 ac.cache_key,
                 s.event_count as skip_event_count,
-                s.reason as skip_reason
+                s.reason as skip_reason,
+                s.context_level as skip_context_level
             FROM conversations c
             LEFT JOIN analysis_cache ac ON c.id = ac.conversation_id AND ac.cache_key = ?
             LEFT JOIN analysis_skips s ON c.id = s.conversation_id
@@ -171,6 +236,7 @@ class AnalysisCacheStore:
             cached_count = row["cached_event_count"]
             skip_count = row["skip_event_count"]
             skip_reason = row["skip_reason"]
+            skip_context = row["skip_context_level"]
             
             # is_skipped indicates a skip marker exists (validity checked in needs_analysis)
             is_skipped = skip_count is not None
@@ -183,6 +249,7 @@ class AnalysisCacheStore:
                 is_skipped=is_skipped,
                 skip_reason=skip_reason if is_skipped else None,
                 skip_event_count=skip_count,
+                skip_context_level=skip_context if is_skipped else None,
             )
         
         return results

--- a/src/ohtv/db/stores/analysis_cache_store.py
+++ b/src/ohtv/db/stores/analysis_cache_store.py
@@ -161,15 +161,22 @@ class AnalysisCacheStore:
         
         # Check if there's an existing skip at a higher context level
         cursor = self.conn.execute(
-            "SELECT context_level FROM analysis_skips WHERE conversation_id = ?",
+            "SELECT context_level, event_count FROM analysis_skips WHERE conversation_id = ?",
             (normalized_id,),
         )
         row = cursor.fetchone()
         if row:
             existing_context = row[0] if row[0] else "minimal"
+            existing_event_count = row[1]
             new_context = entry.context_level or "minimal"
             # Don't downgrade: if existing skip is at higher context, keep it
+            # BUT update event_count if it changed to prevent infinite retry loops
             if context_level_index(existing_context) > context_level_index(new_context):
+                if existing_event_count != entry.event_count:
+                    self.conn.execute(
+                        "UPDATE analysis_skips SET event_count = ?, skipped_at = ? WHERE conversation_id = ?",
+                        (entry.event_count, skipped_at_str, normalized_id),
+                    )
                 return
         
         self.conn.execute(

--- a/tests/unit/analysis/test_cache_context_level.py
+++ b/tests/unit/analysis/test_cache_context_level.py
@@ -1,0 +1,178 @@
+"""Tests for context-aware skip caching in AnalysisCacheManager."""
+
+import json
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from ohtv.analysis.cache import AnalysisCacheManager
+from ohtv.analysis.objectives import ObjectiveAnalysis
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    """Create a temporary cache directory."""
+    cache = tmp_path / "cache" / "analysis"
+    cache.mkdir(parents=True)
+    return cache
+
+
+@pytest.fixture
+def conv_dir(tmp_path):
+    """Create a temporary conversation directory."""
+    conv = tmp_path / "conversations" / "test_conv_123"
+    conv.mkdir(parents=True)
+    events_dir = conv / "events"
+    events_dir.mkdir()
+    return conv
+
+
+@pytest.fixture
+def cache_manager(cache_dir):
+    """Create an AnalysisCacheManager with mocked cache dir."""
+    with patch("ohtv.analysis.cache.get_analysis_cache_dir", return_value=cache_dir):
+        yield AnalysisCacheManager(
+            cache_filename="objective_analysis.json",
+            model_class=ObjectiveAnalysis,
+        )
+
+
+class TestIsSkippedContextAware:
+    """Tests for is_skipped with context level awareness."""
+
+    def test_skip_at_minimal_blocks_minimal(self, cache_manager, conv_dir):
+        """Skip at 'minimal' should block requests at 'minimal' level."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="minimal")
+        
+        result = cache_manager.is_skipped(conv_dir, 5, context_level="minimal")
+        assert result == "no_content"
+
+    def test_skip_at_minimal_allows_default(self, cache_manager, conv_dir):
+        """Skip at 'minimal' should allow retry at 'default' level."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="minimal")
+        
+        result = cache_manager.is_skipped(conv_dir, 5, context_level="default")
+        assert result is None
+
+    def test_skip_at_minimal_allows_full(self, cache_manager, conv_dir):
+        """Skip at 'minimal' should allow retry at 'full' level."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="minimal")
+        
+        result = cache_manager.is_skipped(conv_dir, 5, context_level="full")
+        assert result is None
+
+    def test_skip_at_default_blocks_minimal(self, cache_manager, conv_dir):
+        """Skip at 'default' should block requests at 'minimal' level."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="default")
+        
+        result = cache_manager.is_skipped(conv_dir, 5, context_level="minimal")
+        assert result == "no_content"
+
+    def test_skip_at_default_blocks_default(self, cache_manager, conv_dir):
+        """Skip at 'default' should block requests at 'default' level."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="default")
+        
+        result = cache_manager.is_skipped(conv_dir, 5, context_level="default")
+        assert result == "no_content"
+
+    def test_skip_at_default_allows_full(self, cache_manager, conv_dir):
+        """Skip at 'default' should allow retry at 'full' level."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="default")
+        
+        result = cache_manager.is_skipped(conv_dir, 5, context_level="full")
+        assert result is None
+
+    def test_skip_at_full_blocks_all(self, cache_manager, conv_dir):
+        """Skip at 'full' should block all context levels."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="full")
+        
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="minimal") == "no_content"
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="default") == "no_content"
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="full") == "no_content"
+
+    def test_event_count_change_invalidates_skip(self, cache_manager, conv_dir):
+        """Skip should be invalidated if event count changes, regardless of context."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="full")
+        
+        # Event count changed (conversation grew)
+        result = cache_manager.is_skipped(conv_dir, 10, context_level="minimal")
+        assert result is None
+
+    def test_default_context_level_is_minimal(self, cache_manager, conv_dir):
+        """Default context level should be 'minimal'."""
+        # Mark skipped without explicit context_level
+        cache_manager.mark_skipped(conv_dir, 5, "no_content")
+        
+        # Default is minimal, so should block minimal but allow higher
+        assert cache_manager.is_skipped(conv_dir, 5) == "no_content"
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="minimal") == "no_content"
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="full") is None
+
+
+class TestMarkSkippedContextLevel:
+    """Tests for mark_skipped with context level."""
+
+    def test_stores_context_level_in_cache(self, cache_manager, conv_dir, cache_dir):
+        """Context level should be stored in cache file."""
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="default")
+        
+        cache_file = cache_dir / conv_dir.name / "objective_analysis.json"
+        data = json.loads(cache_file.read_text())
+        
+        assert data["skipped"]["context_level"] == "default"
+
+    def test_does_not_downgrade_context_level(self, cache_manager, conv_dir, cache_dir):
+        """Mark skipped should not overwrite higher context level with lower."""
+        # First mark at 'full'
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="full")
+        
+        # Try to mark at 'minimal'
+        cache_manager.mark_skipped(conv_dir, 5, "different_reason", context_level="minimal")
+        
+        # Should still be 'full'
+        cache_file = cache_dir / conv_dir.name / "objective_analysis.json"
+        data = json.loads(cache_file.read_text())
+        
+        assert data["skipped"]["context_level"] == "full"
+        assert data["skipped"]["reason"] == "no_content"
+
+    def test_upgrades_context_level(self, cache_manager, conv_dir, cache_dir):
+        """Mark skipped at higher context should upgrade existing skip."""
+        # First mark at 'minimal'
+        cache_manager.mark_skipped(conv_dir, 5, "no_content", context_level="minimal")
+        
+        # Mark at 'full'
+        cache_manager.mark_skipped(conv_dir, 5, "still_no_content", context_level="full")
+        
+        # Should now be 'full'
+        cache_file = cache_dir / conv_dir.name / "objective_analysis.json"
+        data = json.loads(cache_file.read_text())
+        
+        assert data["skipped"]["context_level"] == "full"
+        assert data["skipped"]["reason"] == "still_no_content"
+
+
+class TestLegacyCacheCompatibility:
+    """Tests for backward compatibility with existing cache files."""
+
+    def test_legacy_cache_without_context_level(self, cache_manager, conv_dir, cache_dir):
+        """Legacy cache without context_level should be treated as 'minimal'."""
+        # Create legacy cache file (no context_level)
+        cache_file = cache_dir / conv_dir.name / "objective_analysis.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps({
+            "event_count": 5,
+            "analyses": {},
+            "skipped": {
+                "reason": "no_content",
+                "at": datetime.now(timezone.utc).isoformat(),
+                # No context_level field
+            }
+        }))
+        
+        # Should block minimal (default behavior)
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="minimal") == "no_content"
+        
+        # Should allow higher levels
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="default") is None
+        assert cache_manager.is_skipped(conv_dir, 5, context_level="full") is None

--- a/tests/unit/analysis/test_cache_context_level.py
+++ b/tests/unit/analysis/test_cache_context_level.py
@@ -151,6 +151,30 @@ class TestMarkSkippedContextLevel:
         assert data["skipped"]["context_level"] == "full"
         assert data["skipped"]["reason"] == "still_no_content"
 
+    def test_event_count_updated_despite_higher_context_skip(self, cache_manager, conv_dir, cache_dir):
+        """Event count should be updated even when not downgrading context level.
+        
+        This prevents infinite retry loops when:
+        1. Conversation is skipped at 'full' with event_count=10
+        2. Conversation grows to 20 events
+        3. Batch run at 'minimal' context fails, calls mark_skipped(20, 'minimal')
+        4. Without this fix, the early return would leave event_count=10, causing endless retries
+        """
+        # Skip at 'full' with event_count=10
+        cache_manager.mark_skipped(conv_dir, 10, "no_content", context_level="full")
+        
+        # Conversation grows to 20 events, batch run fails at 'minimal'
+        cache_manager.mark_skipped(conv_dir, 20, "still_no_content", context_level="minimal")
+        
+        # Verify event_count was updated (even though context stayed at 'full')
+        cache_file = cache_dir / conv_dir.name / "objective_analysis.json"
+        data = json.loads(cache_file.read_text())
+        
+        assert data["event_count"] == 20, "event_count should be updated to prevent retry loops"
+        assert data["skipped"]["context_level"] == "full", "context_level should remain at 'full'"
+        # Reason should be preserved from the higher-context skip
+        assert data["skipped"]["reason"] == "no_content"
+
 
 class TestLegacyCacheCompatibility:
     """Tests for backward compatibility with existing cache files."""

--- a/tests/unit/db/stores/test_analysis_cache_store.py
+++ b/tests/unit/db/stores/test_analysis_cache_store.py
@@ -317,3 +317,217 @@ class TestCacheStatus:
             skip_event_count=10,  # Older skip
         )
         assert status.needs_analysis is True
+
+
+class TestContextAwareSkipCache:
+    """Tests for context-level-aware skip caching."""
+
+    def test_skip_at_minimal_allows_retry_at_full(self):
+        """Skip at 'minimal' context should allow retry at 'full'."""
+        status = CacheStatus(
+            conversation_id="test",
+            current_event_count=10,
+            is_skipped=True,
+            skip_event_count=10,
+            skip_context_level="minimal",
+        )
+        # Legacy property doesn't consider context
+        assert status.needs_analysis is False
+        # Context-aware method allows retry at higher level
+        assert status.needs_analysis_for_context("minimal") is False
+        assert status.needs_analysis_for_context("default") is True
+        assert status.needs_analysis_for_context("full") is True
+
+    def test_skip_at_default_allows_retry_at_full(self):
+        """Skip at 'default' context should allow retry at 'full' only."""
+        status = CacheStatus(
+            conversation_id="test",
+            current_event_count=10,
+            is_skipped=True,
+            skip_event_count=10,
+            skip_context_level="default",
+        )
+        assert status.needs_analysis_for_context("minimal") is False
+        assert status.needs_analysis_for_context("default") is False
+        assert status.needs_analysis_for_context("full") is True
+
+    def test_skip_at_full_blocks_all_contexts(self):
+        """Skip at 'full' context should block all context levels."""
+        status = CacheStatus(
+            conversation_id="test",
+            current_event_count=10,
+            is_skipped=True,
+            skip_event_count=10,
+            skip_context_level="full",
+        )
+        assert status.needs_analysis_for_context("minimal") is False
+        assert status.needs_analysis_for_context("default") is False
+        assert status.needs_analysis_for_context("full") is False
+
+    def test_legacy_skip_treated_as_minimal(self):
+        """Skip without context_level should be treated as 'minimal'."""
+        status = CacheStatus(
+            conversation_id="test",
+            current_event_count=10,
+            is_skipped=True,
+            skip_event_count=10,
+            skip_context_level=None,  # Legacy entry
+        )
+        # Should allow retry at higher levels
+        assert status.needs_analysis_for_context("minimal") is False
+        assert status.needs_analysis_for_context("default") is True
+        assert status.needs_analysis_for_context("full") is True
+
+    def test_skip_still_invalidated_when_event_count_changes(self):
+        """Skip should be invalidated if event count changed, regardless of context."""
+        status = CacheStatus(
+            conversation_id="test",
+            current_event_count=15,  # Conversation grew
+            is_skipped=True,
+            skip_event_count=10,  # Old skip
+            skip_context_level="full",
+        )
+        # Even at 'full', needs retry because event count changed
+        assert status.needs_analysis_for_context("minimal") is True
+        assert status.needs_analysis_for_context("full") is True
+
+    def test_cached_analysis_still_valid(self):
+        """Cached analysis should still block even with context-aware checks."""
+        status = CacheStatus(
+            conversation_id="test",
+            current_event_count=10,
+            cached_event_count=10,  # Cache hit
+            is_skipped=False,
+        )
+        assert status.needs_analysis_for_context("minimal") is False
+        assert status.needs_analysis_for_context("full") is False
+
+
+class TestUpsertSkipWithContextLevel:
+    """Tests for upsert_skip with context_level."""
+
+    def test_inserts_skip_with_context_level(self, analysis_cache_store, sample_conversation, db_conn):
+        entry = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=42,
+            reason="no_events",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="default",
+        )
+        analysis_cache_store.upsert_skip(entry)
+        db_conn.commit()
+        
+        # Verify context_level is stored
+        cursor = db_conn.execute(
+            "SELECT context_level FROM analysis_skips WHERE conversation_id = ?",
+            ("abc123",),
+        )
+        row = cursor.fetchone()
+        assert row[0] == "default"
+
+    def test_does_not_downgrade_context_level(self, analysis_cache_store, sample_conversation, db_conn):
+        """Skip at higher context should not be overwritten by lower context skip."""
+        # First skip at 'full'
+        entry1 = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=42,
+            reason="no_content",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="full",
+        )
+        analysis_cache_store.upsert_skip(entry1)
+        db_conn.commit()
+        
+        # Try to skip at 'minimal' - should be ignored
+        entry2 = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=42,
+            reason="no_events",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="minimal",
+        )
+        analysis_cache_store.upsert_skip(entry2)
+        db_conn.commit()
+        
+        # Verify context_level is still 'full'
+        cursor = db_conn.execute(
+            "SELECT context_level, reason FROM analysis_skips WHERE conversation_id = ?",
+            ("abc123",),
+        )
+        row = cursor.fetchone()
+        assert row[0] == "full"
+        assert row[1] == "no_content"
+
+    def test_upgrades_context_level(self, analysis_cache_store, sample_conversation, db_conn):
+        """Skip at lower context should be upgraded by higher context skip."""
+        # First skip at 'minimal'
+        entry1 = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=42,
+            reason="no_events",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="minimal",
+        )
+        analysis_cache_store.upsert_skip(entry1)
+        db_conn.commit()
+        
+        # Skip at 'full' - should upgrade
+        entry2 = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=42,
+            reason="no_content",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="full",
+        )
+        analysis_cache_store.upsert_skip(entry2)
+        db_conn.commit()
+        
+        # Verify context_level is now 'full'
+        cursor = db_conn.execute(
+            "SELECT context_level, reason FROM analysis_skips WHERE conversation_id = ?",
+            ("abc123",),
+        )
+        row = cursor.fetchone()
+        assert row[0] == "full"
+        assert row[1] == "no_content"
+
+
+class TestGetCacheStatusBatchWithContextLevel:
+    """Tests for get_cache_status_batch returning skip_context_level."""
+
+    def test_returns_skip_context_level(self, analysis_cache_store, sample_conversation, db_conn):
+        entry = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=42,
+            reason="no_events",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="default",
+        )
+        analysis_cache_store.upsert_skip(entry)
+        db_conn.commit()
+        
+        status_map = analysis_cache_store.get_cache_status_batch(["abc123"], "test_key")
+        
+        assert "abc123" in status_map
+        status = status_map["abc123"]
+        assert status.is_skipped is True
+        assert status.skip_context_level == "default"
+
+    def test_legacy_skip_returns_minimal(self, analysis_cache_store, sample_conversation, db_conn):
+        """Skip without explicit context_level should return default 'minimal'."""
+        # Insert directly without context_level (simulates legacy data)
+        db_conn.execute(
+            """
+            INSERT INTO analysis_skips (conversation_id, event_count, reason, skipped_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("abc123", 42, "no_events", datetime.now(timezone.utc).isoformat()),
+        )
+        db_conn.commit()
+        
+        status_map = analysis_cache_store.get_cache_status_batch(["abc123"], "test_key")
+        
+        status = status_map["abc123"]
+        assert status.is_skipped is True
+        # SQLite default is 'minimal' from migration
+        assert status.skip_context_level == "minimal"

--- a/tests/unit/db/stores/test_analysis_cache_store.py
+++ b/tests/unit/db/stores/test_analysis_cache_store.py
@@ -491,6 +491,50 @@ class TestUpsertSkipWithContextLevel:
         assert row[0] == "full"
         assert row[1] == "no_content"
 
+    def test_event_count_updated_despite_higher_context_skip(
+        self, analysis_cache_store, sample_conversation, db_conn
+    ):
+        """Event count should be updated even when not downgrading context level.
+        
+        This prevents infinite retry loops when:
+        1. Conversation is skipped at 'full' with event_count=10
+        2. Conversation grows to 20 events
+        3. Batch run at 'minimal' context fails, calls upsert_skip(20, 'minimal')
+        4. Without this fix, the early return would leave event_count=10, causing endless retries
+        """
+        # Skip at 'full' with event_count=10
+        entry1 = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=10,
+            reason="no_content",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="full",
+        )
+        analysis_cache_store.upsert_skip(entry1)
+        db_conn.commit()
+        
+        # Conversation grows to 20 events, batch run fails at 'minimal'
+        entry2 = AnalysisSkipEntry(
+            conversation_id="abc123",
+            event_count=20,
+            reason="still_no_content",
+            skipped_at=datetime.now(timezone.utc),
+            context_level="minimal",
+        )
+        analysis_cache_store.upsert_skip(entry2)
+        db_conn.commit()
+        
+        # Verify event_count was updated (even though context stayed at 'full')
+        cursor = db_conn.execute(
+            "SELECT event_count, context_level, reason FROM analysis_skips WHERE conversation_id = ?",
+            ("abc123",),
+        )
+        row = cursor.fetchone()
+        assert row[0] == 20, "event_count should be updated to prevent retry loops"
+        assert row[1] == "full", "context_level should remain at 'full'"
+        # Reason should be preserved from the higher-context skip
+        assert row[2] == "no_content"
+
 
 class TestGetCacheStatusBatchWithContextLevel:
     """Tests for get_cache_status_batch returning skip_context_level."""


### PR DESCRIPTION
## Summary

Fixes #60

The skip cache was previously keyed only by `conversation_id`, which meant that skipping a conversation at a lower context level (e.g., `minimal`) would prevent retry at a higher context level (e.g., `full`). This defeated the purpose of the auto-promotion fix in #59.

## Problem

When running `ohtv gen objs --since 2026-05-14` with minimal context (default for batch), a conversation might be marked as "no_analyzable_content". Later running with full context (`-c 3`) should retry the analysis, but the cached skip was returned regardless of context level.

## Solution

Add `context_level` to the skip cache, with context-aware invalidation:

- **Skip at 'minimal'** → allows retry at 'default' or 'full'
- **Skip at 'default'** → allows retry at 'full'
- **Skip at 'full'** → blocks all context levels (highest includes everything)

## Changes

### Database
- Migration 014: Add `context_level` column to `analysis_skips` table (default: 'minimal')
- `AnalysisSkipEntry` dataclass: Add `context_level` field
- `CacheStatus`: Add `skip_context_level` field and `needs_analysis_for_context()` method
- `upsert_skip()`: Don't downgrade existing higher-context skips; always update event_count to prevent infinite retry loops

### File Cache
- `is_skipped()`: Add `context_level` parameter, return `None` if requested > cached
- `mark_skipped()`: Add `context_level` parameter, store in cache file; update event_count even when not downgrading context
- `_sync_skip_to_db()`: Pass context_level to database

### CLI
- Use `needs_analysis_for_context()` for batch status checks

### Backward Compatibility
- Legacy cache files without `context_level` are treated as 'minimal'
- Migration adds default 'minimal' for existing entries

## Key Decisions During Review

1. **Fixed critical bug**: Initial implementation had an event count stale data bug caught in code review - when a conversation is skipped at a higher context level (e.g., `full` with `event_count=10`), and the conversation later grows (to `event_count=20`), attempting to mark it as skipped at a lower context level (e.g., `minimal`) would return early without updating the stored `event_count`. This caused infinite retry loops. Fixed by updating event_count even when preserving the higher context level.

2. **Context level constant**: Extracted `CONTEXT_LEVELS = ["minimal", "default", "full"]` as a shared constant with `context_level_index()` helper to ensure consistent ordering across file cache and database layers.

## Testing

- **14 tests** for file-based cache context awareness (`tests/unit/analysis/test_cache_context_level.py`)
- **12 tests** for database store context awareness (`tests/unit/db/stores/test_analysis_cache_store.py`)
- **1116 total unit tests pass**
- **Manual testing**: All 9 skip/retry scenarios verified, event count update verified

## Acceptance Criteria

- [x] Skip cache includes context level in cache key
- [x] `is_skipped()` returns None if current context > cached context (allowing retry at higher levels)
- [x] Skip marked at `full` context blocks all lower contexts (full encompasses minimal)
- [x] Database schema migration adds context_level to analysis_skips
- [x] AnalysisSkipEntry dataclass includes context_level field
- [x] Existing skip entries are handled gracefully (treat missing context_level as "minimal")
- [x] Unit tests cover context-aware skip cache behavior
- [x] Event count is updated even when not downgrading context level (prevents infinite retry loops)

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*