### PR TITLE
feat: add PR contribution detection stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,8 +952,11 @@ ohtv db process refs -v
 |-------|-------------|
 | `refs` | Extract repository, issue, and PR references |
 | `actions` | Recognize actions (file edits, git ops, PRs, issues, Notion, etc.) |
+| `contributions` | Walk the action timeline to attribute PR creation/merge/push contributions to `change_refs` (depends on `actions`) |
 | `human_input` | Count human input events per conversation; preserves `initial_prompt_source` for future classification |
 | `all` | Run all stages in sequence |
+
+Stage dependencies are respected when running `all` (e.g. `contributions` runs after `actions`). Running a stage individually before its dependencies have completed is allowed but produces no useful results — prefer `db process all` unless you know what you're doing.
 
 **Options:**
 | Flag | Description |

--- a/src/ohtv/db/stages/__init__.py
+++ b/src/ohtv/db/stages/__init__.py
@@ -10,10 +10,12 @@ Stage ordering:
 4. push_pr_links - Correlate pushes with PRs (requires actions, branch_context)
 5. summaries - Extract summaries from objective analysis cache
 6. human_input - Count human words/messages (initial prompt vs. follow-ups)
+7. contributions - Record PR contributions (created/pushed/merged) per conversation
 """
 
 from ohtv.db.stages.actions import process_actions
 from ohtv.db.stages.branch_context import process_branch_context
+from ohtv.db.stages.contributions import process_contributions
 from ohtv.db.stages.human_input import process_human_input
 from ohtv.db.stages.push_pr_links import process_push_pr_links
 from ohtv.db.stages.refs import process_refs
@@ -28,12 +30,14 @@ STAGES = {
     "push_pr_links": process_push_pr_links,
     "summaries": process_summaries,
     "human_input": process_human_input,
+    "contributions": process_contributions,
 }
 
 __all__ = [
     "STAGES",
     "process_actions",
     "process_branch_context",
+    "process_contributions",
     "process_human_input",
     "process_push_pr_links",
     "process_refs",

--- a/src/ohtv/db/stages/contributions.py
+++ b/src/ohtv/db/stages/contributions.py
@@ -59,20 +59,30 @@ STAGE_NAME = "contributions"
 
 # GitHub/GitLab/Bitbucket PR URL patterns. We accept the same hosts as the
 # refs stage so contribution detection stays in sync with repo recognition.
-_PR_URL_PATTERNS = [
-    re.compile(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"),
-    re.compile(r"https://gitlab\.com/(.+)/([^/]+)/-/merge_requests/(\d+)"),
-    re.compile(r"https://bitbucket\.org/([^/]+)/([^/]+)/pull-requests/(\d+)"),
+# Each entry is ``(pattern, host)`` so we can preserve the originating
+# platform when building canonical repository URLs.
+_PR_URL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"), "github.com"),
+    (re.compile(r"https://gitlab\.com/(.+)/([^/]+)/-/merge_requests/(\d+)"), "gitlab.com"),
+    (re.compile(r"https://bitbucket\.org/([^/]+)/([^/]+)/pull-requests/(\d+)"), "bitbucket.org"),
 ]
 
 
 @dataclass(frozen=True)
 class _PrIdent:
-    """Identifying triple for a PR detected on an action."""
+    """Identifying tuple for a PR detected on an action.
+
+    ``host`` is the platform domain (``github.com``, ``gitlab.com``, or
+    ``bitbucket.org``) and is used to construct the correct canonical
+    repository URL. It defaults to ``github.com`` for the metadata
+    fallback path, which is the only platform recognizers currently
+    populate.
+    """
 
     owner: str
     repo: str
     pr_number: int
+    host: str = "github.com"
 
 
 def process_contributions(
@@ -109,9 +119,9 @@ def process_contributions(
     orphan_push_branches: list[str] = []           # branch_keys awaiting backward pass
 
     # Fallback map for MERGE_PR actions that lack repo metadata: remember
-    # which (owner, repo) was attached to each PR number we created in
-    # this conversation.
-    seen_pr_repo: dict[int, tuple[str, str]] = {}  # pr_number → (owner, repo)
+    # which (owner, repo, host) was attached to each PR number we created
+    # in this conversation, so a follow-up merge keeps the right platform.
+    seen_pr_repo: dict[int, tuple[str, str, str]] = {}  # pr_number → (owner, repo, host)
 
     for action in actions:
         if action.action_type == ActionType.OPEN_PR:
@@ -178,7 +188,7 @@ def _handle_open_pr(
     contributions_store: ContributionsStore,
     active_pr_per_branch: dict[str, int],
     first_pr_per_branch: dict[str, int],
-    seen_pr_repo: dict[int, tuple[str, str]],
+    seen_pr_repo: dict[int, tuple[str, str, str]],
 ) -> None:
     """Record a 'created' contribution for an OPEN_PR action.
 
@@ -204,7 +214,7 @@ def _handle_open_pr(
         conversation_id, change_ref_id, "created"
     )
 
-    seen_pr_repo[ident.pr_number] = (ident.owner, ident.repo)
+    seen_pr_repo[ident.pr_number] = (ident.owner, ident.repo, ident.host)
     branch_key = _branch_key(ident.owner, ident.repo, branch)
     if branch_key is not None:
         active_pr_per_branch[branch_key] = change_ref_id
@@ -217,7 +227,7 @@ def _handle_merge_pr(
     repo_store: RepoStore,
     contributions_store: ContributionsStore,
     link_store: LinkStore,
-    seen_pr_repo: dict[int, tuple[str, str]],
+    seen_pr_repo: dict[int, tuple[str, str, str]],
 ) -> None:
     """Record a 'merged' contribution for a MERGE_PR action.
 
@@ -248,12 +258,12 @@ def _handle_merge_pr(
                 conversation_id[:8],
             )
             return
-        owner_repo = seen_pr_repo.get(pr_number)
-        if owner_repo is None:
-            owner_repo = _single_repo_for_conversation(
+        owner_repo_host = seen_pr_repo.get(pr_number)
+        if owner_repo_host is None:
+            owner_repo_host = _single_repo_for_conversation(
                 conversation_id, repo_store, link_store
             )
-        if owner_repo is None:
+        if owner_repo_host is None:
             log.debug(
                 "MERGE_PR action %s in conversation %s could not resolve a "
                 "repo for PR #%d; skipping contribution",
@@ -262,8 +272,10 @@ def _handle_merge_pr(
                 pr_number,
             )
             return
-        owner, repo = owner_repo
-        ident = _PrIdent(owner=owner, repo=repo, pr_number=pr_number)
+        owner, repo, host = owner_repo_host
+        ident = _PrIdent(
+            owner=owner, repo=repo, pr_number=pr_number, host=host
+        )
 
     repo_id = _upsert_repo_for(repo_store, ident)
     change_ref_id = contributions_store.get_or_create_pr_change_ref(
@@ -323,12 +335,14 @@ def _identify_pr(action: ConversationAction) -> _PrIdent | None:
     """
     target = action.target
     if target:
-        for pattern in _PR_URL_PATTERNS:
+        for pattern, host in _PR_URL_PATTERNS:
             match = pattern.search(target)
             if match:
                 owner, repo, num = match.group(1), match.group(2), match.group(3)
                 try:
-                    return _PrIdent(owner=owner, repo=repo, pr_number=int(num))
+                    return _PrIdent(
+                        owner=owner, repo=repo, pr_number=int(num), host=host
+                    )
                 except ValueError:
                     pass  # extremely unlikely - regex matches \d+
 
@@ -350,7 +364,7 @@ def _pr_number_from_target(target: str | None) -> int | None:
     """
     if not target:
         return None
-    for pattern in _PR_URL_PATTERNS:
+    for pattern, _host in _PR_URL_PATTERNS:
         match = pattern.search(target)
         if match:
             try:
@@ -386,15 +400,15 @@ def _branch_key(owner: str | None, repo: str | None, branch: str | None) -> str 
 
 
 def _upsert_repo_for(repo_store: RepoStore, ident: _PrIdent) -> int:
-    """Upsert a Repository row from a ``(owner, repo)`` pair and return its ID.
+    """Upsert a Repository row from a PR identity and return its ID.
 
-    Assumes GitHub as the canonical host for now (matches the existing
-    OPEN_PR / push-pr-link code paths). Other hosts can be added when
-    their recognizers start populating metadata.
+    The canonical URL is built from ``ident.host`` so GitHub, GitLab,
+    and Bitbucket PRs each round-trip into the correct upstream URL.
+    Mirrors the platform handling in :mod:`ohtv.db.stages.refs`.
     """
     repo = Repository(
         id=None,
-        canonical_url=f"https://github.com/{ident.owner}/{ident.repo}",
+        canonical_url=f"https://{ident.host}/{ident.owner}/{ident.repo}",
         fqn=f"{ident.owner}/{ident.repo}",
         short_name=ident.repo,
     )
