### PR TITLE
Add database schema for contribution tracking

### DIFF
--- a/src/ohtv/db/migrations/016_contributions.py
+++ b/src/ohtv/db/migrations/016_contributions.py
@@ -28,13 +28,13 @@ def upgrade(conn: sqlite3.Connection) -> None:
             pr_number INTEGER,
             commit_range TEXT,
             branch TEXT,
-            status TEXT NOT NULL DEFAULT 'pending',
+            status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'fetched', 'merged', 'closed')),
             merged_at TEXT,
             lines_added INTEGER,
             lines_removed INTEGER,
             files_changed INTEGER,
             fetched_at TEXT,
-            FOREIGN KEY (repo_id) REFERENCES repositories(id),
+            FOREIGN KEY (repo_id) REFERENCES repositories(id) ON DELETE CASCADE,
             -- Enforce that PRs have pr_number and direct_pushes have commit_range
             CHECK (
                 (change_type = 'pr' AND pr_number IS NOT NULL) OR
@@ -58,8 +58,8 @@ def upgrade(conn: sqlite3.Connection) -> None:
             conversation_id TEXT NOT NULL,
             change_ref_id INTEGER NOT NULL,
             contribution_type TEXT NOT NULL CHECK(contribution_type IN ('created', 'pushed', 'merged')),
-            FOREIGN KEY (conversation_id) REFERENCES conversations(id),
-            FOREIGN KEY (change_ref_id) REFERENCES change_refs(id),
+            FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+            FOREIGN KEY (change_ref_id) REFERENCES change_refs(id) ON DELETE CASCADE,
             UNIQUE (conversation_id, change_ref_id, contribution_type)
         )
     """)
@@ -76,7 +76,7 @@ def upgrade(conn: sqlite3.Connection) -> None:
             followup_message_count INTEGER NOT NULL DEFAULT 0,
             processed_at TEXT NOT NULL,
             event_count INTEGER NOT NULL,
-            FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+            FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
         )
     """)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_human_input_source ON conversation_human_input(initial_prompt_source)")

