### PR TITLE
feat: Add conversation labels to gen objs display

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ ohtv list --action open-pr          # Conversations that opened PRs
 # Combine action + repo for precise filtering
 ohtv list --action pushed --repo OpenPaw  # Pushed specifically to OpenPaw
 
+# Filter by label (cloud API tags)
+ohtv list --label project=SDK            # Conversations with label project=SDK
+ohtv list -L status=WIP                  # Short form
+ohtv list --label team=AI --repo OpenPaw # Combine with other filters
+
 # Show idle time instead of duration (for orchestration)
 ohtv list --idle                  # Default: 7 min threshold
 ohtv list --idle 15               # Custom: 15 min threshold
@@ -153,6 +158,7 @@ ohtv list --no-refs               # Refs shown by default
 | `--pr PATTERN` | Filter by PR reference (URL, `owner/repo#N`, or `repo#N`) |
 | `--repo PATTERN` | Filter by repository (URL, `owner/repo`, or name) |
 | `--action TYPE` | Filter by action type (e.g., `pushed`, `open-pr`, `git-commit`) |
+| `-L, --label KEY=VALUE` | Filter by label (cloud API tags in `key=value` format) |
 | `--idle [MINS]` | Show Idle column (time since last event). Colorized: red if < MINS (default: 7), green if >= MINS |
 | `--no-refs` | Hide git refs from title (refs shown by default) |
 | `-E, --with-errors` | Include error info column (agent/LLM errors) |
@@ -169,7 +175,7 @@ ohtv list --no-refs               # Refs shown by default
 | `merged`, `merge` | `merge-pr` |
 | `ci`, `checks` | `check-ci` |
 
-**Note:** PR, repo, and action filters require the database to be indexed. Run `ohtv db scan && ohtv db process all` first.
+**Note:** PR, repo, action, and label filters require the database to be indexed. Run `ohtv db scan && ohtv db process all` first. Labels are stored from the cloud API during `ohtv sync`.
 
 ---
 
@@ -550,7 +556,7 @@ Showing 2 of 150 (2/2 cached)
 | ID | Short conversation ID | Source (`cloud` or `local`) |
 | Date | Date (YYYY-MM-DD) | Start time (HH:MM AM/PM) |
 | Duration | Duration (e.g., "35 mins", "1h 20m") | Event/step count (e.g., "46 steps") |
-| Summary | Goal description | Git refs (PRs, repos modified) |
+| Summary | Goal description | Git refs (PRs, repos modified), labels (if present) |
 
 **JSON Output Fields (`-F json`):**
 ```json
@@ -562,7 +568,8 @@ Showing 2 of 150 (2/2 cached)
     "start_time": "10:42",
     "duration_seconds": 2100,
     "event_count": 46,
-    "goal": "Refactor authentication module..."
+    "goal": "Refactor authentication module...",
+    "labels": {"project": "SDK", "status": "WIP"}
   }
 ]
 ```
@@ -576,12 +583,14 @@ Showing 2 of 150 (2/2 cached)
 | `duration_seconds` | Duration in seconds (or `null` if unknown) |
 | `event_count` | Number of events/steps in the conversation |
 | `goal` | Extracted goal description |
+| `labels` | Cloud-sourced labels/tags as key-value pairs (if present) |
 
 **Markdown Output (`-F markdown`):**
 ```markdown
 - **abc1234** (2024-03-15, 10:42 AM, 35 mins, 46 steps): Refactor authentication...
   - created user/repo/pull/42
   - pushed user/repo
+  - Labels: project=SDK, status=WIP
 ```
 
 **Options (Single-Conversation Mode):**
@@ -610,6 +619,7 @@ Showing 2 of 150 (2/2 cached)
 | `--pr PATTERN` | Filter by PR reference (URL, `owner/repo#N`, or `repo#N`) |
 | `--repo PATTERN` | Filter by repository (URL, `owner/repo`, or name) |
 | `--action TYPE` | Filter by action type (e.g., `pushed`, `open-pr`) |
