### PR TITLE
feat: add human_input counting stage (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ ohtv db process refs -v
 |-------|-------------|
 | `refs` | Extract repository, issue, and PR references |
 | `actions` | Recognize actions (file edits, git ops, PRs, issues, Notion, etc.) |
+| `human_input` | Count human input events per conversation; preserves `initial_prompt_source` for future classification |
 | `all` | Run all stages in sequence |
 
 **Options:**

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -23,6 +23,7 @@ from rich.tree import Tree
 
 from ohtv.actions import READ_ACTIONS, WRITE_ACTIONS
 from ohtv.config import Config
+from ohtv.db.stages import STAGES
 from ohtv.db.utils import generate_unique_source_names
 
 if TYPE_CHECKING:
@@ -6395,7 +6396,7 @@ def db_init(verbose: bool) -> None:
 
 
 @db.command("process")
-@click.argument("stage", type=click.Choice(["refs", "actions", "branch_context", "push_pr_links", "summaries", "all"]))
+@click.argument("stage", type=click.Choice([*STAGES.keys(), "all"]))
 @click.option("--force", "-f", is_flag=True, help="Reprocess all conversations, ignoring stage completion")
 @click.option("--conversation", "-c", help="Process only this conversation ID")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
@@ -6412,6 +6413,7 @@ def db_process(stage: str, force: bool, conversation: str | None, verbose: bool)
       branch_context - Track branches and create branch refs
       push_pr_links  - Correlate git pushes with PRs via branch matching
       summaries      - Extract summaries from objective analysis cache
+      human_input    - Count human words/messages (initial prompt + follow-ups)
       all            - Run all stages in sequence
     """
     from ohtv.db import get_connection, get_db_path, migrate, scan_conversations

--- a/src/ohtv/db/stages/__init__.py
+++ b/src/ohtv/db/stages/__init__.py
@@ -9,10 +9,12 @@ Stage ordering:
 3. branch_context - Track branches and create branch refs (requires actions)
 4. push_pr_links - Correlate pushes with PRs (requires actions, branch_context)
 5. summaries - Extract summaries from objective analysis cache
+6. human_input - Count human words/messages (initial prompt vs. follow-ups)
 """
 
 from ohtv.db.stages.actions import process_actions
 from ohtv.db.stages.branch_context import process_branch_context
+from ohtv.db.stages.human_input import process_human_input
 from ohtv.db.stages.push_pr_links import process_push_pr_links
 from ohtv.db.stages.refs import process_refs
 from ohtv.db.stages.summaries import process_summaries
@@ -25,12 +27,14 @@ STAGES = {
     "branch_context": process_branch_context,
     "push_pr_links": process_push_pr_links,
     "summaries": process_summaries,
+    "human_input": process_human_input,
 }
 
 __all__ = [
     "STAGES",
     "process_actions",
     "process_branch_context",
+    "process_human_input",
     "process_push_pr_links",
     "process_refs",
     "process_summaries",

--- a/src/ohtv/db/stages/human_input.py
+++ b/src/ohtv/db/stages/human_input.py
@@ -1,0 +1,198 @@
+"""Human input counting stage.
+
+Counts human words and messages per conversation, distinguishing between
+the initial prompt (first user message) and follow-up messages (subsequent
+user messages).
+
+Background: Both initial prompt and follow-ups are structurally identical
+in the trace data (``MessageEvent`` with ``source: "user"``). Only their
+position in the event sequence distinguishes them. The first user message
+is the task definition; later user messages represent human steering during
+agent execution.
+
+Results are stored in the ``conversation_human_input`` table (created by
+migration 016). This stage only populates the count fields; the
+``initial_prompt_source`` column is left at its default ('unknown') for
+later stages to classify (see issue #83).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ohtv.db.models import Conversation
+from ohtv.db.stores import StageStore
+
+log = logging.getLogger("ohtv")
+
+STAGE_NAME = "human_input"
+
+
+@dataclass
+class HumanInputMetrics:
+    """Word and message counts for human input in a conversation."""
+
+    initial_prompt_words: int
+    followup_word_count: int
+    followup_message_count: int
+
+
+def count_human_input(events: list[dict]) -> HumanInputMetrics:
+    """Count human input, separating initial prompt from follow-ups.
+
+    The first ``MessageEvent`` with ``source == "user"`` is treated as the
+    initial prompt. All subsequent ones are follow-ups.
+
+    Word counts use whitespace splitting (``str.split()``) for simple,
+    reproducible counts. Non-text content items are ignored.
+
+    Malformed events (missing/wrong-typed fields) are tolerated and
+    contribute zero words.
+
+    Args:
+        events: Ordered list of conversation events.
+
+    Returns:
+        HumanInputMetrics with separate counts for initial prompt and
+        follow-up messages.
+    """
+    initial_prompt_words = 0
+    followup_word_count = 0
+    followup_message_count = 0
+    found_initial = False
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("kind") != "MessageEvent":
+            continue
+        if event.get("source") != "user":
+            continue
+
+        words = _count_words_in_message(event)
+
+        if not found_initial:
+            initial_prompt_words = words
+            found_initial = True
+        else:
+            followup_word_count += words
+            followup_message_count += 1
+
+    return HumanInputMetrics(
+        initial_prompt_words=initial_prompt_words,
+        followup_word_count=followup_word_count,
+        followup_message_count=followup_message_count,
+    )
+
+
+def _count_words_in_message(event: dict) -> int:
+    """Extract text from a MessageEvent and return word count.
+
+    Text is read from ``llm_message.content[].text`` where ``type`` is
+    ``"text"``. Multiple text items in the same message are summed.
+    """
+    llm_message = event.get("llm_message")
+    if not isinstance(llm_message, dict):
+        return 0
+
+    content_list = llm_message.get("content")
+    if not isinstance(content_list, list):
+        return 0
+
+    words = 0
+    for item in content_list:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "text":
+            continue
+        text = item.get("text")
+        if isinstance(text, str):
+            words += len(text.split())
+    return words
+
+
+def process_human_input(conn: sqlite3.Connection, conversation: Conversation) -> None:
+    """Count human input for a conversation and store metrics in DB.
+
+    Reads events from ``<conversation.location>/events/event-*.json``,
+    computes :class:`HumanInputMetrics`, and upserts them into
+    ``conversation_human_input``. Marks the stage complete regardless of
+    whether any user messages were found (e.g., orchestrator worker
+    conversations have none).
+
+    Args:
+        conn: Database connection.
+        conversation: The conversation to process.
+    """
+    conv_dir = Path(conversation.location)
+    events = _load_events(conv_dir / "events")
+
+    metrics = count_human_input(events)
+
+    processed_at = datetime.now(timezone.utc).isoformat()
+    # Upsert into conversation_human_input. We do not touch
+    # initial_prompt_source on update so that later classification stages
+    # can refine it without being overwritten on reprocessing.
+    conn.execute(
+        """
+        INSERT INTO conversation_human_input (
+            conversation_id,
+            initial_prompt_words,
+            followup_word_count,
+            followup_message_count,
+            processed_at,
+            event_count
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(conversation_id) DO UPDATE SET
+            initial_prompt_words = excluded.initial_prompt_words,
+            followup_word_count = excluded.followup_word_count,
+            followup_message_count = excluded.followup_message_count,
+            processed_at = excluded.processed_at,
+            event_count = excluded.event_count
+        """,
+        (
+            conversation.id,
+            metrics.initial_prompt_words,
+            metrics.followup_word_count,
+            metrics.followup_message_count,
+            processed_at,
+            conversation.event_count,
+        ),
+    )
+
+    stage_store = StageStore(conn)
+    stage_store.mark_complete(conversation.id, STAGE_NAME, conversation.event_count)
+
+    log.debug(
+        "human_input %s: initial=%d words, followups=%d msgs/%d words",
+        conversation.id[:8],
+        metrics.initial_prompt_words,
+        metrics.followup_message_count,
+        metrics.followup_word_count,
+    )
+
+
+def _load_events(events_dir: Path) -> list[dict]:
+    """Load all events from a conversation's events directory.
+
+    Returns an empty list if the directory does not exist or contains no
+    parseable event files. Files with JSON errors are skipped.
+    """
+    if not events_dir.exists():
+        return []
+
+    events: list[dict] = []
+    for event_file in sorted(events_dir.glob("event-*.json")):
+        try:
+            data = json.loads(event_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict):
+            events.append(data)
+    return events

--- a/tests/unit/db/stages/test_human_input.py
+++ b/tests/unit/db/stages/test_human_input.py
@@ -409,6 +409,54 @@ class TestProcessHumanInput:
         assert row["followup_word_count"] == 0
         assert row["followup_message_count"] == 0
 
+    def test_preserves_initial_prompt_source_on_reprocessing(
+        self, db_conn, tmp_path
+    ):
+        """``initial_prompt_source`` must NOT revert on reprocessing.
+
+        The upsert in ``process_human_input`` deliberately omits
+        ``initial_prompt_source`` from its ``ON CONFLICT ... DO UPDATE SET``
+        clause so that a downstream classification stage (see issue #83) can
+        set it to e.g. ``'human'`` once and have that value survive any
+        subsequent reprocessing triggered by event growth. This test pins
+        that contract.
+        """
+        conv_dir = tmp_path / "conv-preserve"
+        _write_events(conv_dir, [_user_msg("hello")])
+        conv = _register_conversation(db_conn, "convpres", conv_dir, event_count=1)
+
+        # First processing run: source defaults to 'unknown'.
+        process_human_input(db_conn, conv)
+        initial_row = _get_human_input_row(db_conn, "convpres")
+        assert initial_row["initial_prompt_source"] == "unknown"
+
+        # Simulate a future classification stage marking this prompt as human.
+        db_conn.execute(
+            "UPDATE conversation_human_input "
+            "SET initial_prompt_source = 'human' WHERE conversation_id = ?",
+            ("convpres",),
+        )
+        db_conn.commit()
+
+        # Conversation grows, triggering a reprocess.
+        _write_events(
+            conv_dir,
+            [_user_msg("hello"), _user_msg("now a followup of four words")],
+        )
+        conv2 = Conversation(
+            id="convpres", location=str(conv_dir), event_count=2
+        )
+        ConversationStore(db_conn).upsert(conv2)
+        process_human_input(db_conn, conv2)
+
+        row = _get_human_input_row(db_conn, "convpres")
+        # Contract: classification result is preserved across reprocessing.
+        assert row["initial_prompt_source"] == "human"
+        # Sanity check: the count columns WERE refreshed by the reprocess.
+        assert row["event_count"] == 2
+        assert row["followup_message_count"] == 1
+        assert row["followup_word_count"] == 6
+
     def test_needs_processing_after_first_run(self, db_conn, tmp_path):
         """StageStore.needs_processing reflects completion state correctly."""
         conv_dir = tmp_path / "conv-skip"

--- a/tests/unit/db/stages/test_human_input.py
+++ b/tests/unit/db/stages/test_human_input.py
@@ -1,0 +1,439 @@
+"""Tests for the human_input counting stage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ohtv.db.migrations import migrate
+from ohtv.db.models import Conversation
+from ohtv.db.stages.human_input import (
+    STAGE_NAME,
+    HumanInputMetrics,
+    count_human_input,
+    process_human_input,
+)
+from ohtv.db.stores import ConversationStore, StageStore
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: count_human_input
+# ---------------------------------------------------------------------------
+
+
+def _user_msg(text: str) -> dict:
+    """Build a user MessageEvent with a single text content item."""
+    return {
+        "kind": "MessageEvent",
+        "source": "user",
+        "llm_message": {
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _agent_msg(text: str) -> dict:
+    """Build an agent MessageEvent."""
+    return {
+        "kind": "MessageEvent",
+        "source": "agent",
+        "llm_message": {
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+class TestCountHumanInput:
+    """Unit tests for the pure counting function."""
+
+    def test_empty_events(self):
+        result = count_human_input([])
+        assert result == HumanInputMetrics(0, 0, 0)
+
+    def test_only_initial_prompt(self):
+        events = [_user_msg("Fix the broken tests please")]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 5
+        assert result.followup_word_count == 0
+        assert result.followup_message_count == 0
+
+    def test_initial_and_followups(self):
+        events = [
+            _user_msg("one two three"),  # 3 words - initial
+            _agent_msg("agent talks here"),
+            _user_msg("four five"),  # 2 words - followup 1
+            _user_msg("six seven eight nine"),  # 4 words - followup 2
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 3
+        assert result.followup_word_count == 6
+        assert result.followup_message_count == 2
+
+    def test_no_user_messages(self):
+        """Orchestrator/worker conversations may have no user messages."""
+        events = [
+            _agent_msg("agent thinking"),
+            {"kind": "ActionEvent", "source": "agent", "tool_name": "terminal"},
+        ]
+        result = count_human_input(events)
+        assert result == HumanInputMetrics(0, 0, 0)
+
+    def test_ignores_non_message_events(self):
+        events = [
+            {
+                "kind": "ActionEvent",
+                "source": "user",
+                "llm_message": {"content": [{"type": "text", "text": "ignored"}]},
+            },
+            _user_msg("real prompt"),
+        ]
+        result = count_human_input(events)
+        # Only the MessageEvent counts as the initial prompt.
+        assert result.initial_prompt_words == 2
+        assert result.followup_message_count == 0
+
+    def test_ignores_agent_messages(self):
+        events = [
+            _agent_msg("ignored agent words"),
+            _user_msg("actual initial"),
+            _agent_msg("more agent"),
+            _user_msg("follow up"),
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 2
+        assert result.followup_word_count == 2
+        assert result.followup_message_count == 1
+
+    def test_multiple_text_items_in_content(self):
+        """Multiple text items in one message are summed."""
+        events = [
+            {
+                "kind": "MessageEvent",
+                "source": "user",
+                "llm_message": {
+                    "content": [
+                        {"type": "text", "text": "one two"},
+                        {"type": "text", "text": "three four five"},
+                    ],
+                },
+            },
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 5
+
+    def test_ignores_non_text_content_items(self):
+        events = [
+            {
+                "kind": "MessageEvent",
+                "source": "user",
+                "llm_message": {
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "https://x"}},
+                        {"type": "text", "text": "the words"},
+                    ],
+                },
+            },
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 2
+
+    def test_whitespace_splitting(self):
+        """Word count uses str.split() — collapses runs of whitespace."""
+        events = [_user_msg("  hello   world\n\nfoo\tbar  ")]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 4
+
+    def test_empty_text_content(self):
+        events = [_user_msg("")]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 0
+
+    def test_malformed_missing_llm_message(self):
+        events = [
+            {"kind": "MessageEvent", "source": "user"},  # no llm_message
+            _user_msg("real followup here"),
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 0
+        # The malformed event is still counted as the initial prompt slot
+        # (it is a user MessageEvent), so the next one is a follow-up.
+        assert result.followup_message_count == 1
+        assert result.followup_word_count == 3
+
+    def test_malformed_llm_message_not_dict(self):
+        events = [
+            {"kind": "MessageEvent", "source": "user", "llm_message": "not a dict"},
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 0
+
+    def test_malformed_content_not_list(self):
+        events = [
+            {
+                "kind": "MessageEvent",
+                "source": "user",
+                "llm_message": {"content": "oops not a list"},
+            },
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 0
+
+    def test_malformed_content_item_not_dict(self):
+        events = [
+            {
+                "kind": "MessageEvent",
+                "source": "user",
+                "llm_message": {
+                    "content": ["string-item", {"type": "text", "text": "ok"}]
+                },
+            },
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 1
+
+    def test_malformed_text_field_not_string(self):
+        events = [
+            {
+                "kind": "MessageEvent",
+                "source": "user",
+                "llm_message": {"content": [{"type": "text", "text": 12345}]},
+            },
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 0
+
+    def test_non_dict_event_skipped(self):
+        events = ["a string", 42, None, _user_msg("two words")]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 2
+
+    def test_user_messages_without_source_skipped(self):
+        events = [
+            {
+                "kind": "MessageEvent",
+                "llm_message": {"content": [{"type": "text", "text": "no source"}]},
+            },
+            _user_msg("real one"),
+        ]
+        result = count_human_input(events)
+        assert result.initial_prompt_words == 2
+        assert result.followup_message_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: process_human_input writes to the database
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_conn():
+    """Create an in-memory database with migrations applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrate(conn)
+    yield conn
+    conn.close()
+
+
+def _write_events(conv_dir: Path, events: list[dict]) -> None:
+    """Write events as event-NNNNNN.json files in <conv_dir>/events/."""
+    events_dir = conv_dir / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    for i, event in enumerate(events):
+        (events_dir / f"event-{i:06d}.json").write_text(json.dumps(event))
+
+
+def _register_conversation(
+    db_conn: sqlite3.Connection,
+    conv_id: str,
+    conv_dir: Path,
+    event_count: int,
+) -> Conversation:
+    """Insert a conversation row and return the model."""
+    conv = Conversation(
+        id=conv_id,
+        location=str(conv_dir),
+        event_count=event_count,
+    )
+    ConversationStore(db_conn).upsert(conv)
+    return conv
+
+
+def _get_human_input_row(
+    db_conn: sqlite3.Connection, conv_id: str
+) -> sqlite3.Row | None:
+    cur = db_conn.execute(
+        "SELECT * FROM conversation_human_input WHERE conversation_id = ?",
+        (conv_id,),
+    )
+    return cur.fetchone()
+
+
+class TestProcessHumanInput:
+    """Integration tests for the DB-writing stage."""
+
+    def test_populates_database(self, db_conn, tmp_path):
+        conv_dir = tmp_path / "conv1"
+        _write_events(
+            conv_dir,
+            [
+                _user_msg("hello world"),  # initial: 2 words
+                _agent_msg("agent reply"),
+                _user_msg("please fix"),  # followup: 2 words
+                _user_msg("and add tests"),  # followup: 3 words
+            ],
+        )
+        conv = _register_conversation(db_conn, "conv1", conv_dir, event_count=4)
+
+        process_human_input(db_conn, conv)
+
+        row = _get_human_input_row(db_conn, "conv1")
+        assert row is not None
+        assert row["initial_prompt_words"] == 2
+        assert row["followup_word_count"] == 5
+        assert row["followup_message_count"] == 2
+        assert row["event_count"] == 4
+        assert row["initial_prompt_source"] == "unknown"  # default
+        assert row["processed_at"]
+
+    def test_marks_stage_complete(self, db_conn, tmp_path):
+        conv_dir = tmp_path / "conv2"
+        _write_events(conv_dir, [_user_msg("a prompt")])
+        conv = _register_conversation(db_conn, "conv2", conv_dir, event_count=1)
+
+        process_human_input(db_conn, conv)
+
+        stage = StageStore(db_conn).get("conv2", STAGE_NAME)
+        assert stage is not None
+        assert stage.event_count == 1
+
+    def test_no_events_directory(self, db_conn, tmp_path):
+        """If events dir is missing, we still write a zero-row and mark complete."""
+        conv_dir = tmp_path / "conv-no-events"
+        conv_dir.mkdir()
+        conv = _register_conversation(db_conn, "convne", conv_dir, event_count=0)
+
+        process_human_input(db_conn, conv)
+
+        row = _get_human_input_row(db_conn, "convne")
+        assert row is not None
+        assert row["initial_prompt_words"] == 0
+        assert row["followup_word_count"] == 0
+        assert row["followup_message_count"] == 0
+
+        stage = StageStore(db_conn).get("convne", STAGE_NAME)
+        assert stage is not None
+
+    def test_handles_malformed_event_file(self, db_conn, tmp_path):
+        """Files with invalid JSON should be skipped, not crash the stage."""
+        conv_dir = tmp_path / "conv-bad"
+        events_dir = conv_dir / "events"
+        events_dir.mkdir(parents=True)
+        (events_dir / "event-000000.json").write_text("{not valid json")
+        (events_dir / "event-000001.json").write_text(
+            json.dumps(_user_msg("real prompt"))
+        )
+        conv = _register_conversation(db_conn, "convbad", conv_dir, event_count=2)
+
+        process_human_input(db_conn, conv)
+
+        row = _get_human_input_row(db_conn, "convbad")
+        assert row["initial_prompt_words"] == 2
+
+    def test_idempotent_same_results(self, db_conn, tmp_path):
+        """Running the stage twice on the same data should not change counts."""
+        conv_dir = tmp_path / "conv-idem"
+        _write_events(
+            conv_dir,
+            [
+                _user_msg("first one"),
+                _user_msg("second one here"),
+            ],
+        )
+        conv = _register_conversation(db_conn, "convidem", conv_dir, event_count=2)
+
+        process_human_input(db_conn, conv)
+        first = dict(_get_human_input_row(db_conn, "convidem"))
+
+        process_human_input(db_conn, conv)
+        second = dict(_get_human_input_row(db_conn, "convidem"))
+
+        # The counts and event_count must remain identical; processed_at may
+        # update but the underlying metrics should not change.
+        assert first["initial_prompt_words"] == second["initial_prompt_words"]
+        assert first["followup_word_count"] == second["followup_word_count"]
+        assert first["followup_message_count"] == second["followup_message_count"]
+        assert first["event_count"] == second["event_count"]
+
+    def test_reprocessing_updates_counts(self, db_conn, tmp_path):
+        """If events change between runs, counts should be updated."""
+        conv_dir = tmp_path / "conv-grow"
+        _write_events(conv_dir, [_user_msg("hello")])
+        conv = _register_conversation(db_conn, "convgrow", conv_dir, event_count=1)
+        process_human_input(db_conn, conv)
+
+        # Now grow the conversation: add a follow-up message.
+        _write_events(
+            conv_dir,
+            [_user_msg("hello"), _user_msg("now bigger followup")],
+        )
+        conv2 = Conversation(id="convgrow", location=str(conv_dir), event_count=2)
+        ConversationStore(db_conn).upsert(conv2)
+        process_human_input(db_conn, conv2)
+
+        row = _get_human_input_row(db_conn, "convgrow")
+        assert row["initial_prompt_words"] == 1
+        assert row["followup_message_count"] == 1
+        assert row["followup_word_count"] == 3
+        assert row["event_count"] == 2
+
+    def test_no_user_messages_orchestrator_worker(self, db_conn, tmp_path):
+        """A conversation with only agent messages stores zeros."""
+        conv_dir = tmp_path / "conv-orch"
+        _write_events(
+            conv_dir,
+            [
+                _agent_msg("first agent message"),
+                _agent_msg("second agent message"),
+            ],
+        )
+        conv = _register_conversation(db_conn, "convorch", conv_dir, event_count=2)
+
+        process_human_input(db_conn, conv)
+
+        row = _get_human_input_row(db_conn, "convorch")
+        assert row["initial_prompt_words"] == 0
+        assert row["followup_word_count"] == 0
+        assert row["followup_message_count"] == 0
+
+    def test_needs_processing_after_first_run(self, db_conn, tmp_path):
+        """StageStore.needs_processing reflects completion state correctly."""
+        conv_dir = tmp_path / "conv-skip"
+        _write_events(conv_dir, [_user_msg("hi")])
+        conv = _register_conversation(db_conn, "convskip", conv_dir, event_count=1)
+
+        stage_store = StageStore(db_conn)
+        assert stage_store.needs_processing("convskip", STAGE_NAME, 1) is True
+
+        process_human_input(db_conn, conv)
+
+        # Same event_count: no further work needed.
+        assert stage_store.needs_processing("convskip", STAGE_NAME, 1) is False
+        # Conversation grew: needs reprocessing.
+        assert stage_store.needs_processing("convskip", STAGE_NAME, 5) is True
+
+
+# ---------------------------------------------------------------------------
+# Registry test
+# ---------------------------------------------------------------------------
+
+
+def test_stage_registered_in_registry():
+    """The stage must be exposed in the STAGES registry."""
+    from ohtv.db.stages import STAGES
+
+    assert "human_input" in STAGES
+    assert STAGES["human_input"] is process_human_input

--- a/tests/unit/test_cli_db_process_stages.py
+++ b/tests/unit/test_cli_db_process_stages.py
@@ -1,0 +1,37 @@
+"""Pin the invariant: every stage in the STAGES registry must be a valid
+``ohtv db process <stage>`` choice.
+
+This guards against the click ``Choice`` allowlist drifting from the
+``STAGES`` registry (which is what caused the ``human_input`` regression
+discovered during manual testing of PR #85).
+"""
+
+from click.testing import CliRunner
+
+from ohtv.cli import main
+from ohtv.db.stages import STAGES
+
+
+def test_every_registered_stage_is_a_valid_db_process_choice() -> None:
+    """Each registered stage name must be accepted by ``ohtv db process``."""
+    runner = CliRunner()
+    for name in STAGES:
+        result = runner.invoke(main, ["db", "process", name, "--help"])
+        assert result.exit_code == 0, (
+            f"stage {name!r} rejected by `ohtv db process`:\n{result.output}"
+        )
+
+
+def test_db_process_all_is_a_valid_choice() -> None:
+    """The ``all`` sentinel must remain a valid choice."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["db", "process", "all", "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_db_process_rejects_unknown_stage() -> None:
+    """A name not in STAGES (and not ``all``) must be rejected by click."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["db", "process", "definitely_not_a_stage"])
+    assert result.exit_code != 0
+    assert "definitely_not_a_stage" in result.output


### PR DESCRIPTION
## Summary

Adds a new processing stage `human_input` that counts human words and messages per conversation, distinguishing the **initial prompt** (first user `MessageEvent`) from **follow-up messages** (subsequent user `MessageEvent`s).

This is the first of the metrics-collection stages built on top of migration 016's schema (PR #84). Issue #77's algorithm is implemented as a pure function (`count_human_input`) plus a DB-writing stage (`process_human_input`).

Closes #77.

## What was implemented

- **`src/ohtv/db/stages/human_input.py`** (new) — `HumanInputMetrics` dataclass, pure `count_human_input(events)` function, and `process_human_input(conn, conversation)` stage entry point. Counts:
  - `initial_prompt_words` — words in the first user `MessageEvent`
  - `followup_word_count` / `followup_message_count` — totals for subsequent user `MessageEvent`s
  - `initial_prompt_source` is left at its `'unknown'` default — classification is deferred to issue #83
- **`src/ohtv/db/stages/__init__.py`** — registers `human_input` as the 6th stage in the `STAGES` registry. The stage has no hard dependency on other stages; ordering is purely positional within `db process all` / `sync`.
- **`src/ohtv/cli.py`** — `ohtv db process <stage>` now derives its `click.Choice` allowlist from `STAGES.keys()` so the CLI choice list and the registry can never drift again (regression caught during round-1 manual testing — fix commit `318ea0a`).
- **`README.md`** — documents the `human_input` stage in the “Available Stages” table.

## Key decisions during review

- **CLI choices driven by the registry, not a hard-coded literal.** Round-1 manual testing found that `ohtv db process human_input` was rejected by click even though `db process all` and `sync` both picked up the new stage via the `STAGES` registry. Rather than just adding the missing entry to the literal, the choice list is now sourced from `STAGES.keys()`. A new invariant test (`tests/unit/test_cli_db_process_stages.py`) pins this contract so future stages can't reintroduce the drift.
- **`initial_prompt_source` deliberately omitted from the upsert's `ON CONFLICT ... DO UPDATE SET` clause.** This stage only fills the *count* columns. Once a downstream classifier (issue #83) writes `'human'` / `'automation'` into that column, subsequent reprocessing of `human_input` (e.g. when a conversation grows new events) must **not** clobber that classification back to `'unknown'`. This is now pinned by a dedicated integration test, `test_preserves_initial_prompt_source_on_reprocessing` in `tests/unit/db/stages/test_human_input.py` (added in `6c7c471` in response to the round-2 review suggestion).
- **Tolerant of malformed events.** Non-dict events, non-dict `llm_message`, non-list `content`, non-string `text`, and unparseable JSON files in `events/` are all skipped rather than crashing — important because we run across heterogeneous local + cloud trajectory data.
- **Word count uses `str.split()`** — simple, reproducible, collapses whitespace runs.
- **`event_count` checkpointing** via the standard `StageStore.mark_complete` flow, so `db process all` / `sync` automatically pick up new conversations and reprocess grown ones.

## Test coverage

- **1272 unit tests passing** (`uv run python -m pytest tests/ -q`), including:
  - 27 tests in `tests/unit/db/stages/test_human_input.py` — pure-function branches, DB path, idempotency, reprocessing, no-user-messages convs, malformed events, registry entry, and the new `initial_prompt_source` preservation invariant.
  - 3 invariant tests in `tests/unit/test_cli_db_process_stages.py` — every registered stage is a valid `db process` choice, `all` is accepted, unknown stages are rejected.
- **Full manual blackbox sweep** posted in two rounds:
  - [Round 1 at 21:57:05Z](https://github.com/jpshackelford/ohtv/pull/85#issuecomment-4513100519) — 14 items against 60 cloud-synced conversations; surfaced the CLI choice-list drift (Test #1).
  - [Round 2 at 22:55:11Z](https://github.com/jpshackelford/ohtv/pull/85#issuecomment-4513412435) — re-test on `318ea0a` after the CLI fix: R-1 (previously-failing `ohtv db process human_input`) now PASS, R-2a..R-2f all stages invocable individually, R-3 `db process all` ordering verified, R-4 invariant tests green, all previously-passing items regression-checked. 1271/1271 unit tests at that point.
- **Automated review at 22:28Z**: 🟢 LOW risk / Worth merging.

## Acceptance criteria (issue #77)

- [x] Stage processes conversations without `conversation_human_input` entries (via `StageStore.needs_processing`)
- [x] Correctly identifies user messages (`source="user"`, `kind="MessageEvent"`)
- [x] Separately counts initial prompt vs. follow-up messages
- [x] Extracts text from `llm_message.content[].text`
- [x] Word count uses whitespace splitting
- [x] Stores all metrics in `conversation_human_input`
- [x] Idempotent — reprocessing produces same counts
- [x] Uses `event_count` to skip already-processed conversations
- [x] Runnable on its own via `ohtv db process human_input` *(fixed in `318ea0a`, pinned by new invariant test)*
- [x] `initial_prompt_source` preserved across reprocess *(pinned by `test_preserves_initial_prompt_source_on_reprocessing` in `6c7c471`)*

## Downstream

Issue #83 (conversation classification command) depends on the `initial_prompt_source` preservation contract that this PR establishes. With that invariant now pinned by an integration test, #83 can safely write into the column without worrying about subsequent `human_input` runs clobbering its results.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._