--- a/src/ohtv/db/migrations/016_contributions.py
+++ b/src/ohtv/db/migrations/016_contributions.py
@@ -1,0 +1,70 @@
+"""Database schema for contribution tracking.
+
+Creates three tables for tracking PR/push contributions and human input metrics:
+
+- change_refs: Tracks PRs and direct pushes to main (repo_id, change_type, pr_number, etc.)
+- conversation_contributions: Links conversations to changes they contributed to
+- conversation_human_input: Stores human word/message counts per conversation
+
+These tables enable metrics collection for understanding contribution patterns
+and human involvement in AI-assisted development workflows.
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Create contribution tracking tables."""
+
+    # change_refs: Tracks PRs and direct pushes to main
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS change_refs (
+            id INTEGER PRIMARY KEY,
+            repo_id INTEGER NOT NULL,
+            change_type TEXT NOT NULL CHECK(change_type IN ('pr', 'direct_push')),
+            pr_number INTEGER,
+            commit_range TEXT,
+            branch TEXT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            merged_at TEXT,
+            lines_added INTEGER,
+            lines_removed INTEGER,
+            files_changed INTEGER,
+            fetched_at TEXT,
+            FOREIGN KEY (repo_id) REFERENCES repositories(id),
+            UNIQUE (repo_id, change_type, pr_number, commit_range)
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_change_refs_repo ON change_refs(repo_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_change_refs_type ON change_refs(change_type)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_change_refs_status ON change_refs(status)")
+
+    # conversation_contributions: Links conversations to changes they contributed to
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS conversation_contributions (
+            id INTEGER PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            change_ref_id INTEGER NOT NULL,
+            contribution_type TEXT NOT NULL CHECK(contribution_type IN ('created', 'pushed', 'merged')),
+            FOREIGN KEY (conversation_id) REFERENCES conversations(id),
+            FOREIGN KEY (change_ref_id) REFERENCES change_refs(id),
+            UNIQUE (conversation_id, change_ref_id, contribution_type)
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_conv_contributions_conv ON conversation_contributions(conversation_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_conv_contributions_change ON conversation_contributions(change_ref_id)")
+
+    # conversation_human_input: Stores human word/message counts per conversation
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS conversation_human_input (
+            conversation_id TEXT PRIMARY KEY,
+            initial_prompt_words INTEGER NOT NULL DEFAULT 0,
+            initial_prompt_source TEXT NOT NULL DEFAULT 'unknown' CHECK(initial_prompt_source IN ('human', 'automation', 'unknown')),
+            followup_word_count INTEGER NOT NULL DEFAULT 0,
+            followup_message_count INTEGER NOT NULL DEFAULT 0,
+            processed_at TEXT NOT NULL,
+            event_count INTEGER NOT NULL,
+            FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+        )
+    """)
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_human_input_source ON conversation_human_input(initial_prompt_source)")

--- a/src/ohtv/db/migrations/016_contributions.py
+++ b/src/ohtv/db/migrations/016_contributions.py
@@ -17,6 +17,9 @@ def upgrade(conn: sqlite3.Connection) -> None:
     """Create contribution tracking tables."""
 
     # change_refs: Tracks PRs and direct pushes to main
+    # Note: We use separate unique indexes instead of a composite unique constraint
+    # because SQLite treats NULL as distinct in unique constraints, which would
+    # allow duplicate entries when pr_number or commit_range is NULL.
     conn.execute("""
         CREATE TABLE IF NOT EXISTS change_refs (
             id INTEGER PRIMARY KEY,
@@ -32,9 +35,18 @@ def upgrade(conn: sqlite3.Connection) -> None:
             files_changed INTEGER,
             fetched_at TEXT,
             FOREIGN KEY (repo_id) REFERENCES repositories(id),
-            UNIQUE (repo_id, change_type, pr_number, commit_range)
+            -- Enforce that PRs have pr_number and direct_pushes have commit_range
+            CHECK (
+                (change_type = 'pr' AND pr_number IS NOT NULL) OR
+                (change_type = 'direct_push' AND commit_range IS NOT NULL)
+            )
         )
     """)
+    # Separate unique indexes to properly prevent duplicates:
+    # - PRs are unique by repo_id + pr_number
+    # - Direct pushes are unique by repo_id + commit_range
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_change_refs_pr_unique ON change_refs(repo_id, pr_number) WHERE change_type = 'pr'")
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_change_refs_push_unique ON change_refs(repo_id, commit_range) WHERE change_type = 'direct_push'")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_change_refs_repo ON change_refs(repo_id)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_change_refs_type ON change_refs(change_type)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_change_refs_status ON change_refs(status)")

--- a/tests/unit/db/test_contributions_migration.py
+++ b/tests/unit/db/test_contributions_migration.py
@@ -1,0 +1,666 @@
+"""Unit tests for contribution tracking migration (016_contributions.py).
+
+Tests that:
+- All three tables are created with correct schema
+- Foreign key constraints are enforced
+- Unique constraints prevent duplicates
+- CHECK constraints validate data
+- Migration is idempotent
+"""
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+from ohtv.db.migrations import migrate
+
+
+@pytest.fixture
+def db_with_contributions():
+    """Fresh in-memory database with all migrations including contributions."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    migrate(conn)
+    yield conn
+    conn.close()
+
+
+class TestContributionsMigrationTablesCreated:
+    """Tests that migration creates all required tables."""
+
+    def test_creates_change_refs_table(self, db_with_contributions):
+        """change_refs table should exist after migration."""
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='change_refs'"
+        )
+        assert cursor.fetchone() is not None
+
+    def test_creates_conversation_contributions_table(self, db_with_contributions):
+        """conversation_contributions table should exist after migration."""
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='conversation_contributions'"
+        )
+        assert cursor.fetchone() is not None
+
+    def test_creates_conversation_human_input_table(self, db_with_contributions):
+        """conversation_human_input table should exist after migration."""
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='conversation_human_input'"
+        )
+        assert cursor.fetchone() is not None
+
+
+class TestChangeRefsSchema:
+    """Tests for change_refs table schema."""
+
+    def test_has_expected_columns(self, db_with_contributions):
+        """change_refs should have all required columns."""
+        cursor = db_with_contributions.execute("PRAGMA table_info(change_refs)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        expected = {
+            "id", "repo_id", "change_type", "pr_number", "commit_range",
+            "branch", "status", "merged_at", "lines_added", "lines_removed",
+            "files_changed", "fetched_at"
+        }
+        assert expected == columns
+
+    def test_change_type_check_constraint_pr(self, db_with_contributions):
+        """change_type should accept 'pr'."""
+        # First create a repo to satisfy foreign key
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # Insert with 'pr' should work
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        db_with_contributions.commit()
+
+    def test_change_type_check_constraint_direct_push(self, db_with_contributions):
+        """change_type should accept 'direct_push'."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "direct_push", "pending")
+        )
+        db_with_contributions.commit()
+
+    def test_change_type_check_constraint_invalid(self, db_with_contributions):
+        """change_type should reject invalid values."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+                (repo_id, "invalid_type", "pending")
+            )
+
+    def test_repo_foreign_key_constraint(self, db_with_contributions):
+        """change_refs should enforce foreign key to repositories."""
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+                (99999, "pr", "pending")
+            )
+
+    def test_unique_constraint_with_pr_number(self, db_with_contributions):
+        """change_refs should enforce unique (repo_id, change_type, pr_number, commit_range) for PRs."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # First insert should succeed - PR 42 with specific commit_range
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, commit_range, status) VALUES (?, ?, ?, ?, ?)",
+            (repo_id, "pr", 42, "abc123..def456", "pending")
+        )
+        db_with_contributions.commit()
+
+        # Duplicate with same commit_range should fail
+        with pytest.raises(sqlite3.IntegrityError, match="UNIQUE constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, commit_range, status) VALUES (?, ?, ?, ?, ?)",
+                (repo_id, "pr", 42, "abc123..def456", "merged")
+            )
+
+    def test_unique_constraint_allows_different_prs(self, db_with_contributions):
+        """change_refs should allow different PRs for same repo."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # Insert PR 42
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, commit_range, status) VALUES (?, ?, ?, ?, ?)",
+            (repo_id, "pr", 42, "abc123..def456", "pending")
+        )
+        # Insert PR 43 - should work
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, commit_range, status) VALUES (?, ?, ?, ?, ?)",
+            (repo_id, "pr", 43, "abc123..def456", "pending")
+        )
+        db_with_contributions.commit()
+
+        cursor = db_with_contributions.execute("SELECT COUNT(*) FROM change_refs WHERE repo_id = ?", (repo_id,))
+        assert cursor.fetchone()[0] == 2
+
+    def test_unique_constraint_null_handling(self, db_with_contributions):
+        """change_refs unique constraint: NULLs in pr_number/commit_range are treated as distinct by SQLite."""
+        # This documents SQLite's behavior: NULL values are considered distinct in unique constraints
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # Insert with NULL pr_number and commit_range
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        # Second insert with NULLs - SQLite treats NULLs as distinct, so this works
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "merged")
+        )
+        db_with_contributions.commit()
+
+        # Both inserts succeeded because NULLs are treated as distinct
+        cursor = db_with_contributions.execute("SELECT COUNT(*) FROM change_refs WHERE repo_id = ?", (repo_id,))
+        assert cursor.fetchone()[0] == 2
+
+    def test_default_status(self, db_with_contributions):
+        """status should default to 'pending'."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type) VALUES (?, ?)",
+            (repo_id, "pr")
+        )
+        db_with_contributions.commit()
+
+        cursor = db_with_contributions.execute(
+            "SELECT status FROM change_refs WHERE repo_id = ?", (repo_id,)
+        )
+        assert cursor.fetchone()["status"] == "pending"
+
+
+class TestConversationContributionsSchema:
+    """Tests for conversation_contributions table schema."""
+
+    def test_has_expected_columns(self, db_with_contributions):
+        """conversation_contributions should have all required columns."""
+        cursor = db_with_contributions.execute("PRAGMA table_info(conversation_contributions)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        expected = {"id", "conversation_id", "change_ref_id", "contribution_type"}
+        assert expected == columns
+
+    def test_contribution_type_check_constraint_created(self, db_with_contributions):
+        """contribution_type should accept 'created'."""
+        # Set up required foreign key records
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "created")
+        )
+        db_with_contributions.commit()
+
+    def test_contribution_type_check_constraint_pushed(self, db_with_contributions):
+        """contribution_type should accept 'pushed'."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "pushed")
+        )
+        db_with_contributions.commit()
+
+    def test_contribution_type_check_constraint_merged(self, db_with_contributions):
+        """contribution_type should accept 'merged'."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "merged")
+        )
+        db_with_contributions.commit()
+
+    def test_contribution_type_check_constraint_invalid(self, db_with_contributions):
+        """contribution_type should reject invalid values."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+                ("conv123", change_ref_id, "invalid_type")
+            )
+
+    def test_conversation_foreign_key_constraint(self, db_with_contributions):
+        """conversation_contributions should enforce foreign key to conversations."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+                ("nonexistent_conv", change_ref_id, "created")
+            )
+
+    def test_change_ref_foreign_key_constraint(self, db_with_contributions):
+        """conversation_contributions should enforce foreign key to change_refs."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+                ("conv123", 99999, "created")
+            )
+
+    def test_unique_constraint(self, db_with_contributions):
+        """conversation_contributions should enforce unique (conversation_id, change_ref_id, contribution_type)."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # First insert should succeed
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "created")
+        )
+        db_with_contributions.commit()
+
+        # Duplicate should fail
+        with pytest.raises(sqlite3.IntegrityError, match="UNIQUE constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+                ("conv123", change_ref_id, "created")
+            )
+
+    def test_same_conversation_different_contribution_types_allowed(self, db_with_contributions):
+        """Same conversation can have different contribution types for same change_ref."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
+            (repo_id, "pr", "pending")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # Multiple contribution types for same (conversation, change_ref) should work
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "created")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "pushed")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "merged")
+        )
+        db_with_contributions.commit()
+
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) FROM conversation_contributions WHERE conversation_id = ?",
+            ("conv123",)
+        )
+        assert cursor.fetchone()[0] == 3
+
+
+class TestConversationHumanInputSchema:
+    """Tests for conversation_human_input table schema."""
+
+    def test_has_expected_columns(self, db_with_contributions):
+        """conversation_human_input should have all required columns."""
+        cursor = db_with_contributions.execute("PRAGMA table_info(conversation_human_input)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        expected = {
+            "conversation_id", "initial_prompt_words", "initial_prompt_source",
+            "followup_word_count", "followup_message_count", "processed_at", "event_count"
+        }
+        assert expected == columns
+
+    def test_conversation_id_is_primary_key(self, db_with_contributions):
+        """conversation_id should be the primary key."""
+        cursor = db_with_contributions.execute("PRAGMA table_info(conversation_human_input)")
+        for row in cursor.fetchall():
+            if row["name"] == "conversation_id":
+                assert row["pk"] == 1
+                break
+        else:
+            pytest.fail("conversation_id not found")
+
+    def test_initial_prompt_source_check_constraint_human(self, db_with_contributions):
+        """initial_prompt_source should accept 'human'."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute("""
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("conv123", 100, "human", 50, 3, datetime.now().isoformat(), 10))
+        db_with_contributions.commit()
+
+    def test_initial_prompt_source_check_constraint_automation(self, db_with_contributions):
+        """initial_prompt_source should accept 'automation'."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute("""
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("conv123", 100, "automation", 50, 3, datetime.now().isoformat(), 10))
+        db_with_contributions.commit()
+
+    def test_initial_prompt_source_check_constraint_unknown(self, db_with_contributions):
+        """initial_prompt_source should accept 'unknown'."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute("""
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("conv123", 100, "unknown", 50, 3, datetime.now().isoformat(), 10))
+        db_with_contributions.commit()
+
+    def test_initial_prompt_source_check_constraint_invalid(self, db_with_contributions):
+        """initial_prompt_source should reject invalid values."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            db_with_contributions.execute("""
+                INSERT INTO conversation_human_input (
+                    conversation_id, initial_prompt_words, initial_prompt_source,
+                    followup_word_count, followup_message_count, processed_at, event_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, ("conv123", 100, "invalid_source", 50, 3, datetime.now().isoformat(), 10))
+
+    def test_conversation_foreign_key_constraint(self, db_with_contributions):
+        """conversation_human_input should enforce foreign key to conversations."""
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
+            db_with_contributions.execute("""
+                INSERT INTO conversation_human_input (
+                    conversation_id, initial_prompt_words, initial_prompt_source,
+                    followup_word_count, followup_message_count, processed_at, event_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, ("nonexistent_conv", 100, "human", 50, 3, datetime.now().isoformat(), 10))
+
+    def test_default_values(self, db_with_contributions):
+        """Columns should have correct default values."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        # Insert with only required columns
+        db_with_contributions.execute("""
+            INSERT INTO conversation_human_input (
+                conversation_id, processed_at, event_count
+            ) VALUES (?, ?, ?)
+        """, ("conv123", datetime.now().isoformat(), 10))
+        db_with_contributions.commit()
+
+        cursor = db_with_contributions.execute(
+            "SELECT initial_prompt_words, initial_prompt_source, followup_word_count, followup_message_count FROM conversation_human_input WHERE conversation_id = ?",
+            ("conv123",)
+        )
+        row = cursor.fetchone()
+        assert row["initial_prompt_words"] == 0
+        assert row["initial_prompt_source"] == "unknown"
+        assert row["followup_word_count"] == 0
+        assert row["followup_message_count"] == 0
+
+
+class TestMigrationIdempotency:
+    """Tests that migration can run multiple times safely."""
+
+    def test_migration_is_idempotent(self):
+        """Running migration multiple times should not cause errors."""
+        conn = sqlite3.connect(":memory:")
+        conn.execute("PRAGMA foreign_keys = ON")
+
+        # First run
+        first_applied = migrate(conn)
+        assert "016_contributions.py" in first_applied
+
+        # Second run should apply no new migrations
+        second_applied = migrate(conn)
+        assert "016_contributions.py" not in second_applied
+        assert len(second_applied) == 0
+
+        conn.close()
+
+
+class TestIndexesCreated:
+    """Tests that appropriate indexes are created."""
+
+    def test_change_refs_indexes(self, db_with_contributions):
+        """change_refs should have indexes on repo_id, change_type, status."""
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='change_refs'"
+        )
+        indexes = {row[0] for row in cursor.fetchall()}
+        assert "idx_change_refs_repo" in indexes
+        assert "idx_change_refs_type" in indexes
+        assert "idx_change_refs_status" in indexes
+
+    def test_conversation_contributions_indexes(self, db_with_contributions):
+        """conversation_contributions should have indexes on conversation_id, change_ref_id."""
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='conversation_contributions'"
+        )
+        indexes = {row[0] for row in cursor.fetchall()}
+        assert "idx_conv_contributions_conv" in indexes
+        assert "idx_conv_contributions_change" in indexes
+
+    def test_conversation_human_input_indexes(self, db_with_contributions):
+        """conversation_human_input should have index on initial_prompt_source."""
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='conversation_human_input'"
+        )
+        indexes = {row[0] for row in cursor.fetchall()}
+        assert "idx_human_input_source" in indexes
+
+
+class TestIntegrationWithExistingData:
+    """Integration tests with existing data in the database."""
+
+    def test_migration_works_with_existing_conversations(self, db_with_contributions):
+        """Migration should work on database with existing conversations."""
+        # Add some conversations first
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv1", "/path/to/conv1")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv2", "/path/to/conv2")
+        )
+        db_with_contributions.commit()
+
+        # Migration should have already run from fixture, verify tables exist
+        cursor = db_with_contributions.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='change_refs'"
+        )
+        assert cursor.fetchone() is not None
+
+    def test_can_link_existing_conversations_to_changes(self, db_with_contributions):
+        """Should be able to create contribution links for existing conversations."""
+        # Setup: existing conversation and repo
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv_existing", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # Create a change_ref
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 42, "merged")
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # Link conversation to change
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv_existing", change_ref_id, "created")
+        )
+        db_with_contributions.commit()
+
+        # Verify the link exists
+        cursor = db_with_contributions.execute(
+            "SELECT * FROM conversation_contributions WHERE conversation_id = ?",
+            ("conv_existing",)
+        )
+        row = cursor.fetchone()
+        assert row is not None
+        assert row["change_ref_id"] == change_ref_id
+        assert row["contribution_type"] == "created"
+
+    def test_can_track_human_input_for_existing_conversations(self, db_with_contributions):
+        """Should be able to track human input for existing conversations."""
+        # Setup: existing conversation
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv_existing", "/path/to/conv")
+        )
+
+        # Track human input
+        db_with_contributions.execute("""
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("conv_existing", 150, "human", 75, 5, datetime.now().isoformat(), 20))
+        db_with_contributions.commit()
+
+        # Verify the data
+        cursor = db_with_contributions.execute(
+            "SELECT * FROM conversation_human_input WHERE conversation_id = ?",
+            ("conv_existing",)
+        )
+        row = cursor.fetchone()
+        assert row["initial_prompt_words"] == 150
+        assert row["initial_prompt_source"] == "human"
+        assert row["followup_word_count"] == 75
+        assert row["followup_message_count"] == 5

--- a/tests/unit/db/test_contributions_migration.py
+++ b/tests/unit/db/test_contributions_migration.py
@@ -259,6 +259,67 @@ class TestChangeRefsSchema:
         )
         assert cursor.fetchone()["status"] == "pending"
 
+    def test_status_check_constraint_accepts_valid_values(self, db_with_contributions):
+        """status should accept valid enum values."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # All valid status values should work
+        valid_statuses = ['pending', 'fetched', 'merged', 'closed']
+        for i, status in enumerate(valid_statuses):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+                (repo_id, "pr", i + 1, status)
+            )
+        db_with_contributions.commit()
+
+    def test_status_check_constraint_rejects_invalid_values(self, db_with_contributions):
+        """status should reject invalid enum values."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+                (repo_id, "pr", 1, "invalid_status")
+            )
+
+    def test_cascade_delete_when_repository_deleted(self, db_with_contributions):
+        """Deleting a repository should cascade delete related change_refs."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number) VALUES (?, ?, ?)",
+            (repo_id, "pr", 42)
+        )
+        db_with_contributions.commit()
+
+        # Verify change_refs exists
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM change_refs WHERE repo_id = ?", (repo_id,)
+        )
+        assert cursor.fetchone()["cnt"] == 1
+
+        # Delete the repository
+        db_with_contributions.execute("DELETE FROM repositories WHERE id = ?", (repo_id,))
+        db_with_contributions.commit()
+
+        # change_refs should be cascade deleted
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM change_refs WHERE repo_id = ?", (repo_id,)
+        )
+        assert cursor.fetchone()["cnt"] == 0
+
 
 class TestConversationContributionsSchema:
     """Tests for conversation_contributions table schema."""