+| `-L, --label KEY=VALUE` | Filter by label (cloud API tags in `key=value` format) |
 | `--reverse` | Show oldest first |
 | `-r, --refresh` | Force re-analysis (refresh cache) |
 | `-m, --model` | LLM model to use |

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1774,6 +1774,7 @@ def _apply_conversation_filters(
     pr_filter: str | None = None,
     repo_filter: str | None = None,
     action_filter: str | None = None,
+    label_filter: str | None = None,
     include_empty: bool = False,
     initial_show_all: bool = False,
     errors_only: bool = False,
@@ -1789,6 +1790,7 @@ def _apply_conversation_filters(
         pr_filter: PR reference filter (URL, FQN, or short name)
         repo_filter: Repository filter (URL, FQN, or name)
         action_filter: Action type filter (e.g., "git-push", "pushed")
+        label_filter: Label filter in key=value format
         include_empty: Include conversations with 0 events
         initial_show_all: Initial value for show_all flag
         errors_only: Only include conversations with agent/LLM errors
@@ -1799,7 +1801,7 @@ def _apply_conversation_filters(
     show_all = initial_show_all
     
     # Any filter implies --all (show all matching records)
-    if any([since, until, pr_filter, repo_filter, action_filter, errors_only]):
+    if any([since, until, pr_filter, repo_filter, action_filter, label_filter, errors_only]):
         show_all = True
     
     # Load conversations from both sources, with date filtering pushed to DB
@@ -1828,6 +1830,10 @@ def _apply_conversation_filters(
     # Apply repo filtering (requires database) - only if not already combined with action
     if repo_filter is not None:
         conversations = _filter_by_repo(conversations, repo_filter)
+    
+    # Apply label filtering (requires database)
+    if label_filter is not None:
+        conversations = _filter_by_label(config, conversations, label_filter)
     
     # Apply error filtering
     if errors_only:
@@ -1945,6 +1951,63 @@ def _filter_by_action(
         
         console.print(f"[dim]Filtering by action '{action_type}': {len(conversation_ids)} matches[/dim]")
         return filter_conversations_by_ids(conversations, conversation_ids), set()
+
+
+def _filter_by_label(
+    config: Config,
+    conversations: list[ConversationInfo],
+    label_filter: str,
+) -> list[ConversationInfo]:
+    """Filter conversations by label (key=value format).
+    
+    Args:
+        config: Application configuration
+        conversations: List of conversations to filter
+        label_filter: Filter string in "key=value" format
+        
+    Returns:
+        Filtered list of conversations matching the label
+    """
+    from ohtv.db import get_connection, get_db_path, migrate
+    from ohtv.db.stores import ConversationStore
+    from ohtv.filters import filter_conversations_by_ids
+    
+    # Parse label filter
+    if "=" not in label_filter:
+        console.print(f"[red]Error:[/red] Label filter must be in 'key=value' format, got: {label_filter}")
+        return []
+    
+    key, value = label_filter.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+    
+    if not key or not value:
+        console.print(f"[red]Error:[/red] Label filter must have non-empty key and value: {label_filter}")
+        return []
+    
+    db_path = get_db_path()
+    if not db_path.exists():
+        console.print("[yellow]Warning:[/yellow] Database not initialized. Run 'ohtv db scan' first.")
+        console.print("[dim]Label filtering requires indexed conversations.[/dim]")
+        return []
+    
+    try:
+        with get_connection(config) as conn:
+            migrate(conn)
+            store = ConversationStore(conn)
+            matching = store.list_by_label(key, value)
+            
+            if not matching:
+                console.print(f"[dim]No conversations found with label {key}={value}[/dim]")
+                return []
+            
+            matching_ids = {c.id for c in matching}
+            console.print(f"[dim]Filtering by label {key}={value}: {len(matching_ids)} matches[/dim]")
+            
+            return filter_conversations_by_ids(conversations, matching_ids)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] Failed to filter by label: {e}")
+        return []
 
 
 def _count_uncached_conversations_fast(
@@ -2142,6 +2205,7 @@ def _populate_error_info(
 @click.option("--pr", "pr_filter", help="Filter by PR (URL, owner/repo#N, or repo#N)")
 @click.option("--repo", "repo_filter", help="Filter by repo (URL, owner/repo, or repo name)")
 @click.option("--action", "action_filter", help="Filter by action type (e.g., git-push, pushed, open-pr)")
+@click.option("--label", "-L", "label_filter", help="Filter by label (key=value)")
 @click.option("--no-refs", "hide_refs", is_flag=True, help="Hide git refs (shown by default)")
 @click.option("--idle", "idle_minutes", type=int, default=None, is_flag=False, flag_value=7,
               help="Show Idle column (minutes since last event). Colorized: red if < MINS (default: 7), green if >= MINS")
@@ -2163,6 +2227,7 @@ def list_conversations(
     pr_filter: str | None,
     repo_filter: str | None,
     action_filter: str | None,
+    label_filter: str | None,
     hide_refs: bool,
     idle_minutes: int | None,
     with_errors: bool,
@@ -2184,6 +2249,7 @@ def list_conversations(
         pr_filter=pr_filter,
         repo_filter=repo_filter,
         action_filter=action_filter,
+        label_filter=label_filter,
         include_empty=include_empty,
         initial_show_all=show_all,
         errors_only=errors_only,
@@ -4930,6 +4996,36 @@ def _format_refs_for_summary(outputs: dict | None) -> list[str]:
     return lines
 
 
+def _format_labels_for_summary(labels: dict[str, str] | None) -> str:
+    """Format labels for display in summary table.
+
+    Returns a formatted string like: "project=SDK, status=WIP"
+    Returns empty string if no labels.
+    """
+    if not labels:
+        return ""
+
+    parts = [f"{k}={v}" for k, v in sorted(labels.items())]
+    return "[magenta]Labels:[/magenta] " + ", ".join(parts)
+
+
+def _get_conversation_labels(config: "Config", conv_id: str) -> dict[str, str] | None:
+    """Fetch labels for a conversation from the database."""
+    from ohtv.db import get_connection
+    from ohtv.db.stores import ConversationStore
+
+    # Normalize ID (remove dashes)
+    normalized_id = conv_id.replace("-", "")
+
+    try:
+        with get_connection(config) as conn:
+            store = ConversationStore(conn)
+            conv = store.get(normalized_id)
+            return conv.labels if conv else None
+    except Exception:
+        return None
+
+
 def _print_summary_table(
     results: list[dict],
     total_count: int,
@@ -4954,13 +5050,17 @@ def _print_summary_table(
     # Use display schema if provided, otherwise fall back to default
     schema = display_schema if display_schema and display_schema.columns else get_default_display_schema()
     
-    # Add refs/outputs to results if needed (for default schema with Summary column)
+    # Add refs/outputs and labels to results if needed (for default schema with Summary column)
     if include_outputs:
         for r in results:
             if r.get("outputs"):
                 # Store formatted refs in result for display schema access
                 ref_lines = _format_refs_for_summary(r["outputs"])
                 r["refs_display"] = "\n".join(ref_lines) if ref_lines else ""
+            
+            # Format labels if present
+            if r.get("labels"):
+                r["labels_display"] = _format_labels_for_summary(r.get("labels"))
     
     # Use TableRenderer for schema-based rendering
     renderer = TableRenderer(schema, console=console)
@@ -5058,6 +5158,11 @@ def _format_summary_markdown(results: list[dict], *, include_outputs: bool = Tru
         if include_outputs and r.get("outputs"):
             ref_lines = _format_refs_for_markdown(r["outputs"])
             lines.extend(ref_lines)
+        
+        # Add labels as sub-item if present
+        if r.get("labels"):
+            labels_str = ", ".join(f"{k}={v}" for k, v in sorted(r["labels"].items()))
+            lines.append(f"  - Labels: {labels_str}")
 
     return "\n".join(lines)
 
@@ -7692,6 +7797,9 @@ def _run_batch_objectives_analysis(
                 elif analysis.primary_objectives:
                     display_goal = analysis.primary_objectives[0].description
             
+            # Fetch labels from database
+            labels = _get_conversation_labels(config, conv.id)
+            
             # Build result dict with all analysis fields for display schema rendering
             result_dict = {
                 "id": conv.id,
@@ -7719,6 +7827,8 @@ def _run_batch_objectives_analysis(
                 "summary": analysis.summary,
                 "detail_level": analysis.detail_level,
                 "assess": analysis.assess,
+                # Labels from cloud API
+                "labels": labels,
             }
             return result_dict, None, analysis_result.cost, analysis_result.from_cache
         except (ValueError, RuntimeError) as e:
@@ -7904,6 +8014,9 @@ def _run_batch_objectives_analysis(
                 }
                 if unpushed:
                     item["unpushed_commits"] = sorted(unpushed)
+            # Include labels if present
+            if r.get("labels"):
+                item["labels"] = r["labels"]
             json_results.append(item)
         print(json.dumps(json_results, indent=2))
     elif fmt == "markdown":

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -1992,7 +1992,7 @@ def _filter_by_label(
         return []
     
     try:
-        with get_connection(config) as conn:
+        with get_connection() as conn:
             migrate(conn)
             store = ConversationStore(conn)
             matching = store.list_by_label(key, value)
@@ -5018,7 +5018,7 @@ def _get_conversation_labels(config: "Config", conv_id: str) -> dict[str, str] |
     normalized_id = conv_id.replace("-", "")
 
     try:
-        with get_connection(config) as conn:
+        with get_connection() as conn:
             store = ConversationStore(conn)
             conv = store.get(normalized_id)
             return conv.labels if conv else None
@@ -7456,6 +7456,7 @@ def gen() -> None:
 @click.option("--pr", "pr_filter", help="Filter by PR (URL, owner/repo#N, or repo#N)")
 @click.option("--repo", "repo_filter", help="Filter by repo (URL, owner/repo, or repo name)")
 @click.option("--action", "action_filter", help="Filter by action type (e.g., git-push, pushed, open-pr)")
+@click.option("--label", "-L", "label_filter", help="Filter by label (key=value)")
 @click.option("--reverse", is_flag=True, help="Show oldest first (default: newest first)")
 @click.option(
     "--format", "-F", "fmt",
@@ -7485,6 +7486,7 @@ def gen_objs_cmd(
     pr_filter: str | None,
     repo_filter: str | None,
     action_filter: str | None,
+    label_filter: str | None,
     reverse: bool,
     fmt: str,
     yes: bool,
@@ -7506,6 +7508,7 @@ def gen_objs_cmd(
       ohtv gen objs --day               # Today's conversations
       ohtv gen objs --week              # This week's conversations
       ohtv gen objs --pr repo#42        # Conversations for a PR
+      ohtv gen objs --label team=AI     # Conversations with specific label
       ohtv gen objs --all               # All conversations (no limit)
     
     \b
@@ -7528,14 +7531,14 @@ def gen_objs_cmd(
     # Check if filters are being used (multi-conversation options)
     has_filters = any([
         limit is not None, show_all, offset > 0, since_date, until_date,
-        day_date, week_date, pr_filter, repo_filter, action_filter, reverse
+        day_date, week_date, pr_filter, repo_filter, action_filter, label_filter, reverse
     ])
     
     # Error if both conversation_id and filters are provided
     if conversation_id is not None and has_filters:
         raise click.UsageError(
             "Cannot use filters (--day, --week, --since, --until, --pr, --repo, "
-            "--action, -n, --all, --offset, --reverse) with a specific conversation_id.\n"
+            "--action, --label, -n, --all, --offset, --reverse) with a specific conversation_id.\n"
             "Either analyze a single conversation: ohtv gen objs <conversation_id>\n"
             "Or analyze multiple conversations: ohtv gen objs --day"
         )
@@ -7559,6 +7562,7 @@ def gen_objs_cmd(
             pr_filter=pr_filter,
             repo_filter=repo_filter,
             action_filter=action_filter,
+            label_filter=label_filter,
             reverse=reverse,
             fmt=fmt,
             yes=yes,
@@ -7596,6 +7600,7 @@ def _run_batch_objectives_analysis(
     pr_filter: str | None = None,
     repo_filter: str | None = None,
     action_filter: str | None = None,
+    label_filter: str | None = None,
     reverse: bool = False,
     fmt: str = "table",
     yes: bool = False,
@@ -7622,6 +7627,7 @@ def _run_batch_objectives_analysis(
         pr_filter=pr_filter,
         repo_filter=repo_filter,
         action_filter=action_filter,
+        label_filter=label_filter,
         include_empty=False,  # Summary always excludes empty
         initial_show_all=show_all,
     )

--- a/src/ohtv/db/migrations/015_conversation_labels.py
+++ b/src/ohtv/db/migrations/015_conversation_labels.py
@@ -14,8 +14,10 @@ def upgrade(conn: sqlite3.Connection) -> None:
         ADD COLUMN labels TEXT DEFAULT NULL
     """)
     
-    # Create index for label-based filtering using JSON extraction
-    # This enables queries like: WHERE json_extract(labels, '$.key') = 'value'
+    # Partial index for label presence filtering (labels IS NOT NULL checks).
+    # NOTE: This index does NOT accelerate json_extract() queries because SQLite
+    # cannot use a column index for JSON path extraction. It only helps queries
+    # that filter on labels being non-NULL (e.g., list_with_labels, count_with_labels).
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_conversations_labels
         ON conversations(labels)

--- a/src/ohtv/db/migrations/015_conversation_labels.py
+++ b/src/ohtv/db/migrations/015_conversation_labels.py
@@ -1,0 +1,23 @@
+"""Add labels column for storing cloud-sourced conversation labels.
+
+Labels are stored as a JSON string (dict[str, str]) from the Cloud API's tags field.
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Add labels column to conversations table."""
+    # Add labels column (JSON format: {"key1": "value1", "key2": "value2"})
+    conn.execute("""
+        ALTER TABLE conversations
+        ADD COLUMN labels TEXT DEFAULT NULL
+    """)
+    
+    # Create index for label-based filtering using JSON extraction
+    # This enables queries like: WHERE json_extract(labels, '$.key') = 'value'
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_conversations_labels
+        ON conversations(labels)
+        WHERE labels IS NOT NULL
+    """)

--- a/src/ohtv/db/models/conversation.py
+++ b/src/ohtv/db/models/conversation.py
@@ -20,6 +20,7 @@ class Conversation:
         selected_repository: Repository selected for this conversation
         source: Source identifier ('local', 'cloud', or custom name)
         summary: Brief summary of conversation goal/objective (for RAG)
+        labels: Cloud-sourced labels/tags (key=value pairs from API)
     """
     id: str
     location: str
@@ -32,3 +33,4 @@ class Conversation:
     selected_repository: str | None = None
     source: str | None = None
     summary: str | None = None
+    labels: dict[str, str] | None = None

--- a/src/ohtv/db/scanner.py
+++ b/src/ohtv/db/scanner.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Callable
 import logging
 
-from ohtv.config import Config, get_openhands_dir
+from ohtv.config import Config, get_openhands_dir, get_manifest_path
 from ohtv.db.models import Conversation
 from ohtv.db.stores import ConversationStore
 from ohtv.db.utils import generate_unique_source_names
@@ -64,15 +64,40 @@ def discover_conversations(base_dir: Path, source: str) -> list[tuple[str, Path,
     return conversations
 
 
-def extract_metadata(conv_path: Path, source: str) -> dict:
+def load_manifest_labels() -> dict[str, dict[str, str]]:
+    """Load labels from sync manifest.
+    
+    Returns:
+        Dict mapping conversation ID to labels dict.
+        Only includes conversations that have labels.
+    """
+    manifest_path = get_manifest_path()
+    if not manifest_path.exists():
+        return {}
+    
+    try:
+        data = json.loads(manifest_path.read_text())
+        conversations = data.get("conversations", {})
+        labels_map = {}
+        for conv_id, conv_data in conversations.items():
+            labels = conv_data.get("labels")
+            if labels and isinstance(labels, dict) and len(labels) > 0:
+                labels_map[conv_id] = labels
+        return labels_map
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def extract_metadata(conv_path: Path, source: str, labels_map: dict[str, dict[str, str]] | None = None) -> dict:
     """Extract metadata from a conversation directory.
     
     Args:
         conv_path: Path to conversation directory
         source: Source identifier ('local' or 'cloud')
+        labels_map: Optional pre-loaded labels from manifest (keyed by conversation ID)
     
     Returns:
-        Dict with title, created_at, updated_at, selected_repository
+        Dict with title, created_at, updated_at, selected_repository, labels
     """
     timestamps_are_utc = source != "local"
     
@@ -112,11 +137,18 @@ def extract_metadata(conv_path: Path, source: str) -> dict:
     if not title:
         title = _get_title_from_first_user_message(conv_path)
     
+    # Get labels from manifest (for cloud conversations)
+    labels = None
+    if labels_map:
+        conv_id = conv_path.name
+        labels = labels_map.get(conv_id)
+    
     return {
         "title": title,
         "created_at": created_at,
         "updated_at": updated_at,
         "selected_repository": selected_repository,
+        "labels": labels,
     }
 
 
@@ -229,6 +261,9 @@ def scan_conversations(
     store = ConversationStore(conn)
     openhands_dir = get_openhands_dir()
     
+    # Load labels from manifest (for cloud conversations)
+    labels_map = load_manifest_labels()
+    
     # Discover from both local CLI and synced cloud locations
     local_dir = openhands_dir / "conversations"
     cloud_dir = openhands_dir / "cloud" / "conversations"
@@ -270,7 +305,7 @@ def scan_conversations(
         
         if existing is None:
             # New conversation - extract metadata
-            metadata = extract_metadata(conv_path, source)
+            metadata = extract_metadata(conv_path, source, labels_map)
             store.upsert(Conversation(
                 id=conv_id,
                 location=str(conv_path),
@@ -281,11 +316,12 @@ def scan_conversations(
                 updated_at=metadata["updated_at"],
                 selected_repository=metadata["selected_repository"],
                 source=source,
+                labels=metadata.get("labels"),
             ))
             new_count += 1
         elif force or _has_changed(existing, current_mtime, current_count):
             # Changed or forced update - re-extract metadata
-            metadata = extract_metadata(conv_path, source)
+            metadata = extract_metadata(conv_path, source, labels_map)
             store.upsert(Conversation(
                 id=conv_id,
                 location=str(conv_path),
@@ -297,6 +333,7 @@ def scan_conversations(
                 updated_at=metadata["updated_at"],
                 selected_repository=metadata["selected_repository"],
                 source=source,
+                labels=metadata.get("labels"),
             ))
             updated_count += 1
         else:
@@ -350,6 +387,9 @@ def get_changed_conversations(conn: sqlite3.Connection) -> list[Conversation]:
     store = ConversationStore(conn)
     openhands_dir = get_openhands_dir()
     
+    # Load labels from manifest (for cloud conversations)
+    labels_map = load_manifest_labels()
+    
     local_dir = openhands_dir / "conversations"
     cloud_dir = openhands_dir / "cloud" / "conversations"
     
@@ -368,7 +408,7 @@ def get_changed_conversations(conn: sqlite3.Connection) -> list[Conversation]:
         existing = store.get(conv_id)
         
         if existing is None or _has_changed(existing, current_mtime, current_count):
-            metadata = extract_metadata(conv_path, source)
+            metadata = extract_metadata(conv_path, source, labels_map)
             changed.append(Conversation(
                 id=conv_id,
                 location=str(conv_path),
@@ -379,6 +419,7 @@ def get_changed_conversations(conn: sqlite3.Connection) -> list[Conversation]:
                 updated_at=metadata["updated_at"],
                 selected_repository=metadata["selected_repository"],
                 source=source,
+                labels=metadata.get("labels"),
             ))
     
     return changed

--- a/src/ohtv/db/scanner.py
+++ b/src/ohtv/db/scanner.py
@@ -69,7 +69,8 @@ def load_manifest_labels() -> dict[str, dict[str, str]]:
     
     Returns:
         Dict mapping conversation ID to labels dict.
-        Only includes conversations that have labels.
+        Includes all conversations (empty dict for those without labels)
+        so that label removal can propagate from cloud to database.
     """
     manifest_path = get_manifest_path()
     if not manifest_path.exists():
@@ -81,8 +82,9 @@ def load_manifest_labels() -> dict[str, dict[str, str]]:
         labels_map = {}
         for conv_id, conv_data in conversations.items():
             labels = conv_data.get("labels")
-            if labels and isinstance(labels, dict) and len(labels) > 0:
-                labels_map[conv_id] = labels
+            # Include all conversations, even those with null/empty labels
+            # This ensures label removal propagates from cloud to database
+            labels_map[conv_id] = labels if (labels and isinstance(labels, dict)) else {}
         return labels_map
     except (json.JSONDecodeError, OSError):
         return {}
@@ -138,10 +140,14 @@ def extract_metadata(conv_path: Path, source: str, labels_map: dict[str, dict[st
         title = _get_title_from_first_user_message(conv_path)
     
     # Get labels from manifest (for cloud conversations)
+    # Empty dict {} means labels were explicitly removed; convert to None for storage
     labels = None
     if labels_map:
         conv_id = conv_path.name
-        labels = labels_map.get(conv_id)
+        manifest_labels = labels_map.get(conv_id)
+        # {} from manifest means no labels (explicit removal), store as None
+        # dict with content means real labels
+        labels = manifest_labels if manifest_labels else None
     
     return {
         "title": title,

--- a/src/ohtv/db/stores/conversation_store.py
+++ b/src/ohtv/db/stores/conversation_store.py
@@ -1,5 +1,6 @@
 """Data store for conversations."""
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 
@@ -12,7 +13,7 @@ class ConversationStore:
     # All columns for SELECT queries
     _ALL_COLUMNS = """
         id, location, registered_at, events_mtime, event_count,
-        title, created_at, updated_at, selected_repository, source, summary
+        title, created_at, updated_at, selected_repository, source, summary, labels
     """
     
     def __init__(self, conn: sqlite3.Connection):
@@ -39,6 +40,15 @@ class ConversationStore:
         except (IndexError, KeyError):
             pass
         
+        # Handle labels column gracefully - may not exist in older databases
+        labels = None
+        try:
+            labels_json = row["labels"]
+            if labels_json:
+                labels = json.loads(labels_json)
+        except (IndexError, KeyError, json.JSONDecodeError):
+            pass
+        
         return Conversation(
             id=row["id"],
             location=row["location"],
@@ -51,6 +61,7 @@ class ConversationStore:
             selected_repository=row["selected_repository"],
             source=row["source"],
             summary=summary,
+            labels=labels,
         )
     
     def upsert(self, conversation: Conversation) -> None:
@@ -63,14 +74,15 @@ class ConversationStore:
         registered_at_str = registered_at.isoformat() if registered_at else None
         created_at_str = conversation.created_at.isoformat() if conversation.created_at else None
         updated_at_str = conversation.updated_at.isoformat() if conversation.updated_at else None
+        labels_json = json.dumps(conversation.labels) if conversation.labels else None
         
         self.conn.execute(
             """
             INSERT INTO conversations (
                 id, location, registered_at, events_mtime, event_count,
-                title, created_at, updated_at, selected_repository, source, summary
+                title, created_at, updated_at, selected_repository, source, summary, labels
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 location = excluded.location,
                 events_mtime = excluded.events_mtime,
@@ -80,7 +92,8 @@ class ConversationStore:
                 updated_at = excluded.updated_at,
                 selected_repository = excluded.selected_repository,
                 source = excluded.source,
-                summary = COALESCE(excluded.summary, conversations.summary)
+                summary = COALESCE(excluded.summary, conversations.summary),
+                labels = COALESCE(excluded.labels, conversations.labels)
             """,
             (
                 conversation.id,
@@ -94,6 +107,7 @@ class ConversationStore:
                 conversation.selected_repository,
                 conversation.source,
                 conversation.summary,
+                labels_json,
             ),
         )
     
@@ -216,3 +230,47 @@ class ConversationStore:
             f"SELECT {self._ALL_COLUMNS} FROM conversations WHERE summary IS NULL"
         )
         return [self._row_to_conversation(row) for row in cursor.fetchall()]
+    
+    def list_by_label(self, key: str, value: str) -> list[Conversation]:
+        """List conversations with a specific label key=value.
+        
+        Args:
+            key: Label key to filter by
+            value: Label value to match
+            
+        Returns:
+            List of matching conversations, ordered by created_at descending
+        """
+        cursor = self.conn.execute(
+            f"""
+            SELECT {self._ALL_COLUMNS}
+            FROM conversations
+            WHERE json_extract(labels, ?) = ?
+            ORDER BY created_at DESC
+            """,
+            (f"$.{key}", value),
+        )
+        return [self._row_to_conversation(row) for row in cursor.fetchall()]
+    
+    def list_with_labels(self) -> list[Conversation]:
+        """List conversations that have labels.
+        
+        Returns:
+            List of conversations with labels, ordered by created_at descending
+        """
+        cursor = self.conn.execute(
+            f"""
+            SELECT {self._ALL_COLUMNS}
+            FROM conversations
+            WHERE labels IS NOT NULL AND labels != '{{}}'
+            ORDER BY created_at DESC
+            """
+        )
+        return [self._row_to_conversation(row) for row in cursor.fetchall()]
+    
+    def count_with_labels(self) -> int:
+        """Return count of conversations that have labels populated."""
+        cursor = self.conn.execute(
+            "SELECT COUNT(*) FROM conversations WHERE labels IS NOT NULL AND labels != '{}'"
+        )
+        return cursor.fetchone()[0]

--- a/src/ohtv/db/stores/conversation_store.py
+++ b/src/ohtv/db/stores/conversation_store.py
@@ -93,7 +93,7 @@ class ConversationStore:
                 selected_repository = excluded.selected_repository,
                 source = excluded.source,
                 summary = COALESCE(excluded.summary, conversations.summary),
-                labels = COALESCE(excluded.labels, conversations.labels)
+                labels = excluded.labels
             """,
             (
                 conversation.id,

--- a/src/ohtv/db/stores/conversation_store.py
+++ b/src/ohtv/db/stores/conversation_store.py
@@ -241,6 +241,8 @@ class ConversationStore:
         Returns:
             List of matching conversations, ordered by created_at descending
         """
+        # Quote the key in JSON path to handle special characters (dots, brackets)
+        # e.g., key "env.type" becomes '$."env.type"' instead of '$.env.type'
         cursor = self.conn.execute(
             f"""
             SELECT {self._ALL_COLUMNS}
@@ -248,7 +250,7 @@ class ConversationStore:
             WHERE json_extract(labels, ?) = ?
             ORDER BY created_at DESC
             """,
-            (f"$.{key}", value),
+            (f'$."{key}"', value),
         )
         return [self._row_to_conversation(row) for row in cursor.fetchall()]
     

--- a/src/ohtv/prompts/renderer.py
+++ b/src/ohtv/prompts/renderer.py
@@ -196,7 +196,7 @@ def get_default_display_schema() -> DisplaySchema:
     - ID + source on second line
     - Date + time on second line  
     - Duration + step count
-    - Summary + refs
+    - Summary + refs + labels
     
     Returns:
         DisplaySchema with ID, Date, Duration, and Summary columns
@@ -221,5 +221,6 @@ def get_default_display_schema() -> DisplaySchema:
         ColumnDef(name="Summary", fields=[
             FieldRef(field_name="goal"),
             FieldRef(field_name="refs_display"),
+            FieldRef(field_name="labels_display"),
         ], combine="newline"),
     ])

--- a/src/ohtv/sources/base.py
+++ b/src/ohtv/sources/base.py
@@ -22,6 +22,8 @@ class ConversationInfo:
     error_types: dict[str, int] | None = None  # ErrorType name -> count
     has_terminal_error: bool | None = None
     execution_status: str | None = None  # From base_state.json
+    # Cloud-sourced labels (key=value pairs from API tags field)
+    labels: dict[str, str] | None = None
 
     @property
     def duration(self) -> timedelta | None:

--- a/src/ohtv/sources/cloud.py
+++ b/src/ohtv/sources/cloud.py
@@ -201,12 +201,17 @@ class RateLimitExceededError(Exception):
 
 def parse_conversation_info(data: dict) -> ConversationInfo:
     """Parse API response into ConversationInfo."""
+    # Parse tags - API returns dict[str, str] or empty dict
+    tags = data.get("tags")
+    labels = tags if tags and isinstance(tags, dict) else None
+    
     return ConversationInfo(
         id=data["id"],
         title=data.get("title"),
         created_at=_parse_datetime(data.get("created_at")),
         updated_at=_parse_datetime(data.get("updated_at")),
         selected_repository=data.get("selected_repository"),
+        labels=labels,
     )
 
 

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -515,11 +515,16 @@ class SyncManager:
         conv_dir: Path,
     ) -> None:
         """Update the manifest with new conversation info."""
+        # Extract labels/tags from API response (may be empty dict or None)
+        tags = conv.get("tags")
+        labels = tags if tags and isinstance(tags, dict) and len(tags) > 0 else None
+        
         self.manifest.conversations[conv_id] = {
             "title": conv.get("title"),
             "updated_at": cloud_updated_at,
             "event_count": count_events(conv_dir),
             "downloaded_at": _format_datetime(datetime.now(timezone.utc)),
+            "labels": labels,
         }
 
     def _update_result(self, result: SyncResult, action: str) -> None:

--- a/tests/unit/prompts/test_formatters.py
+++ b/tests/unit/prompts/test_formatters.py
@@ -290,8 +290,8 @@ class TestDefaultDisplaySchema:
         assert field_refs[1].format == "step_count"
         assert duration_col.combine == "newline"
     
-    def test_summary_column_has_goal_and_refs(self):
-        """Test Summary column has goal and refs_display fields."""
+    def test_summary_column_has_goal_refs_and_labels(self):
+        """Test Summary column has goal, refs_display, and labels_display fields."""
         from ohtv.prompts.renderer import get_default_display_schema
         
         schema = get_default_display_schema()
@@ -299,9 +299,10 @@ class TestDefaultDisplaySchema:
         
         assert summary_col is not None
         field_refs = summary_col.get_field_refs()
-        assert len(field_refs) == 2
+        assert len(field_refs) == 3
         assert field_refs[0].field_name == "goal"
         assert field_refs[1].field_name == "refs_display"
+        assert field_refs[2].field_name == "labels_display"
     
     def test_table_renderer_with_new_schema(self):
         """Test TableRenderer can render with the new schema."""

--- a/tests/unit/test_labels.py
+++ b/tests/unit/test_labels.py
@@ -1,0 +1,297 @@
+"""Unit tests for conversation labels functionality."""
+
+import json
+import pytest
+import sqlite3
+from datetime import datetime, timezone
+
+from ohtv.cli import _format_labels_for_summary
+from ohtv.db.models import Conversation
+from ohtv.db.stores import ConversationStore
+from ohtv.sources.base import ConversationInfo
+from ohtv.sources.cloud import parse_conversation_info
+
+
+class TestFormatLabelsForSummary:
+    """Tests for _format_labels_for_summary function."""
+
+    def test_none_labels_returns_empty(self):
+        """None labels should return empty string."""
+        assert _format_labels_for_summary(None) == ""
+
+    def test_empty_labels_returns_empty(self):
+        """Empty dict should return empty string."""
+        assert _format_labels_for_summary({}) == ""
+
+    def test_single_label(self):
+        """Single label should be formatted correctly."""
+        labels = {"project": "SDK"}
+        result = _format_labels_for_summary(labels)
+        assert "project=SDK" in result
+        assert "[magenta]Labels:[/magenta]" in result
+
+    def test_multiple_labels_sorted(self):
+        """Multiple labels should be sorted alphabetically."""
+        labels = {"status": "WIP", "project": "SDK", "team": "AI"}
+        result = _format_labels_for_summary(labels)
+        # Check all labels are present
+        assert "project=SDK" in result
+        assert "status=WIP" in result
+        assert "team=AI" in result
+        # Labels should appear in sorted order
+        assert (
+            result.index("project=SDK")
+            < result.index("status=WIP")
+            < result.index("team=AI")
+        )
+
+    def test_label_with_special_characters(self):
+        """Labels with special characters should be handled."""
+        labels = {"env": "prod-1", "version": "2.0.0"}
+        result = _format_labels_for_summary(labels)
+        assert "env=prod-1" in result
+        assert "version=2.0.0" in result
+
+
+class TestParseConversationInfo:
+    """Tests for parsing labels from cloud API response."""
+
+    def test_parse_with_no_tags(self):
+        """Conversation without tags should have None labels."""
+        data = {
+            "id": "abc123",
+            "title": "Test conversation",
+            "created_at": "2026-05-16T10:00:00Z",
+            "updated_at": "2026-05-16T11:00:00Z",
+        }
+        conv = parse_conversation_info(data)
+        assert conv.labels is None
+
+    def test_parse_with_empty_tags(self):
+        """Conversation with empty tags dict should have None labels."""
+        data = {
+            "id": "abc123",
+            "title": "Test conversation",
+            "created_at": "2026-05-16T10:00:00Z",
+            "updated_at": "2026-05-16T11:00:00Z",
+            "tags": {},
+        }
+        conv = parse_conversation_info(data)
+        assert conv.labels is None
+
+    def test_parse_with_tags(self):
+        """Conversation with tags should have labels populated."""
+        data = {
+            "id": "abc123",
+            "title": "Test conversation",
+            "created_at": "2026-05-16T10:00:00Z",
+            "updated_at": "2026-05-16T11:00:00Z",
+            "tags": {"project": "SDK", "status": "WIP"},
+        }
+        conv = parse_conversation_info(data)
+        assert conv.labels == {"project": "SDK", "status": "WIP"}
+
+    def test_parse_with_non_dict_tags(self):
+        """Non-dict tags field should result in None labels."""
+        data = {
+            "id": "abc123",
+            "title": "Test conversation",
+            "created_at": "2026-05-16T10:00:00Z",
+            "updated_at": "2026-05-16T11:00:00Z",
+            "tags": "invalid",  # Should be dict
+        }
+        conv = parse_conversation_info(data)
+        assert conv.labels is None
+
+
+class TestConversationStoreLabels:
+    """Tests for ConversationStore label operations."""
+
+    @pytest.fixture
+    def db_conn(self):
+        """Create an in-memory database with schema."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+
+        # Create conversations table with labels column
+        conn.execute("""
+            CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                location TEXT NOT NULL,
+                registered_at TEXT,
+                events_mtime REAL,
+                event_count INTEGER DEFAULT 0,
+                title TEXT,
+                created_at TEXT,
+                updated_at TEXT,
+                selected_repository TEXT,
+                source TEXT,
+                summary TEXT,
+                labels TEXT
+            )
+        """)
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_upsert_conversation_with_labels(self, db_conn):
+        """Labels should be stored as JSON when upserting."""
+        store = ConversationStore(db_conn)
+
+        conv = Conversation(
+            id="abc123",
+            location="/path/to/conv",
+            labels={"project": "SDK", "status": "WIP"},
+        )
+        store.upsert(conv)
+
+        # Verify labels stored as JSON
+        cursor = db_conn.execute("SELECT labels FROM conversations WHERE id = 'abc123'")
+        row = cursor.fetchone()
+        labels_json = row["labels"]
+        assert json.loads(labels_json) == {"project": "SDK", "status": "WIP"}
+
+    def test_get_conversation_with_labels(self, db_conn):
+        """Labels should be parsed from JSON when getting."""
+        store = ConversationStore(db_conn)
+
+        # Insert directly with JSON
+        db_conn.execute(
+            "INSERT INTO conversations (id, location, labels) VALUES (?, ?, ?)",
+            ("abc123", "/path/to/conv", '{"project": "SDK"}'),
+        )
+        db_conn.commit()
+
+        conv = store.get("abc123")
+        assert conv is not None
+        assert conv.labels == {"project": "SDK"}
+
+    def test_list_by_label(self, db_conn):
+        """list_by_label should find conversations with matching label."""
+        store = ConversationStore(db_conn)
+
+        # Insert multiple conversations with different labels
+        store.upsert(
+            Conversation(
+                id="conv1",
+                location="/path/1",
+                labels={"project": "SDK", "status": "WIP"},
+                created_at=datetime(2026, 5, 16, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+        store.upsert(
+            Conversation(
+                id="conv2",
+                location="/path/2",
+                labels={"project": "CLI", "status": "WIP"},
+                created_at=datetime(2026, 5, 16, 11, 0, tzinfo=timezone.utc),
+            )
+        )
+        store.upsert(
+            Conversation(
+                id="conv3",
+                location="/path/3",
+                labels={"project": "SDK", "status": "done"},
+                created_at=datetime(2026, 5, 16, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+
+        # Find by project=SDK
+        matches = store.list_by_label("project", "SDK")
+        assert len(matches) == 2
+        ids = {c.id for c in matches}
+        assert ids == {"conv1", "conv3"}
+
+        # Find by status=WIP
+        matches = store.list_by_label("status", "WIP")
+        assert len(matches) == 2
+        ids = {c.id for c in matches}
+        assert ids == {"conv1", "conv2"}
+
+    def test_list_by_label_no_match(self, db_conn):
+        """list_by_label should return empty list when no matches."""
+        store = ConversationStore(db_conn)
+
+        store.upsert(
+            Conversation(
+                id="conv1",
+                location="/path/1",
+                labels={"project": "SDK"},
+            )
+        )
+
+        matches = store.list_by_label("project", "CLI")
+        assert matches == []
+
+    def test_count_with_labels(self, db_conn):
+        """count_with_labels should count only conversations with labels."""
+        store = ConversationStore(db_conn)
+
+        store.upsert(Conversation(id="conv1", location="/path/1", labels={"k": "v"}))
+        store.upsert(Conversation(id="conv2", location="/path/2", labels=None))
+        store.upsert(Conversation(id="conv3", location="/path/3", labels={"k2": "v2"}))
+
+        assert store.count_with_labels() == 2
+
+
+class TestConversationModel:
+    """Tests for Conversation model with labels."""
+
+    def test_conversation_has_labels_field(self):
+        """Conversation dataclass should have labels field."""
+        conv = Conversation(
+            id="abc123",
+            location="/path/to/conv",
+            labels={"project": "SDK"},
+        )
+        assert conv.labels == {"project": "SDK"}
+
+    def test_conversation_labels_default_none(self):
+        """Labels should default to None."""
+        conv = Conversation(id="abc123", location="/path/to/conv")
+        assert conv.labels is None
+
+
+class TestConversationInfoModel:
+    """Tests for ConversationInfo model with labels."""
+
+    def test_conversation_info_has_labels_field(self):
+        """ConversationInfo dataclass should have labels field."""
+        conv = ConversationInfo(
+            id="abc123",
+            title="Test",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            labels={"project": "SDK"},
+        )
+        assert conv.labels == {"project": "SDK"}
+
+    def test_conversation_info_labels_default_none(self):
+        """Labels should default to None."""
+        conv = ConversationInfo(
+            id="abc123",
+            title="Test",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        assert conv.labels is None
+
+
+class TestLabelFilterParsing:
+    """Tests for label filter string parsing."""
+
+    def test_valid_label_filter(self):
+        """Valid key=value format should parse correctly."""
+        # This is implicitly tested by _filter_by_label,
+        # but we can verify the logic
+        filter_str = "project=SDK"
+        key, value = filter_str.split("=", 1)
+        assert key == "project"
+        assert value == "SDK"
+
+    def test_label_with_equals_in_value(self):
+        """Value containing = should be handled correctly."""
+        filter_str = "config=a=b"
+        key, value = filter_str.split("=", 1)
+        assert key == "config"
+        assert value == "a=b"  # Only split on first =

--- a/tests/unit/test_labels.py
+++ b/tests/unit/test_labels.py
@@ -208,6 +208,29 @@ class TestConversationStoreLabels:
         ids = {c.id for c in matches}
         assert ids == {"conv1", "conv2"}
 
+    def test_list_by_label_with_dots_in_key(self, db_conn):
+        """Label keys with dots should be matched correctly."""
+        store = ConversationStore(db_conn)
+
+        store.upsert(
+            Conversation(
+                id="conv1",
+                location="/path/1",
+                labels={"env.type": "prod", "feature[new]": "enabled"},
+                created_at=datetime(2026, 5, 16, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+
+        # Should find conversation with dotted key
+        matches = store.list_by_label("env.type", "prod")
+        assert len(matches) == 1
+        assert matches[0].id == "conv1"
+
+        # Should find conversation with bracket key
+        matches = store.list_by_label("feature[new]", "enabled")
+        assert len(matches) == 1
+        assert matches[0].id == "conv1"
+
     def test_list_by_label_no_match(self, db_conn):
         """list_by_label should return empty list when no matches."""
         store = ConversationStore(db_conn)

--- a/tests/unit/test_labels.py
+++ b/tests/unit/test_labels.py
@@ -277,6 +277,85 @@ class TestConversationInfoModel:
         assert conv.labels is None
 
 
+class TestLabelRemoval:
+    """Tests for label removal synchronization."""
+
+    @pytest.fixture
+    def db_conn(self):
+        """Create an in-memory database with schema."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+
+        conn.execute("""
+            CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                location TEXT NOT NULL,
+                registered_at TEXT,
+                events_mtime REAL,
+                event_count INTEGER DEFAULT 0,
+                title TEXT,
+                created_at TEXT,
+                updated_at TEXT,
+                selected_repository TEXT,
+                source TEXT,
+                summary TEXT,
+                labels TEXT
+            )
+        """)
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_upsert_removes_labels_when_set_to_none(self, db_conn):
+        """Upserting with labels=None should remove existing labels."""
+        store = ConversationStore(db_conn)
+
+        # Insert with labels
+        store.upsert(Conversation(
+            id="conv1",
+            location="/path/1",
+            labels={"project": "SDK"},
+        ))
+
+        # Verify labels exist
+        conv = store.get("conv1")
+        assert conv.labels == {"project": "SDK"}
+
+        # Update with labels=None (simulating removal in cloud)
+        store.upsert(Conversation(
+            id="conv1",
+            location="/path/1",
+            labels=None,
+        ))
+
+        # Labels should be removed
+        conv = store.get("conv1")
+        assert conv.labels is None
+
+    def test_upsert_replaces_labels_completely(self, db_conn):
+        """Upserting should replace labels, not merge them."""
+        store = ConversationStore(db_conn)
+
+        # Insert with multiple labels
+        store.upsert(Conversation(
+            id="conv1",
+            location="/path/1",
+            labels={"project": "SDK", "status": "WIP"},
+        ))
+
+        # Update with different labels
+        store.upsert(Conversation(
+            id="conv1",
+            location="/path/1",
+            labels={"team": "AI"},
+        ))
+
+        # Labels should be completely replaced
+        conv = store.get("conv1")
+        assert conv.labels == {"team": "AI"}
+        assert "project" not in conv.labels
+
+
 class TestLabelFilterParsing:
     """Tests for label filter string parsing."""
 


### PR DESCRIPTION
## Summary

Adds support for displaying conversation labels/tags (from OpenHands Cloud) in the `gen objs` command output, following the same pattern as refs (repos, PRs, issues).

Fixes #53

## Changes

### Data Model & Storage
- **Migration 015**: Add `labels` column to `conversations` table (JSON format)
- **Conversation model**: Add `labels: dict[str, str] | None` field
- **ConversationStore**: Handle JSON serialization/deserialization of labels
- **ConversationInfo**: Add labels field to the base source model

### Data Ingestion
- **cloud.py**: Parse `tags` field from Cloud API response as labels
- **sync.py**: Store labels in manifest during sync
- **scanner.py**: Load labels from manifest during database scan (`load_manifest_labels()`)

### Display Formatting
- **CLI**: Add `_format_labels_for_summary()` - formats labels as `key=value, key2=value2`
- **CLI**: Add `_get_conversation_labels()` - fetches labels from database
- **Summary table**: Include `labels_display` in output (purple text to match refs)
- **JSON output**: Include labels in JSON format
- **Markdown output**: Include labels section in markdown format
- **Display schema**: Add `labels_display` to default Summary column

### Filtering
- **CLI**: Add `--label`/`-L` filter option to `list` command
- **CLI**: Add `_filter_by_label()` function with `key=value` parsing

## Testing

Added 20 unit tests covering:
- Label formatting (empty, single, multiple, special characters)
- Cloud API parsing (with/without tags)
- Database storage and retrieval
- Label filtering
- Model fields

All 1113 tests pass.

## Example Output

```
│ b91a3b9 │ 2026-05-14 │ Investigate conversation renaming...                  │
│         │            │                                                        │
│         │            │ Repos: All-Hands-AI/OpenHands [cloned, pushed]         │
│         │            │ PRs: OpenHands/OpenHands/pull/14420 [created, viewed]  │
│         │            │ Labels: project=SDK, status=WIP                        │
```

## Checklist

- [x] Labels displayed in `gen objs` table output when present
- [x] `labels_display` field available for display schema rendering
- [x] Labels stored in database `conversations` table as JSON column
- [x] Labels parsed from cloud API `tags` field during sync
- [x] `--label key=value` filter option on `ohtv list` command
- [x] JSON output format includes labels
- [x] Markdown output format includes labels
- [x] Labels shown in purple formatting (matching refs)

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ddcd0376-cc80-459c-8604-ce573d7abd42)