@@ -405,12 +419,14 @@ def _single_repo_for_conversation(
     conversation_id: str,
     repo_store: RepoStore,
     link_store: LinkStore,
-) -> tuple[str, str] | None:
-    """If exactly one repo is linked to a conversation, return its ``(owner, repo)``.
+) -> tuple[str, str, str] | None:
+    """If exactly one repo is linked to a conversation, return its ``(owner, repo, host)``.
 
     Used as a last-resort fallback for MERGE_PR actions that have no
     repo info of their own. Refuses to choose if there are zero or
-    multiple linked repos.
+    multiple linked repos. ``host`` is parsed from the linked
+    repository's ``canonical_url`` so the platform is preserved across
+    the fallback path.
     """
     linked = link_store.get_repos_for_conversation(conversation_id)
     if len(linked) != 1:
@@ -422,4 +438,18 @@ def _single_repo_for_conversation(
     owner, _, name = repo.fqn.partition("/")
     if not owner or not name:
         return None
-    return owner, name
+    host = _host_from_canonical_url(repo.canonical_url)
+    return owner, name, host
+
+
+def _host_from_canonical_url(canonical_url: str | None) -> str:
+    """Extract the host (e.g. ``github.com``) from a canonical repo URL.
+
+    Defaults to ``github.com`` if the URL is missing or unparseable, to
+    match the historical assumption in this stage.
+    """
+    if canonical_url:
+        match = re.match(r"https?://([^/]+)/", canonical_url)
+        if match:
+            return match.group(1)
+    return "github.com"

--- a/src/ohtv/db/stages/contributions.py
+++ b/src/ohtv/db/stages/contributions.py
@@ -1,0 +1,425 @@
+"""Contribution detection stage.
+
+Walks the (already-processed) ``actions`` for a conversation and records
+the conversation's contributions to PRs in two tables created by
+migration 016:
+
+- ``change_refs`` rows (one per ``(repo, pr_number)``) are upserted via
+  :class:`ContributionsStore`. Multiple conversations contributing to the
+  same PR share a single ``change_refs`` row (many-to-many).
+- ``conversation_contributions`` rows link the conversation to each
+  change with a ``contribution_type`` of ``created``, ``pushed``, or
+  ``merged``.
+
+Mapping from action → contribution:
+
+- ``OPEN_PR``  → ``contribution_type="created"``
+- ``MERGE_PR`` → ``contribution_type="merged"``
+- ``GIT_PUSH`` to a branch with an active PR → ``contribution_type="pushed"``
+
+Push-to-PR correlation mirrors the temporal logic in
+:mod:`ohtv.db.stages.push_pr_links`: a forward pass tracks the active PR
+per branch while iterating actions in temporal order, and a backward
+pass attaches "orphan" pushes (those that occurred before any PR on
+their branch) to the first subsequent PR opened on the same branch.
+
+This stage runs after ``actions``. It is idempotent: contributions are
+fully recomputed from the current actions on each run, so growing
+conversations and prompt-revised action recognizers both Just Work
+without leaving stale rows behind. ``change_refs`` rows themselves are
+left in place because they are shared across conversations.
+
+The stage is also written to be generic enough that issue #79
+(direct-push-to-main detection) can add a sibling stage which records
+``contribution_type="pushed"`` against a ``direct_push`` ``change_ref``
+without any refactoring here.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from dataclasses import dataclass
+
+from ohtv.db.models import Conversation, Repository
+from ohtv.db.models.action import ActionType, ConversationAction
+from ohtv.db.stores import (
+    ActionStore,
+    ContributionsStore,
+    LinkStore,
+    RepoStore,
+    StageStore,
+)
+
+log = logging.getLogger("ohtv")
+
+STAGE_NAME = "contributions"
+
+
+# GitHub/GitLab/Bitbucket PR URL patterns. We accept the same hosts as the
+# refs stage so contribution detection stays in sync with repo recognition.
+_PR_URL_PATTERNS = [
+    re.compile(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"),
+    re.compile(r"https://gitlab\.com/(.+)/([^/]+)/-/merge_requests/(\d+)"),
+    re.compile(r"https://bitbucket\.org/([^/]+)/([^/]+)/pull-requests/(\d+)"),
+]
+
+
+@dataclass(frozen=True)
+class _PrIdent:
+    """Identifying triple for a PR detected on an action."""
+
+    owner: str
+    repo: str
+    pr_number: int
+
+
+def process_contributions(
+    conn: sqlite3.Connection, conversation: Conversation
+) -> None:
+    """Detect PR contributions for a conversation and persist them.
+
+    Reads recognized actions from the database (the ``actions`` stage
+    must have run first), derives ``created``/``merged``/``pushed``
+    contributions, and writes them to ``conversation_contributions``,
+    creating ``change_refs`` and ``repositories`` rows as needed.
+
+    Args:
+        conn: Database connection.
+        conversation: The conversation to process.
+    """
+    action_store = ActionStore(conn)
+    repo_store = RepoStore(conn)
+    link_store = LinkStore(conn)
+    contributions_store = ContributionsStore(conn)
+    stage_store = StageStore(conn)
+
+    # Reprocessing-safe: blow away this conversation's prior contributions
+    # before re-deriving them. We never touch change_refs themselves, since
+    # they may be referenced by other contributors.
+    contributions_store.delete_contributions_for_conversation(conversation.id)
+
+    # Actions are returned in temporal order (by id ASC) - see ActionStore.
+    actions = action_store.get_by_conversation(conversation.id)
+
+    # Forward-pass state for push-to-PR correlation. Mirrors push_pr_links.
+    active_pr_per_branch: dict[str, int] = {}      # branch_key → change_ref_id
+    first_pr_per_branch: dict[str, int] = {}       # branch_key → change_ref_id
+    orphan_push_branches: list[str] = []           # branch_keys awaiting backward pass
+
+    # Fallback map for MERGE_PR actions that lack repo metadata: remember
+    # which (owner, repo) was attached to each PR number we created in
+    # this conversation.
+    seen_pr_repo: dict[int, tuple[str, str]] = {}  # pr_number → (owner, repo)
+
+    for action in actions:
+        if action.action_type == ActionType.OPEN_PR:
+            _handle_open_pr(
+                action,
+                conversation.id,
+                repo_store,
+                contributions_store,
+                active_pr_per_branch,
+                first_pr_per_branch,
+                seen_pr_repo,
+            )
+        elif action.action_type == ActionType.MERGE_PR:
+            _handle_merge_pr(
+                action,
+                conversation.id,
+                repo_store,
+                contributions_store,
+                link_store,
+                seen_pr_repo,
+            )
+        elif action.action_type == ActionType.GIT_PUSH:
+            _handle_git_push(
+                action,
+                conversation.id,
+                contributions_store,
+                active_pr_per_branch,
+                orphan_push_branches,
+            )
+
+    # Backward pass: pushes that happened before any PR on their branch
+    # link to the first PR subsequently opened on that branch (matches
+    # push_pr_links semantics for the WRITE ref link).
+    for branch_key in orphan_push_branches:
+        change_ref_id = first_pr_per_branch.get(branch_key)
+        if change_ref_id is not None:
+            contributions_store.record_contribution(
+                conversation.id, change_ref_id, "pushed"
+            )
+
+    stage_store.mark_complete(
+        conversation.id, STAGE_NAME, conversation.event_count
+    )
+
+    log.debug(
+        "contributions %s: %d action(s) scanned, %d active PR branch(es), "
+        "%d orphan push(es)",
+        conversation.id[:8],
+        len(actions),
+        len(active_pr_per_branch),
+        len(orphan_push_branches),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-action handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_open_pr(
+    action: ConversationAction,
+    conversation_id: str,
+    repo_store: RepoStore,
+    contributions_store: ContributionsStore,
+    active_pr_per_branch: dict[str, int],
+    first_pr_per_branch: dict[str, int],
+    seen_pr_repo: dict[int, tuple[str, str]],
+) -> None:
+    """Record a 'created' contribution for an OPEN_PR action.
+
+    Updates the branch → change_ref maps so subsequent pushes on the
+    same branch can be attributed to this PR.
+    """
+    ident = _identify_pr(action)
+    if ident is None:
+        log.debug(
+            "OPEN_PR action %s in conversation %s has no parseable PR "
+            "identity; skipping contribution",
+            action.id,
+            conversation_id[:8],
+        )
+        return
+
+    repo_id = _upsert_repo_for(repo_store, ident)
+    branch = _branch_from_metadata(action)
+    change_ref_id = contributions_store.get_or_create_pr_change_ref(
+        repo_id, ident.pr_number, branch=branch
+    )
+    contributions_store.record_contribution(
+        conversation_id, change_ref_id, "created"
+    )
+
+    seen_pr_repo[ident.pr_number] = (ident.owner, ident.repo)
+    branch_key = _branch_key(ident.owner, ident.repo, branch)
+    if branch_key is not None:
+        active_pr_per_branch[branch_key] = change_ref_id
+        first_pr_per_branch.setdefault(branch_key, change_ref_id)
+
+
+def _handle_merge_pr(
+    action: ConversationAction,
+    conversation_id: str,
+    repo_store: RepoStore,
+    contributions_store: ContributionsStore,
+    link_store: LinkStore,
+    seen_pr_repo: dict[int, tuple[str, str]],
+) -> None:
+    """Record a 'merged' contribution for a MERGE_PR action.
+
+    The recognizer does not currently attach repo info to MERGE_PR
+    metadata - ``target`` is usually just the PR number from the
+    command. We fall back through:
+
+      1. A PR URL parsed from ``target`` (when the user merged by URL).
+      2. ``metadata.owner`` / ``metadata.repo`` (future-proofing).
+      3. The (pr_number → repo) map populated by earlier OPEN_PR
+         actions in the same conversation.
+      4. A single repository linked to this conversation via
+         ``conversation_repos`` (only used if exactly one - we refuse to
+         guess across multiple repos).
+
+    If none of those resolve, the action is logged at DEBUG and
+    skipped: better to miss a contribution than to attribute it to the
+    wrong repo.
+    """
+    ident = _identify_pr(action)
+    if ident is None:
+        # Fall back to the PRs we have already seen in this conversation.
+        pr_number = _pr_number_from_target(action.target)
+        if pr_number is None:
+            log.debug(
+                "MERGE_PR action %s in conversation %s has no PR number; skipping",
+                action.id,
+                conversation_id[:8],
+            )
+            return
+        owner_repo = seen_pr_repo.get(pr_number)
+        if owner_repo is None:
+            owner_repo = _single_repo_for_conversation(
+                conversation_id, repo_store, link_store
+            )
+        if owner_repo is None:
+            log.debug(
+                "MERGE_PR action %s in conversation %s could not resolve a "
+                "repo for PR #%d; skipping contribution",
+                action.id,
+                conversation_id[:8],
+                pr_number,
+            )
+            return
+        owner, repo = owner_repo
+        ident = _PrIdent(owner=owner, repo=repo, pr_number=pr_number)
+
+    repo_id = _upsert_repo_for(repo_store, ident)
+    change_ref_id = contributions_store.get_or_create_pr_change_ref(
+        repo_id, ident.pr_number
+    )
+    contributions_store.record_contribution(
+        conversation_id, change_ref_id, "merged"
+    )
+
+
+def _handle_git_push(
+    action: ConversationAction,
+    conversation_id: str,
+    contributions_store: ContributionsStore,
+    active_pr_per_branch: dict[str, int],
+    orphan_push_branches: list[str],
+) -> None:
+    """Attribute a GIT_PUSH action to its branch's PR, when possible.
+
+    If no PR has yet been opened on the branch (within this conversation)
+    the push is queued as an orphan for the backward pass.
+    """
+    if not action.metadata:
+        return
+    branch = action.metadata.get("branch")
+    owner = action.metadata.get("owner")
+    repo = action.metadata.get("repo")
+    if not branch or not owner or not repo:
+        # Conservative: don't guess across repos.
+        return
+
+    branch_key = _branch_key(owner, repo, branch)
+    if branch_key is None:
+        return
+
+    change_ref_id = active_pr_per_branch.get(branch_key)
+    if change_ref_id is not None:
+        contributions_store.record_contribution(
+            conversation_id, change_ref_id, "pushed"
+        )
+    else:
+        orphan_push_branches.append(branch_key)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _identify_pr(action: ConversationAction) -> _PrIdent | None:
+    """Return ``(owner, repo, pr_number)`` for a PR action, if derivable.
+
+    Looks first at ``target`` (which is the canonical PR URL for
+    ``OPEN_PR``) and falls back to ``metadata.owner`` / ``metadata.repo``
+    combined with a number extracted from ``target``. Returns ``None``
+    if no triple can be assembled.
+    """
+    target = action.target
+    if target:
+        for pattern in _PR_URL_PATTERNS:
+            match = pattern.search(target)
+            if match:
+                owner, repo, num = match.group(1), match.group(2), match.group(3)
+                try:
+                    return _PrIdent(owner=owner, repo=repo, pr_number=int(num))
+                except ValueError:
+                    pass  # extremely unlikely - regex matches \d+
+
+    metadata = action.metadata or {}
+    owner = metadata.get("owner")
+    repo = metadata.get("repo")
+    pr_number = _pr_number_from_target(target)
+    if owner and repo and pr_number is not None:
+        return _PrIdent(owner=owner, repo=repo, pr_number=pr_number)
+    return None
+
+
+def _pr_number_from_target(target: str | None) -> int | None:
+    """Best-effort PR number extraction from an action's ``target``.
+
+    ``target`` for ``MERGE_PR`` is typically just a stringified number
+    (from ``gh pr merge 123``); for ``OPEN_PR`` it is a full URL. We
+    handle both shapes and return ``None`` if neither matches.
+    """
+    if not target:
+        return None
+    for pattern in _PR_URL_PATTERNS:
+        match = pattern.search(target)
+        if match:
+            try:
+                return int(match.group(3))
+            except ValueError:
+                return None
+    # Bare digits, e.g. "123"
+    if target.isdigit():
+        try:
+            return int(target)
+        except ValueError:
+            return None
+    return None
+
+
+def _branch_from_metadata(action: ConversationAction) -> str | None:
+    """Pull a head branch name from an OPEN_PR action's metadata."""
+    if not action.metadata:
+        return None
+    branch = action.metadata.get("head_branch")
+    return branch if isinstance(branch, str) and branch else None
+
+
+def _branch_key(owner: str | None, repo: str | None, branch: str | None) -> str | None:
+    """Build the ``owner/repo:branch`` key used for push correlation.
+
+    Returns ``None`` unless all three components are present - we
+    deliberately refuse partial matches to avoid cross-repo confusion.
+    """
+    if not owner or not repo or not branch:
+        return None
+    return f"{owner}/{repo}:{branch}"
+
+
+def _upsert_repo_for(repo_store: RepoStore, ident: _PrIdent) -> int:
+    """Upsert a Repository row from a ``(owner, repo)`` pair and return its ID.
+
+    Assumes GitHub as the canonical host for now (matches the existing
+    OPEN_PR / push-pr-link code paths). Other hosts can be added when
+    their recognizers start populating metadata.
+    """
+    repo = Repository(
+        id=None,
+        canonical_url=f"https://github.com/{ident.owner}/{ident.repo}",
+        fqn=f"{ident.owner}/{ident.repo}",
+        short_name=ident.repo,
+    )
+    return repo_store.upsert(repo)
+
+
+def _single_repo_for_conversation(
+    conversation_id: str,
+    repo_store: RepoStore,
+    link_store: LinkStore,
+) -> tuple[str, str] | None:
+    """If exactly one repo is linked to a conversation, return its ``(owner, repo)``.
+
+    Used as a last-resort fallback for MERGE_PR actions that have no
+    repo info of their own. Refuses to choose if there are zero or
+    multiple linked repos.
+    """
+    linked = link_store.get_repos_for_conversation(conversation_id)
+    if len(linked) != 1:
+        return None
+    repo_id, _link_type = linked[0]
+    repo = repo_store.get_by_id(repo_id)
+    if repo is None or "/" not in repo.fqn:
+        return None
+    owner, _, name = repo.fqn.partition("/")
+    if not owner or not name:
+        return None
+    return owner, name

--- a/src/ohtv/db/stages/contributions.py
+++ b/src/ohtv/db/stages/contributions.py
@@ -116,7 +116,7 @@ def process_contributions(
     # Forward-pass state for push-to-PR correlation. Mirrors push_pr_links.
     active_pr_per_branch: dict[str, int] = {}      # branch_key → change_ref_id
     first_pr_per_branch: dict[str, int] = {}       # branch_key → change_ref_id
-    orphan_push_branches: list[str] = []           # branch_keys awaiting backward pass
+    orphan_push_branches: set[str] = set()         # branch_keys awaiting backward pass
 
     # Fallback map for MERGE_PR actions that lack repo metadata: remember
     # which (owner, repo, host) was attached to each PR number we created
@@ -291,7 +291,7 @@ def _handle_git_push(
     conversation_id: str,
     contributions_store: ContributionsStore,
     active_pr_per_branch: dict[str, int],
-    orphan_push_branches: list[str],
+    orphan_push_branches: set[str],
 ) -> None:
     """Attribute a GIT_PUSH action to its branch's PR, when possible.
 
@@ -317,7 +317,7 @@ def _handle_git_push(
             conversation_id, change_ref_id, "pushed"
         )
     else:
-        orphan_push_branches.append(branch_key)
+        orphan_push_branches.add(branch_key)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ohtv/db/stores/__init__.py
+++ b/src/ohtv/db/stores/__init__.py
@@ -2,6 +2,11 @@
 
 from ohtv.db.stores.action_store import ActionStore
 from ohtv.db.stores.analysis_cache_store import AnalysisCacheStore
+from ohtv.db.stores.contributions_store import (
+    ChangeRef,
+    Contribution,
+    ContributionsStore,
+)
 from ohtv.db.stores.conversation_store import ConversationStore
 from ohtv.db.stores.embedding_store import EmbeddingStore
 from ohtv.db.stores.link_store import LinkStore
@@ -12,6 +17,9 @@ from ohtv.db.stores.stage_store import StageStore
 __all__ = [
     "ActionStore",
     "AnalysisCacheStore",
+    "ChangeRef",
+    "Contribution",
+    "ContributionsStore",
     "ConversationStore",
     "EmbeddingStore",
     "LinkStore",

--- a/src/ohtv/db/stores/contributions_store.py
+++ b/src/ohtv/db/stores/contributions_store.py
@@ -1,0 +1,269 @@
+"""Data store for change references and conversation contributions.
+
+This store backs the contribution tracking tables (created by migration 016):
+
+- ``change_refs`` - PRs and direct pushes to main, deduplicated per repo
+- ``conversation_contributions`` - many-to-many links between conversations
+  and the changes they created/pushed/merged
+
+The store is intentionally narrow and generic: it knows how to upsert PR
+and direct-push change refs and how to record contributions of any type.
+This keeps the per-conversation processing logic (see
+``ohtv.db.stages.contributions``) free of SQL concerns and lets follow-up
+features (e.g. issue #79 - direct push detection) reuse the same store
+without modification.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+ChangeType = Literal["pr", "direct_push"]
+ContributionType = Literal["created", "pushed", "merged"]
+
+
+@dataclass(frozen=True)
+class ChangeRef:
+    """A row from the ``change_refs`` table."""
+
+    id: int
+    repo_id: int
+    change_type: ChangeType
+    pr_number: int | None
+    commit_range: str | None
+    branch: str | None
+    status: str
+
+
+@dataclass(frozen=True)
+class Contribution:
+    """A row from the ``conversation_contributions`` table."""
+
+    id: int
+    conversation_id: str
+    change_ref_id: int
+    contribution_type: ContributionType
+
+
+class ContributionsStore:
+    """Data access for ``change_refs`` and ``conversation_contributions``."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    # ---- change_refs ----------------------------------------------------
+
+    def get_or_create_pr_change_ref(
+        self,
+        repo_id: int,
+        pr_number: int,
+        branch: str | None = None,
+    ) -> int:
+        """Return the change_ref ID for a PR, creating it if needed.
+
+        PRs are uniquely identified by ``(repo_id, pr_number)``. If a row
+        already exists, its ID is returned unchanged - ``branch`` and
+        ``status`` are not modified on lookup so we never clobber data a
+        future stage (or manual fetch) may have populated. A new row is
+        created with ``status='pending'`` and the supplied ``branch``.
+
+        Args:
+            repo_id: Foreign key into ``repositories``.
+            pr_number: PR or MR number (e.g. ``42`` for ``#42``).
+            branch: Optional head branch name, recorded on creation only.
+
+        Returns:
+            The integer ID of the (existing or newly inserted) change_ref.
+        """
+        cursor = self.conn.execute(
+            "SELECT id FROM change_refs "
+            "WHERE repo_id = ? AND change_type = 'pr' AND pr_number = ?",
+            (repo_id, pr_number),
+        )
+        row = cursor.fetchone()
+        if row is not None:
+            return row[0] if not isinstance(row, sqlite3.Row) else row["id"]
+
+        cursor = self.conn.execute(
+            """
+            INSERT INTO change_refs (repo_id, change_type, pr_number, branch, status)
+            VALUES (?, 'pr', ?, ?, 'pending')
+            RETURNING id
+            """,
+            (repo_id, pr_number, branch),
+        )
+        return cursor.fetchone()[0]
+
+    def get_or_create_direct_push_change_ref(
+        self,
+        repo_id: int,
+        commit_range: str,
+        branch: str | None = None,
+    ) -> int:
+        """Return the change_ref ID for a direct push, creating it if needed.
+
+        Direct pushes are uniquely identified by ``(repo_id, commit_range)``.
+        This method is provided so a future stage (issue #79) can detect
+        pushes that bypass PRs without needing to add a new store.
+
+        Args:
+            repo_id: Foreign key into ``repositories``.
+            commit_range: A unique identifier for the push - typically the
+                ``oldsha..newsha`` range from ``git push`` output.
+            branch: Optional branch name, recorded on creation only.
+
+        Returns:
+            The integer ID of the (existing or newly inserted) change_ref.
+        """
+        cursor = self.conn.execute(
+            "SELECT id FROM change_refs "
+            "WHERE repo_id = ? AND change_type = 'direct_push' "
+            "AND commit_range = ?",
+            (repo_id, commit_range),
+        )
+        row = cursor.fetchone()
+        if row is not None:
+            return row[0] if not isinstance(row, sqlite3.Row) else row["id"]
+
+        cursor = self.conn.execute(
+            """
+            INSERT INTO change_refs
+                (repo_id, change_type, commit_range, branch, status)
+            VALUES (?, 'direct_push', ?, ?, 'pending')
+            RETURNING id
+            """,
+            (repo_id, commit_range, branch),
+        )
+        return cursor.fetchone()[0]
+
+    def get_change_ref(self, change_ref_id: int) -> ChangeRef | None:
+        """Fetch a single change_ref by ID, or None if it does not exist."""
+        cursor = self.conn.execute(
+            "SELECT id, repo_id, change_type, pr_number, commit_range, "
+            "branch, status FROM change_refs WHERE id = ?",
+            (change_ref_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_change_ref(row)
+
+    def list_pr_change_refs(self, repo_id: int) -> Sequence[ChangeRef]:
+        """List all PR change_refs for a repository, ordered by pr_number."""
+        cursor = self.conn.execute(
+            "SELECT id, repo_id, change_type, pr_number, commit_range, "
+            "branch, status FROM change_refs "
+            "WHERE repo_id = ? AND change_type = 'pr' "
+            "ORDER BY pr_number",
+            (repo_id,),
+        )
+        return [_row_to_change_ref(row) for row in cursor.fetchall()]
+
+    # ---- conversation_contributions ------------------------------------
+
+    def record_contribution(
+        self,
+        conversation_id: str,
+        change_ref_id: int,
+        contribution_type: ContributionType,
+    ) -> None:
+        """Record a contribution, ignoring exact duplicates.
+
+        The ``(conversation_id, change_ref_id, contribution_type)`` triple
+        is unique in the schema; ``INSERT OR IGNORE`` keeps the method
+        idempotent so callers can replay events safely.
+        """
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO conversation_contributions
+                (conversation_id, change_ref_id, contribution_type)
+            VALUES (?, ?, ?)
+            """,
+            (conversation_id, change_ref_id, contribution_type),
+        )
+
+    def delete_contributions_for_conversation(self, conversation_id: str) -> int:
+        """Delete all contributions for a conversation.
+
+        Used by the stage to make reprocessing idempotent: clear the prior
+        state for this conversation, then re-derive contributions from the
+        current actions. Returns the number of rows deleted.
+
+        Note: this does NOT delete ``change_refs`` themselves - those are
+        shared across conversations (many-to-many) and may still be
+        referenced by other contributors.
+        """
+        cursor = self.conn.execute(
+            "DELETE FROM conversation_contributions WHERE conversation_id = ?",
+            (conversation_id,),
+        )
+        return cursor.rowcount
+
+    def get_contributions_for_conversation(
+        self, conversation_id: str
+    ) -> Sequence[Contribution]:
+        """Return all contributions made by a conversation, ordered by id."""
+        cursor = self.conn.execute(
+            "SELECT id, conversation_id, change_ref_id, contribution_type "
+            "FROM conversation_contributions "
+            "WHERE conversation_id = ? ORDER BY id",
+            (conversation_id,),
+        )
+        return [_row_to_contribution(row) for row in cursor.fetchall()]
+
+    def get_contributors_for_change_ref(
+        self, change_ref_id: int
+    ) -> Sequence[Contribution]:
+        """Return all contributions made to a change_ref, ordered by id."""
+        cursor = self.conn.execute(
+            "SELECT id, conversation_id, change_ref_id, contribution_type "
+            "FROM conversation_contributions "
+            "WHERE change_ref_id = ? ORDER BY id",
+            (change_ref_id,),
+        )
+        return [_row_to_contribution(row) for row in cursor.fetchall()]
+
+
+def _row_to_change_ref(row: sqlite3.Row | tuple) -> ChangeRef:
+    """Convert a ``change_refs`` row to a :class:`ChangeRef`.
+
+    Works for both ``Row`` (dict-like) and plain-tuple cursors.
+    """
+    if isinstance(row, sqlite3.Row):
+        return ChangeRef(
+            id=row["id"],
+            repo_id=row["repo_id"],
+            change_type=row["change_type"],
+            pr_number=row["pr_number"],
+            commit_range=row["commit_range"],
+            branch=row["branch"],
+            status=row["status"],
+        )
+    return ChangeRef(
+        id=row[0],
+        repo_id=row[1],
+        change_type=row[2],
+        pr_number=row[3],
+        commit_range=row[4],
+        branch=row[5],
+        status=row[6],
+    )
+
+
+def _row_to_contribution(row: sqlite3.Row | tuple) -> Contribution:
+    """Convert a ``conversation_contributions`` row to a :class:`Contribution`."""
+    if isinstance(row, sqlite3.Row):
+        return Contribution(
+            id=row["id"],
+            conversation_id=row["conversation_id"],
+            change_ref_id=row["change_ref_id"],
+            contribution_type=row["contribution_type"],
+        )
+    return Contribution(
+        id=row[0],
+        conversation_id=row[1],
+        change_ref_id=row[2],
+        contribution_type=row[3],
+    )

--- a/tests/unit/db/stages/test_contributions.py
+++ b/tests/unit/db/stages/test_contributions.py
@@ -89,7 +89,9 @@ class TestIdentifyPr:
             target="https://github.com/acme/widgets/pull/42",
         )
         ident = _identify_pr(action)
-        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=42)
+        assert ident == _PrIdent(
+            owner="acme", repo="widgets", pr_number=42, host="github.com"
+        )
 
     def test_from_gitlab_mr_url(self):
         action = ConversationAction(
@@ -99,7 +101,9 @@ class TestIdentifyPr:
             target="https://gitlab.com/acme/widgets/-/merge_requests/17",
         )
         ident = _identify_pr(action)
-        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=17)
+        assert ident == _PrIdent(
+            owner="acme", repo="widgets", pr_number=17, host="gitlab.com"
+        )
 
     def test_from_bitbucket_pr_url(self):
         action = ConversationAction(
@@ -109,7 +113,9 @@ class TestIdentifyPr:
             target="https://bitbucket.org/acme/widgets/pull-requests/9",
         )
         ident = _identify_pr(action)
-        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=9)
+        assert ident == _PrIdent(
+            owner="acme", repo="widgets", pr_number=9, host="bitbucket.org"
+        )
 
     def test_falls_back_to_metadata_when_target_is_bare_number(self):
         action = ConversationAction(
@@ -120,7 +126,11 @@ class TestIdentifyPr:
             metadata={"owner": "acme", "repo": "widgets"},
         )
         ident = _identify_pr(action)
-        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=42)
+        # Metadata fallback path has no URL to inspect, so it defaults to
+        # github.com - this matches the recognizer's current behavior.
+        assert ident == _PrIdent(
+            owner="acme", repo="widgets", pr_number=42, host="github.com"
+        )
 
     def test_returns_none_when_target_is_bare_number_without_metadata(self):
         action = ConversationAction(
@@ -209,6 +219,83 @@ class TestProcessContributions:
         assert repo is not None
         assert repo.fqn == "acme/widgets"
         assert repo.canonical_url == "https://github.com/acme/widgets"
+
+    def test_open_pr_on_gitlab_preserves_canonical_url(self, db_conn):
+        """OPEN_PR for a GitLab MR must upsert a gitlab.com repo, not github.com."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://gitlab.com/acme/widgets/-/merge_requests/17",
+            metadata={"head_branch": "feature/x"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert len(contributions) == 1
+        change_ref = ContributionsStore(db_conn).get_change_ref(
+            contributions[0].change_ref_id
+        )
+        assert change_ref is not None
+        repo = RepoStore(db_conn).get_by_id(change_ref.repo_id)
+        assert repo is not None
+        assert repo.fqn == "acme/widgets"
+        assert repo.canonical_url == "https://gitlab.com/acme/widgets"
+
+    def test_open_pr_on_bitbucket_preserves_canonical_url(self, db_conn):
+        """OPEN_PR for a Bitbucket PR must upsert a bitbucket.org repo, not github.com."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://bitbucket.org/acme/widgets/pull-requests/9",
+            metadata={"head_branch": "feature/x"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert len(contributions) == 1
+        change_ref = ContributionsStore(db_conn).get_change_ref(
+            contributions[0].change_ref_id
+        )
+        assert change_ref is not None
+        repo = RepoStore(db_conn).get_by_id(change_ref.repo_id)
+        assert repo is not None
+        assert repo.fqn == "acme/widgets"
+        assert repo.canonical_url == "https://bitbucket.org/acme/widgets"
+
+    def test_merge_pr_on_gitlab_preserves_canonical_url(self, db_conn):
+        """MERGE_PR for a GitLab MR (by URL) must upsert a gitlab.com repo."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="https://gitlab.com/acme/widgets/-/merge_requests/17",
+            metadata={"source": "gitlab"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert len(contributions) == 1
+        change_ref = ContributionsStore(db_conn).get_change_ref(
+            contributions[0].change_ref_id
+        )
+        assert change_ref is not None
+        repo = RepoStore(db_conn).get_by_id(change_ref.repo_id)
+        assert repo is not None
+        assert repo.canonical_url == "https://gitlab.com/acme/widgets"
 
     def test_merge_pr_creates_change_ref_and_merged_contribution(self, db_conn):
         conv = _register_conversation(db_conn)

--- a/tests/unit/db/stages/test_contributions.py
+++ b/tests/unit/db/stages/test_contributions.py
@@ -1,0 +1,699 @@
+"""Tests for the contributions detection stage."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from ohtv.db.migrations import migrate
+from ohtv.db.models import Conversation, LinkType, Repository
+from ohtv.db.models.action import ActionType, ConversationAction
+from ohtv.db.stages.contributions import (
+    STAGE_NAME,
+    _branch_key,
+    _identify_pr,
+    _pr_number_from_target,
+    _PrIdent,
+    process_contributions,
+)
+from ohtv.db.stores import (
+    ActionStore,
+    ContributionsStore,
+    ConversationStore,
+    LinkStore,
+    RepoStore,
+    StageStore,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_conn():
+    """In-memory DB with the full migration chain applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrate(conn)
+    yield conn
+    conn.close()
+
+
+def _register_conversation(
+    db_conn: sqlite3.Connection,
+    conv_id: str = "conv-1",
+    event_count: int = 5,
+) -> Conversation:
+    conv = Conversation(
+        id=conv_id,
+        location=f"/tmp/{conv_id}",
+        event_count=event_count,
+    )
+    ConversationStore(db_conn).upsert(conv)
+    return conv
+
+
+def _insert_action(
+    db_conn: sqlite3.Connection,
+    conversation_id: str,
+    action_type: ActionType,
+    target: str | None = None,
+    metadata: dict | None = None,
+) -> int:
+    """Insert a single action and return its DB id."""
+    return ActionStore(db_conn).insert(
+        ConversationAction(
+            id=None,
+            conversation_id=conversation_id,
+            action_type=action_type,
+            target=target,
+            metadata=metadata,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyPr:
+    def test_from_github_pr_url(self):
+        action = ConversationAction(
+            id=1,
+            conversation_id="c",
+            action_type=ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+        )
+        ident = _identify_pr(action)
+        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=42)
+
+    def test_from_gitlab_mr_url(self):
+        action = ConversationAction(
+            id=1,
+            conversation_id="c",
+            action_type=ActionType.OPEN_PR,
+            target="https://gitlab.com/acme/widgets/-/merge_requests/17",
+        )
+        ident = _identify_pr(action)
+        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=17)
+
+    def test_from_bitbucket_pr_url(self):
+        action = ConversationAction(
+            id=1,
+            conversation_id="c",
+            action_type=ActionType.OPEN_PR,
+            target="https://bitbucket.org/acme/widgets/pull-requests/9",
+        )
+        ident = _identify_pr(action)
+        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=9)
+
+    def test_falls_back_to_metadata_when_target_is_bare_number(self):
+        action = ConversationAction(
+            id=1,
+            conversation_id="c",
+            action_type=ActionType.MERGE_PR,
+            target="42",
+            metadata={"owner": "acme", "repo": "widgets"},
+        )
+        ident = _identify_pr(action)
+        assert ident == _PrIdent(owner="acme", repo="widgets", pr_number=42)
+
+    def test_returns_none_when_target_is_bare_number_without_metadata(self):
+        action = ConversationAction(
+            id=1,
+            conversation_id="c",
+            action_type=ActionType.MERGE_PR,
+            target="42",
+            metadata={"source": "github"},
+        )
+        assert _identify_pr(action) is None
+
+    def test_returns_none_when_nothing_parseable(self):
+        action = ConversationAction(
+            id=1,
+            conversation_id="c",
+            action_type=ActionType.OPEN_PR,
+            target=None,
+            metadata=None,
+        )
+        assert _identify_pr(action) is None
+
+
+class TestPrNumberFromTarget:
+    def test_none(self):
+        assert _pr_number_from_target(None) is None
+
+    def test_url(self):
+        assert _pr_number_from_target(
+            "https://github.com/o/r/pull/55"
+        ) == 55
+
+    def test_bare_digits(self):
+        assert _pr_number_from_target("123") == 123
+
+    def test_garbage(self):
+        assert _pr_number_from_target("nope") is None
+
+
+class TestBranchKey:
+    def test_full(self):
+        assert _branch_key("o", "r", "feature/x") == "o/r:feature/x"
+
+    def test_missing_owner(self):
+        assert _branch_key(None, "r", "b") is None
+
+    def test_missing_branch(self):
+        assert _branch_key("o", "r", None) is None
+
+
+# ---------------------------------------------------------------------------
+# process_contributions - end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestProcessContributions:
+    def test_open_pr_creates_change_ref_and_created_contribution(self, db_conn):
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+
+        store = ContributionsStore(db_conn)
+        contributions = store.get_contributions_for_conversation(conv.id)
+        assert len(contributions) == 1
+        assert contributions[0].contribution_type == "created"
+
+        change_ref = store.get_change_ref(contributions[0].change_ref_id)
+        assert change_ref is not None
+        assert change_ref.pr_number == 42
+        assert change_ref.change_type == "pr"
+        assert change_ref.status == "pending"
+        assert change_ref.branch == "feature/x"
+
+        # Repository row was upserted.
+        repo = RepoStore(db_conn).get_by_id(change_ref.repo_id)
+        assert repo is not None
+        assert repo.fqn == "acme/widgets"
+        assert repo.canonical_url == "https://github.com/acme/widgets"
+
+    def test_merge_pr_creates_change_ref_and_merged_contribution(self, db_conn):
+        conv = _register_conversation(db_conn)
+        # Merge by URL is the most reliable shape - covers the common case
+        # where the recognizer was able to attach the canonical URL.
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert len(contributions) == 1
+        assert contributions[0].contribution_type == "merged"
+
+    def test_merge_pr_with_only_pr_number_uses_earlier_open_pr_repo(self, db_conn):
+        """MERGE_PR after OPEN_PR in same conversation should reuse the repo."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="42",  # bare number from `gh pr merge 42`
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        types = sorted(c.contribution_type for c in contributions)
+        assert types == ["created", "merged"]
+        # Both contributions point at the same change_ref.
+        assert len({c.change_ref_id for c in contributions}) == 1
+
+    def test_merge_pr_with_unparseable_target_is_skipped(self, db_conn):
+        """If the target is neither a URL nor a bare number, skip cleanly."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="not-a-number-or-url",
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+    def test_merge_pr_with_unresolvable_repo_is_skipped(self, db_conn):
+        """No OPEN_PR, no repo link, no URL → log-and-skip, not crash."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="42",
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert contributions == []
+        # No change_ref was created either.
+        cursor = db_conn.execute("SELECT COUNT(*) FROM change_refs")
+        assert cursor.fetchone()[0] == 0
+
+    def test_merge_pr_uses_single_linked_repo_as_fallback(self, db_conn):
+        """If the conv is linked to exactly one repo, use it for unresolved MERGE_PR."""
+        conv = _register_conversation(db_conn)
+        repo_id = RepoStore(db_conn).upsert(
+            Repository(
+                id=None,
+                canonical_url="https://github.com/acme/widgets",
+                fqn="acme/widgets",
+                short_name="widgets",
+            )
+        )
+        LinkStore(db_conn).link_repo(conv.id, repo_id, LinkType.READ)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="7",
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert len(contributions) == 1
+        cr = ContributionsStore(db_conn).get_change_ref(
+            contributions[0].change_ref_id
+        )
+        assert cr is not None
+        assert cr.repo_id == repo_id
+        assert cr.pr_number == 7
+
+    def test_merge_pr_with_multiple_linked_repos_is_skipped(self, db_conn):
+        """We refuse to guess across repos."""
+        conv = _register_conversation(db_conn)
+        repo_store = RepoStore(db_conn)
+        a = repo_store.upsert(
+            Repository(
+                id=None,
+                canonical_url="https://github.com/acme/widgets",
+                fqn="acme/widgets",
+                short_name="widgets",
+            )
+        )
+        b = repo_store.upsert(
+            Repository(
+                id=None,
+                canonical_url="https://github.com/acme/gadgets",
+                fqn="acme/gadgets",
+                short_name="gadgets",
+            )
+        )
+        link_store = LinkStore(db_conn)
+        link_store.link_repo(conv.id, a, LinkType.READ)
+        link_store.link_repo(conv.id, b, LinkType.READ)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.MERGE_PR,
+            target="9",
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+    def test_git_push_after_open_pr_links_to_pr(self, db_conn):
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata={
+                "branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        types = sorted(c.contribution_type for c in contributions)
+        assert types == ["created", "pushed"]
+        # Both link to the same change_ref (the PR).
+        assert len({c.change_ref_id for c in contributions}) == 1
+
+    def test_git_push_before_open_pr_links_via_backward_pass(self, db_conn):
+        """An orphan push gets attributed to the first PR opened on its branch."""
+        conv = _register_conversation(db_conn)
+        # Push first.
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata={
+                "branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+        # PR opened later.
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        types = sorted(c.contribution_type for c in contributions)
+        assert types == ["created", "pushed"]
+
+    def test_git_push_without_pr_creates_no_contribution(self, db_conn):
+        """A push to a branch that never gets a PR (in this conversation) is ignored."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata={
+                "branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+    def test_git_push_missing_metadata_is_ignored(self, db_conn):
+        conv = _register_conversation(db_conn)
+        # Push action with no metadata at all.
+        _insert_action(db_conn, conv.id, ActionType.GIT_PUSH, target=None)
+        # Push action with branch but no owner/repo (conservative skip).
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="origin",
+            metadata={"branch": "feature/x"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+    def test_git_push_to_different_branch_does_not_link(self, db_conn):
+        """Push to branch B must not be linked to PR on branch A."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/a",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata={
+                "branch": "feature/b",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        # Only the PR creation; the push on a different branch is ignored.
+        types = [c.contribution_type for c in contributions]
+        assert types == ["created"]
+
+    def test_multiple_conversations_share_one_change_ref(self, db_conn):
+        """Two conversations contributing to PR #42 produce a single change_ref."""
+        conv_a = _register_conversation(db_conn, conv_id="conv-a")
+        conv_b = _register_conversation(db_conn, conv_id="conv-b")
+        for conv in (conv_a, conv_b):
+            _insert_action(
+                db_conn,
+                conv.id,
+                ActionType.OPEN_PR,
+                target="https://github.com/acme/widgets/pull/42",
+                metadata={
+                    "head_branch": "feature/x",
+                    "owner": "acme",
+                    "repo": "widgets",
+                },
+            )
+            process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs WHERE pr_number = 42"
+        )
+        assert cursor.fetchone()[0] == 1
+
+        cursor = db_conn.execute(
+            "SELECT conversation_id FROM conversation_contributions "
+            "WHERE contribution_type = 'created'"
+        )
+        contributors = {row[0] for row in cursor.fetchall()}
+        assert contributors == {"conv-a", "conv-b"}
+
+    def test_reprocessing_is_idempotent(self, db_conn):
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+        process_contributions(db_conn, conv)  # replay
+
+        contributions = ContributionsStore(db_conn).get_contributions_for_conversation(
+            conv.id
+        )
+        assert len(contributions) == 1
+
+    def test_reprocessing_after_action_removed_clears_old_contribution(
+        self, db_conn
+    ):
+        """If actions change between runs, stale contributions are removed."""
+        conv = _register_conversation(db_conn)
+        action_id = _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target="https://github.com/acme/widgets/pull/42",
+            metadata={
+                "head_branch": "feature/x",
+                "owner": "acme",
+                "repo": "widgets",
+            },
+        )
+        process_contributions(db_conn, conv)
+        assert (
+            len(
+                ContributionsStore(db_conn).get_contributions_for_conversation(
+                    conv.id
+                )
+            )
+            == 1
+        )
+
+        # Simulate a recognizer update that no longer produces the action.
+        db_conn.execute("DELETE FROM actions WHERE id = ?", (action_id,))
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+        # change_ref persists in case other conversations contributed.
+        cursor = db_conn.execute("SELECT COUNT(*) FROM change_refs")
+        assert cursor.fetchone()[0] == 1
+
+    def test_marks_stage_complete(self, db_conn):
+        conv = _register_conversation(db_conn, event_count=12)
+        process_contributions(db_conn, conv)
+
+        stage = StageStore(db_conn).get(conv.id, STAGE_NAME)
+        assert stage is not None
+        assert stage.event_count == 12
+        # Future runs with the same event count don't need reprocessing.
+        assert (
+            StageStore(db_conn).needs_processing(
+                conv.id, STAGE_NAME, conv.event_count
+            )
+            is False
+        )
+
+    def test_no_actions_marks_stage_complete_with_no_contributions(self, db_conn):
+        conv = _register_conversation(db_conn)
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+        stage = StageStore(db_conn).get(conv.id, STAGE_NAME)
+        assert stage is not None
+
+    def test_open_pr_with_no_parseable_identity_skipped(self, db_conn):
+        """OPEN_PR with no URL and no owner/repo metadata is logged and skipped."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.OPEN_PR,
+            target=None,
+            metadata={"source": "github"},
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+    def test_ignores_non_contribution_action_types(self, db_conn):
+        """Other actions (commits, comments, edits) don't produce contributions."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_COMMIT,
+            target="abc1234",
+            metadata={"commit_message": "wip"},
+        )
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.PR_COMMENT,
+            target="42",
+            metadata={"source": "github"},
+        )
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.EDIT_CODE,
+            target="src/foo.py",
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stage registry
+# ---------------------------------------------------------------------------
+
+
+def test_stage_registered_in_registry():
+    from ohtv.db.stages import STAGES
+
+    assert "contributions" in STAGES
+    assert STAGES["contributions"] is process_contributions

--- a/tests/unit/db/stores/test_contributions_store.py
+++ b/tests/unit/db/stores/test_contributions_store.py
@@ -1,0 +1,299 @@
+"""Tests for ContributionsStore."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from ohtv.db.migrations import migrate
+from ohtv.db.models import Repository
+from ohtv.db.stores import ContributionsStore, RepoStore
+
+
+@pytest.fixture
+def db_conn():
+    """Create an in-memory database with all migrations applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrate(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def repo_id(db_conn) -> int:
+    """Insert a repo and return its id for use in change_refs."""
+    return RepoStore(db_conn).upsert(
+        Repository(
+            id=None,
+            canonical_url="https://github.com/acme/widgets",
+            fqn="acme/widgets",
+            short_name="widgets",
+        )
+    )
+
+
+@pytest.fixture
+def conversation_id(db_conn) -> str:
+    """Insert a conversation row so FK constraints are satisfied."""
+    conv_id = "conv-1"
+    db_conn.execute(
+        "INSERT INTO conversations (id, location) VALUES (?, ?)",
+        (conv_id, "/tmp/conv-1"),
+    )
+    return conv_id
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_pr_change_ref
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrCreatePrChangeRef:
+    def test_creates_new_pr(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 42, branch="feature/x")
+
+        change_ref = store.get_change_ref(cr_id)
+        assert change_ref is not None
+        assert change_ref.repo_id == repo_id
+        assert change_ref.change_type == "pr"
+        assert change_ref.pr_number == 42
+        assert change_ref.branch == "feature/x"
+        assert change_ref.status == "pending"
+        assert change_ref.commit_range is None
+
+    def test_get_change_ref_returns_none_for_missing_id(self, db_conn):
+        store = ContributionsStore(db_conn)
+        assert store.get_change_ref(99999) is None
+
+    def test_returns_existing_pr_without_duplicating(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        first = store.get_or_create_pr_change_ref(repo_id, 42, branch="feature/x")
+        second = store.get_or_create_pr_change_ref(repo_id, 42, branch="ignored")
+        assert first == second
+
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs WHERE repo_id = ? AND pr_number = ?",
+            (repo_id, 42),
+        )
+        assert cursor.fetchone()[0] == 1
+
+    def test_existing_pr_branch_is_not_overwritten(self, db_conn, repo_id):
+        """Calling again with a different branch must not change the stored branch.
+
+        Branch is only set on creation - this keeps an external fetcher
+        free to populate it without us clobbering on the next replay.
+        """
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 7, branch="orig")
+        store.get_or_create_pr_change_ref(repo_id, 7, branch="rewritten")
+
+        change_ref = store.get_change_ref(cr_id)
+        assert change_ref is not None
+        assert change_ref.branch == "orig"
+
+    def test_different_pr_numbers_create_different_rows(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        a = store.get_or_create_pr_change_ref(repo_id, 1)
+        b = store.get_or_create_pr_change_ref(repo_id, 2)
+        assert a != b
+
+    def test_different_repos_with_same_pr_number_create_different_rows(
+        self, db_conn, repo_id
+    ):
+        other_repo_id = RepoStore(db_conn).upsert(
+            Repository(
+                id=None,
+                canonical_url="https://github.com/acme/gadgets",
+                fqn="acme/gadgets",
+                short_name="gadgets",
+            )
+        )
+        store = ContributionsStore(db_conn)
+        a = store.get_or_create_pr_change_ref(repo_id, 42)
+        b = store.get_or_create_pr_change_ref(other_repo_id, 42)
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_direct_push_change_ref
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrCreateDirectPushChangeRef:
+    def test_creates_new_direct_push(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_direct_push_change_ref(
+            repo_id, "abc123..def456", branch="main"
+        )
+
+        change_ref = store.get_change_ref(cr_id)
+        assert change_ref is not None
+        assert change_ref.change_type == "direct_push"
+        assert change_ref.commit_range == "abc123..def456"
+        assert change_ref.branch == "main"
+        assert change_ref.pr_number is None
+        assert change_ref.status == "pending"
+
+    def test_returns_existing_direct_push(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        a = store.get_or_create_direct_push_change_ref(repo_id, "abc..def")
+        b = store.get_or_create_direct_push_change_ref(repo_id, "abc..def")
+        assert a == b
+
+    def test_pr_and_direct_push_with_same_repo_are_independent(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        pr = store.get_or_create_pr_change_ref(repo_id, 1)
+        push = store.get_or_create_direct_push_change_ref(repo_id, "aaa..bbb")
+        assert pr != push
+
+
+# ---------------------------------------------------------------------------
+# record_contribution / get_*_for_*
+# ---------------------------------------------------------------------------
+
+
+class TestRecordContribution:
+    def test_record_and_fetch_for_conversation(
+        self, db_conn, repo_id, conversation_id
+    ):
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 42)
+        store.record_contribution(conversation_id, cr_id, "created")
+        store.record_contribution(conversation_id, cr_id, "merged")
+
+        contributions = store.get_contributions_for_conversation(conversation_id)
+        types = sorted(c.contribution_type for c in contributions)
+        assert types == ["created", "merged"]
+
+    def test_duplicate_record_is_ignored(self, db_conn, repo_id, conversation_id):
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 1)
+        store.record_contribution(conversation_id, cr_id, "created")
+        store.record_contribution(conversation_id, cr_id, "created")  # duplicate
+
+        contributions = store.get_contributions_for_conversation(conversation_id)
+        assert len(contributions) == 1
+
+    def test_many_to_many_multiple_conversations_one_pr(
+        self, db_conn, repo_id, conversation_id
+    ):
+        """Two different conversations can both contribute to the same PR."""
+        # Add a second conversation.
+        db_conn.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv-2", "/tmp/conv-2"),
+        )
+
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 42)
+        store.record_contribution(conversation_id, cr_id, "created")
+        store.record_contribution("conv-2", cr_id, "merged")
+
+        contributors = store.get_contributors_for_change_ref(cr_id)
+        assert {c.conversation_id for c in contributors} == {
+            conversation_id,
+            "conv-2",
+        }
+
+        # And only one change_ref exists.
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs WHERE pr_number = 42"
+        )
+        assert cursor.fetchone()[0] == 1
+
+
+class TestDeleteContributionsForConversation:
+    def test_deletes_only_target_conversations_rows(
+        self, db_conn, repo_id, conversation_id
+    ):
+        db_conn.execute(
+            "INSERT INTO conversations (id, location) VALUES (?, ?)",
+            ("conv-2", "/tmp/conv-2"),
+        )
+
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 1)
+        store.record_contribution(conversation_id, cr_id, "created")
+        store.record_contribution("conv-2", cr_id, "merged")
+
+        deleted = store.delete_contributions_for_conversation(conversation_id)
+        assert deleted == 1
+
+        # conv-1's contributions are gone, conv-2's remain.
+        assert store.get_contributions_for_conversation(conversation_id) == []
+        assert len(store.get_contributions_for_conversation("conv-2")) == 1
+
+    def test_delete_leaves_change_ref_intact(
+        self, db_conn, repo_id, conversation_id
+    ):
+        """Deleting a conversation's contributions must NOT delete change_refs."""
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 1)
+        store.record_contribution(conversation_id, cr_id, "created")
+
+        store.delete_contributions_for_conversation(conversation_id)
+
+        assert store.get_change_ref(cr_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Listing helpers
+# ---------------------------------------------------------------------------
+
+
+class TestListPrChangeRefs:
+    def test_returns_only_pr_change_refs_in_pr_number_order(self, db_conn, repo_id):
+        store = ContributionsStore(db_conn)
+        store.get_or_create_pr_change_ref(repo_id, 5)
+        store.get_or_create_pr_change_ref(repo_id, 1)
+        store.get_or_create_pr_change_ref(repo_id, 3)
+        # A direct push must not appear in the PR listing.
+        store.get_or_create_direct_push_change_ref(repo_id, "x..y")
+
+        listed = store.list_pr_change_refs(repo_id)
+        assert [cr.pr_number for cr in listed] == [1, 3, 5]
+        assert all(cr.change_type == "pr" for cr in listed)
+
+
+# ---------------------------------------------------------------------------
+# Schema-level constraints (defence in depth)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaConstraints:
+    def test_unique_constraint_on_pr_per_repo(self, db_conn, repo_id):
+        # Direct INSERTs to confirm the migration's unique index works as
+        # we expect - our helper depends on this.
+        db_conn.execute(
+            "INSERT INTO change_refs (repo_id, change_type, pr_number, status) "
+            "VALUES (?, 'pr', 99, 'pending')",
+            (repo_id,),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            db_conn.execute(
+                "INSERT INTO change_refs (repo_id, change_type, pr_number, status) "
+                "VALUES (?, 'pr', 99, 'pending')",
+                (repo_id,),
+            )
+
+    def test_unique_constraint_on_contribution_triple(
+        self, db_conn, repo_id, conversation_id
+    ):
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_pr_change_ref(repo_id, 1)
+        db_conn.execute(
+            "INSERT INTO conversation_contributions "
+            "(conversation_id, change_ref_id, contribution_type) "
+            "VALUES (?, ?, 'created')",
+            (conversation_id, cr_id),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            db_conn.execute(
+                "INSERT INTO conversation_contributions "
+                "(conversation_id, change_ref_id, contribution_type) "
+                "VALUES (?, ?, 'created')",
+                (conversation_id, cr_id),
+            )


### PR DESCRIPTION
## Summary

Adds a new `contributions` processing stage that walks (already-processed) actions per conversation, derives PR contributions, and persists them to the `change_refs` / `conversation_contributions` tables created by migration 016 (issue #76). Works across GitHub, GitLab, and Bitbucket.

Closes #78

## What it does

| Action recognized | Contribution recorded |
| --- | --- |
| `OPEN_PR`  | `contribution_type="created"` |
| `MERGE_PR` | `contribution_type="merged"`  |
| `GIT_PUSH` to a branch with an active PR | `contribution_type="pushed"` |

`change_refs` rows are deduplicated per `(repo_id, pr_number)`, so multiple conversations contributing to the same PR share one row (many-to-many) and are all visible via `conversation_contributions`.

## Implementation notes

- **`src/ohtv/db/stores/contributions_store.py`** – New store with `get_or_create_pr_change_ref` and `get_or_create_direct_push_change_ref`, plus `record_contribution` (INSERT-OR-IGNORE for idempotency) and a `delete_contributions_for_conversation` helper used by the stage to make reprocessing safe.
- **`src/ohtv/db/stages/contributions.py`** – Mirrors the forward/backward pass logic of `push_pr_links`: a forward pass tracks the active PR per branch while iterating actions in temporal order; a backward pass attributes "orphan" pushes (those that happened before any PR on their branch) to the first subsequent PR opened on the same branch.
- **Multi-platform support** – `_identify_pr` captures the originating host (github.com / gitlab.com / bitbucket.org) alongside owner/repo when matching `_PR_URL_PATTERNS`, and carries it on `_PrIdent`. `_upsert_repo_for` builds `canonical_url=f"https://{ident.host}/{ident.owner}/{ident.repo}"` so Repository rows are recorded against the correct platform. The host is also propagated through the MERGE_PR fallback chain (`seen_pr_repo` and `_single_repo_for_conversation` via the new `_host_from_canonical_url` helper). Mirrors the multi-platform handling already in `src/ohtv/db/stages/refs.py`.
- **`MERGE_PR` fallback chain** – `MERGE_PR` actions often have no repo info (target is usually just the bare PR number from `gh pr merge 42`). The stage falls back through:
  1. PR URL parsed from `target` (covers `gh pr merge https://github.com/o/r/pull/42`, GitLab MR URLs, Bitbucket PR URLs)
  2. `metadata.owner` / `metadata.repo` (future-proofing)
  3. The `(pr_number → owner/repo/host)` map populated by earlier `OPEN_PR` actions in the same conversation
  4. A single repo linked to the conversation via `conversation_repos`

  We refuse to guess if 0 or >1 repos are linked – better to miss a contribution than misattribute it.
- **Registered** in `STAGES`; the CLI's `db process` command picks the stage up automatically via the existing `click.Choice(STAGES.keys())`.

## Generic enough for #79

`ContributionsStore` already exposes `get_or_create_direct_push_change_ref(repo_id, commit_range, branch=None)` and the contribution-type enum supports `"pushed"`/`"created"` against `direct_push` change_refs, so issue #79 can land as a sibling stage without refactoring this one.

## Key review decisions

- **🔴 Critical accepted — host preservation** (commit `54008f7`): The initial implementation always wrote `canonical_url=https://github.com/...` even for GitLab/Bitbucket PRs accepted by `_PR_URL_PATTERNS`. Fixed by capturing host at pattern-match time on `_PrIdent` rather than re-parsing the source URL inside `_upsert_repo_for` — keeps the helper's signature clean and avoids a second regex pass. Round-trip tests added for GitLab `OPEN_PR`, Bitbucket `OPEN_PR`, and GitLab `MERGE_PR` by URL.
- **🟡 Suggestion accepted — `set` for `orphan_push_branches`** (commit `879f75e`): Switched from `list[str]` to `set[str]` to deduplicate at source when multiple pushes hit the same branch before a PR is opened. Backward pass only iterates and does a dict lookup per entry, so no ordering dependency. `record_contribution` was already idempotent per `(conversation, change_ref, type)` — this just removes redundant work.
- **🟡 Suggestion respectfully declined — composite `seen_pr_repo` key**: The bot flagged that `seen_pr_repo` is keyed by `pr_number` alone, so a hypothetical conversation that touches PR #42 in repo A *and* PR #42 in repo B could misattribute. We kept the existing `pr_number`-only key because (a) this map is only consulted in the MERGE_PR fallback chain *after* URL parsing and `metadata.owner/repo` have both failed, (b) the failure mode already skips the contribution rather than guessing if `_single_repo_for_conversation` doesn't yield a unique repo, and (c) a composite `(pr_number, owner/repo)` key cannot help in the failing-fallback case because by definition the lookup site does not know the owner/repo — that's why it's falling back. Adding the composite key would be speculative complexity without a real behavior change. Documented in the resolved review thread.

## Tests / verification

- **Full suite:** 1325 / 1325 passing at HEAD `879f75e`.
- **New tests:** 50+ in `tests/unit/db/stages/test_contributions.py` and `tests/unit/db/stores/test_contributions_store.py`, plus 3 round-trip platform-host tests added in the review round.
- **Coverage on new code:** `contributions.py` 93%, `contributions_store.py` 97%. Untested lines are defensive paths (e.g. `int()` of a regex-`\d+` match, repo `fqn` without a `/`).
- **Blackbox manual test (re-test at HEAD `879f75e`):** 5/5 scenarios pass — GitLab PR round-trip, Bitbucket PR round-trip, GitHub default-path regression, `orphan_push_branches` set dedup with multiple pushes on the same branch, and the mixed pre-PR/post-PR push scenario. Documented in PR comment timestamped `2026-05-22T03:23:57Z`. No documentation edits needed beyond `14ec8c7` (verified in the re-test report).
- Test shape follows the recently merged `tests/unit/db/stages/test_human_input.py` (PR #85): pure-function tests of the helpers, then end-to-end stage tests that drive the real `ActionStore`/`ContributionsStore` against an in-memory DB with the full migration chain.

## Acceptance criteria checklist

- [x] Detects `open-pr` actions and creates change_ref with `contribution_type="created"`
- [x] Detects `merge-pr` actions and creates change_ref with `contribution_type="merged"`
- [x] Links PR branch pushes to existing PR change_refs (`contribution_type="pushed"`)
- [x] Does not create duplicate change_refs for same PR (`get_or_create_pr_change_ref` + test)
- [x] Multiple conversations can contribute to same PR (many-to-many, dedicated test)
- [x] Extracts repo from action metadata and links to existing `repositories` table (`RepoStore.upsert`)
- [x] PR change_refs have `status="pending"` initially (asserted in tests)
- [x] Works across GitHub / GitLab / Bitbucket (host preserved in `canonical_url`)

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._