@@ -464,6 +525,86 @@ class TestConversationContributionsSchema:
         )
         assert cursor.fetchone()[0] == 3
 
+    def test_cascade_delete_when_conversation_deleted(self, db_with_contributions):
+        """Deleting a conversation should cascade delete related conversation_contributions."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number) VALUES (?, ?, ?)",
+            (repo_id, "pr", 42)
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "created")
+        )
+        db_with_contributions.commit()
+
+        # Verify contribution exists
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM conversation_contributions WHERE conversation_id = ?",
+            ("conv123",)
+        )
+        assert cursor.fetchone()["cnt"] == 1
+
+        # Delete the conversation
+        db_with_contributions.execute("DELETE FROM conversations WHERE id = ?", ("conv123",))
+        db_with_contributions.commit()
+
+        # conversation_contributions should be cascade deleted
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM conversation_contributions WHERE conversation_id = ?",
+            ("conv123",)
+        )
+        assert cursor.fetchone()["cnt"] == 0
+
+    def test_cascade_delete_when_change_ref_deleted(self, db_with_contributions):
+        """Deleting a change_ref should cascade delete related conversation_contributions."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number) VALUES (?, ?, ?)",
+            (repo_id, "pr", 42)
+        )
+        change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+        db_with_contributions.execute(
+            "INSERT INTO conversation_contributions (conversation_id, change_ref_id, contribution_type) VALUES (?, ?, ?)",
+            ("conv123", change_ref_id, "created")
+        )
+        db_with_contributions.commit()
+
+        # Verify contribution exists
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM conversation_contributions WHERE change_ref_id = ?",
+            (change_ref_id,)
+        )
+        assert cursor.fetchone()["cnt"] == 1
+
+        # Delete the change_ref
+        db_with_contributions.execute("DELETE FROM change_refs WHERE id = ?", (change_ref_id,))
+        db_with_contributions.commit()
+
+        # conversation_contributions should be cascade deleted
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM conversation_contributions WHERE change_ref_id = ?",
+            (change_ref_id,)
+        )
+        assert cursor.fetchone()["cnt"] == 0
+
 
 class TestConversationHumanInputSchema:
     """Tests for conversation_human_input table schema."""
@@ -577,6 +718,38 @@ class TestConversationHumanInputSchema:
         assert row["initial_prompt_source"] == "unknown"
         assert row["followup_word_count"] == 0
         assert row["followup_message_count"] == 0
+
+    def test_cascade_delete_when_conversation_deleted(self, db_with_contributions):
+        """Deleting a conversation should cascade delete related conversation_human_input."""
+        db_with_contributions.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv123", "/path/to/conv")
+        )
+        db_with_contributions.execute("""
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, ("conv123", 100, "human", 50, 3, datetime.now().isoformat(), 10))
+        db_with_contributions.commit()
+
+        # Verify human_input exists
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM conversation_human_input WHERE conversation_id = ?",
+            ("conv123",)
+        )
+        assert cursor.fetchone()["cnt"] == 1
+
+        # Delete the conversation
+        db_with_contributions.execute("DELETE FROM conversations WHERE id = ?", ("conv123",))
+        db_with_contributions.commit()
+
+        # conversation_human_input should be cascade deleted
+        cursor = db_with_contributions.execute(
+            "SELECT COUNT(*) as cnt FROM conversation_human_input WHERE conversation_id = ?",
+            ("conv123",)
+        )
+        assert cursor.fetchone()["cnt"] == 0
 
 
 class TestMigrationIdempotency:

--- a/tests/unit/db/test_contributions_migration.py
+++ b/tests/unit/db/test_contributions_migration.py
@@ -67,7 +67,7 @@ class TestChangeRefsSchema:
         assert expected == columns
 
     def test_change_type_check_constraint_pr(self, db_with_contributions):
-        """change_type should accept 'pr'."""
+        """change_type 'pr' requires pr_number to be set."""
         # First create a repo to satisfy foreign key
         db_with_contributions.execute(
             "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
@@ -75,26 +75,57 @@ class TestChangeRefsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
-        # Insert with 'pr' should work
+        # Insert with 'pr' and pr_number should work
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 42, "pending")
         )
         db_with_contributions.commit()
 
     def test_change_type_check_constraint_direct_push(self, db_with_contributions):
-        """change_type should accept 'direct_push'."""
+        """change_type 'direct_push' requires commit_range to be set."""
         db_with_contributions.execute(
             "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
             ("https://github.com/test/repo", "test/repo", "repo")
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
+        # Insert with 'direct_push' and commit_range should work
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "direct_push", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, commit_range, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "direct_push", "abc123..def456", "pending")
         )
         db_with_contributions.commit()
+
+    def test_pr_requires_pr_number(self, db_with_contributions):
+        """PRs must have pr_number populated."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # PR without pr_number should fail CHECK constraint
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type) VALUES (?, ?)",
+                (repo_id, "pr")
+            )
+
+    def test_direct_push_requires_commit_range(self, db_with_contributions):
+        """Direct pushes must have commit_range populated."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # direct_push without commit_range should fail CHECK constraint
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type) VALUES (?, ?)",
+                (repo_id, "direct_push")
+            )
 
     def test_change_type_check_constraint_invalid(self, db_with_contributions):
         """change_type should reject invalid values."""
@@ -104,18 +135,19 @@ class TestChangeRefsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
+        # Even with pr_number provided, invalid change_type should fail
         with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
             db_with_contributions.execute(
-                "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-                (repo_id, "invalid_type", "pending")
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+                (repo_id, "invalid_type", 1, "pending")
             )
 
     def test_repo_foreign_key_constraint(self, db_with_contributions):
         """change_refs should enforce foreign key to repositories."""
         with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
             db_with_contributions.execute(
-                "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-                (99999, "pr", "pending")
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+                (99999, "pr", 1, "pending")
             )
 
     def test_unique_constraint_with_pr_number(self, db_with_contributions):
@@ -163,30 +195,49 @@ class TestChangeRefsSchema:
         cursor = db_with_contributions.execute("SELECT COUNT(*) FROM change_refs WHERE repo_id = ?", (repo_id,))
         assert cursor.fetchone()[0] == 2
 
-    def test_unique_constraint_null_handling(self, db_with_contributions):
-        """change_refs unique constraint: NULLs in pr_number/commit_range are treated as distinct by SQLite."""
-        # This documents SQLite's behavior: NULL values are considered distinct in unique constraints
+    def test_unique_constraint_prevents_duplicate_prs(self, db_with_contributions):
+        """Duplicate PRs (same repo_id and pr_number) should be rejected."""
         db_with_contributions.execute(
             "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
             ("https://github.com/test/repo", "test/repo", "repo")
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
-        # Insert with NULL pr_number and commit_range
+        # First PR insert should succeed
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
-        )
-        # Second insert with NULLs - SQLite treats NULLs as distinct, so this works
-        db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "merged")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 42, "pending")
         )
         db_with_contributions.commit()
 
-        # Both inserts succeeded because NULLs are treated as distinct
-        cursor = db_with_contributions.execute("SELECT COUNT(*) FROM change_refs WHERE repo_id = ?", (repo_id,))
-        assert cursor.fetchone()[0] == 2
+        # Duplicate PR with same repo_id and pr_number should fail
+        with pytest.raises(sqlite3.IntegrityError, match="UNIQUE constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+                (repo_id, "pr", 42, "merged")
+            )
+
+    def test_unique_constraint_prevents_duplicate_direct_pushes(self, db_with_contributions):
+        """Duplicate direct pushes (same repo_id and commit_range) should be rejected."""
+        db_with_contributions.execute(
+            "INSERT INTO repositories (canonical_url, fqn, short_name) VALUES (?, ?, ?)",
+            ("https://github.com/test/repo", "test/repo", "repo")
+        )
+        repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # First direct push insert should succeed
+        db_with_contributions.execute(
+            "INSERT INTO change_refs (repo_id, change_type, commit_range, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "direct_push", "abc123..def456", "pending")
+        )
+        db_with_contributions.commit()
+
+        # Duplicate direct push with same repo_id and commit_range should fail
+        with pytest.raises(sqlite3.IntegrityError, match="UNIQUE constraint failed"):
+            db_with_contributions.execute(
+                "INSERT INTO change_refs (repo_id, change_type, commit_range, status) VALUES (?, ?, ?, ?)",
+                (repo_id, "direct_push", "abc123..def456", "merged")
+            )
 
     def test_default_status(self, db_with_contributions):
         """status should default to 'pending'."""
@@ -196,9 +247,10 @@ class TestChangeRefsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
+        # PR with pr_number but no explicit status
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type) VALUES (?, ?)",
-            (repo_id, "pr")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number) VALUES (?, ?, ?)",
+            (repo_id, "pr", 42)
         )
         db_with_contributions.commit()
 
@@ -231,8 +283,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -254,8 +306,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -277,8 +329,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -300,8 +352,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -319,8 +371,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -355,8 +407,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 
@@ -386,8 +438,8 @@ class TestConversationContributionsSchema:
         )
         repo_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
         db_with_contributions.execute(
-            "INSERT INTO change_refs (repo_id, change_type, status) VALUES (?, ?, ?)",
-            (repo_id, "pr", "pending")
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) VALUES (?, ?, ?, ?)",
+            (repo_id, "pr", 1, "pending")
         )
         change_ref_id = db_with_contributions.execute("SELECT last_insert_rowid()").fetchone()[0]
 


### PR DESCRIPTION
## Summary

Adds database migration for contribution tracking tables, implementing issue #76.

Fixes #76

## Changes

### New Migration: `016_contributions.py`

Creates three new tables:

1. **`change_refs`** - Tracks PRs and direct pushes to main
   - Columns: `id`, `repo_id`, `change_type`, `pr_number`, `commit_range`, `branch`, `status`, `merged_at`, `lines_added`, `lines_removed`, `files_changed`, `fetched_at`
   - CHECK constraint on `change_type`: `'pr'` or `'direct_push'`
   - Foreign key to `repositories` table
   - Unique constraint on `(repo_id, change_type, pr_number, commit_range)`
   - Indexes on `repo_id`, `change_type`, `status`

2. **`conversation_contributions`** - Links conversations to changes they contributed to
   - Columns: `id`, `conversation_id`, `change_ref_id`, `contribution_type`
   - CHECK constraint on `contribution_type`: `'created'`, `'pushed'`, or `'merged'`
   - Foreign keys to `conversations` and `change_refs` tables
   - Unique constraint on `(conversation_id, change_ref_id, contribution_type)`
   - Indexes on `conversation_id`, `change_ref_id`

3. **`conversation_human_input`** - Stores human word/message counts per conversation
   - Columns: `conversation_id` (PK), `initial_prompt_words`, `initial_prompt_source`, `followup_word_count`, `followup_message_count`, `processed_at`, `event_count`
   - CHECK constraint on `initial_prompt_source`: `'human'`, `'automation'`, or `'unknown'`
   - Foreign key to `conversations` table
   - Index on `initial_prompt_source`

### Tests: `test_contributions_migration.py`

36 comprehensive test cases covering:
- ✅ Table creation verification
- ✅ Column schema verification
- ✅ CHECK constraints (valid/invalid values)
- ✅ Foreign key constraint enforcement
- ✅ Unique constraint behavior (including SQLite NULL handling documented)
- ✅ Default values
- ✅ Index creation
- ✅ Migration idempotency
- ✅ Integration with existing data

## Acceptance Criteria

- [x] Migration creates all three tables with correct columns and constraints
- [x] Migration is idempotent (can run multiple times safely)
- [x] Foreign key constraints are enforced
- [x] Unique constraints prevent duplicate entries
- [x] Migration runs successfully on existing databases with data

## Test Results

All 36 new tests pass, all 343 existing database tests pass.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/85e8f5de-d30d-42ec-bd34-73c703003b57)