### PR TITLE
feat(contributions): detect direct pushes to main/master (#79)

### DIFF
--- a/src/ohtv/db/stages/contributions.py
+++ b/src/ohtv/db/stages/contributions.py
@@ -67,6 +67,13 @@ _PR_URL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"https://bitbucket\.org/([^/]+)/([^/]+)/pull-requests/(\d+)"), "bitbucket.org"),
 ]
 
+# Default branches that indicate a "direct push" (a push that lands changes
+# without going through a PR). Comparison is case-sensitive: virtually all
+# real-world projects use lowercase ``main`` / ``master``, and matching
+# lowercase only avoids spurious hits on unrelated branches that happen to
+# share a case-insensitive prefix.
+_DIRECT_PUSH_BRANCHES: frozenset[str] = frozenset({"main", "master"})
+
 
 @dataclass(frozen=True)
 class _PrIdent:
@@ -147,6 +154,7 @@ def process_contributions(
             _handle_git_push(
                 action,
                 conversation.id,
+                repo_store,
                 contributions_store,
                 active_pr_per_branch,
                 orphan_push_branches,
@@ -289,14 +297,22 @@ def _handle_merge_pr(
 def _handle_git_push(
     action: ConversationAction,
     conversation_id: str,
+    repo_store: RepoStore,
     contributions_store: ContributionsStore,
     active_pr_per_branch: dict[str, int],
     orphan_push_branches: set[str],
 ) -> None:
-    """Attribute a GIT_PUSH action to its branch's PR, when possible.
+    """Attribute a GIT_PUSH action to a contribution.
 
-    If no PR has yet been opened on the branch (within this conversation)
-    the push is queued as an orphan for the backward pass.
+    Two paths:
+
+    1. **Direct push to main/master**: if the remote branch is ``main`` or
+       ``master`` and we have a commit range from the push output, create
+       (or reuse) a ``direct_push`` ``change_ref`` with ``status="merged"``
+       and record a ``pushed`` contribution. Direct pushes never participate
+       in the PR-link backward pass because they have already landed.
+    2. **Push to feature branch**: link to the active PR on that branch
+       (forward pass) or queue as an orphan for the backward pass.
     """
     if not action.metadata:
         return
@@ -307,6 +323,37 @@ def _handle_git_push(
         # Conservative: don't guess across repos.
         return
 
+    # --- Direct push to main/master ---------------------------------------
+    # Prefer the remote branch (what was actually updated on the server) but
+    # fall back to the local branch name, which the recognizer records as
+    # ``branch`` for backwards compatibility.
+    remote_branch = action.metadata.get("remote_branch") or branch
+    commit_range = action.metadata.get("commit_range")
+    if remote_branch in _DIRECT_PUSH_BRANCHES and commit_range:
+        # The push-target recognizer currently only emits owner/repo for
+        # github.com, so we hard-code the host here. If/when GitLab and
+        # Bitbucket push targets are recognized, ``_extract_repo_from_push_target``
+        # should grow a ``host`` field and this call should consume it.
+        repo_id = repo_store.upsert(
+            Repository(
+                id=None,
+                canonical_url=f"https://github.com/{owner}/{repo}",
+                fqn=f"{owner}/{repo}",
+                short_name=repo,
+            )
+        )
+        change_ref_id = contributions_store.get_or_create_direct_push_change_ref(
+            repo_id,
+            commit_range,
+            branch=remote_branch,
+            status="merged",
+        )
+        contributions_store.record_contribution(
+            conversation_id, change_ref_id, "pushed"
+        )
+        return
+
+    # --- Push to feature branch (existing PR-link path) -------------------
     branch_key = _branch_key(owner, repo, branch)
     if branch_key is None:
         return

--- a/src/ohtv/db/stages/recognizers/git_operations.py
+++ b/src/ohtv/db/stages/recognizers/git_operations.py
@@ -25,6 +25,18 @@ PUSH_BRANCH_PATTERN = re.compile(
     r"(?:[a-f0-9.]+|\*\s+\[new branch\])\s+([^\s]+)\s+->\s+([^\s]+)"
 )
 
+# Pattern to extract a commit-range update from git push output.
+# Captures: old_sha, separator, new_sha, local_branch, remote_branch.
+# Handles both fast-forward updates (``oldsha..newsha``) and force-push
+# updates (``oldsha...newsha``, typically prefixed with ``+`` and suffixed
+# with ``(forced update)``).
+# Example lines (the leading ``To <remote>`` line is ignored):
+#   ``   418680a..6ecae71  main -> main``
+#   `` + 418680a...6ecae71  main -> main (forced update)``
+PUSH_RANGE_PATTERN = re.compile(
+    r"([a-f0-9]{7,40})(\.{2,3})([a-f0-9]{7,40})\s+(\S+)\s+->\s+(\S+)"
+)
+
 # Pattern to extract branch from git push command
 # Matches: git push origin branch-name, git push -u origin branch-name
 PUSH_COMMAND_BRANCH_PATTERN = re.compile(
@@ -130,6 +142,7 @@ def recognize_git_operations(
             push_target = _extract_push_target(output)
             branch = _extract_push_branch(command, output)
             repo_info = _extract_repo_from_push_target(push_target)
+            push_info = extract_push_info(output)
             
             # If no branch found from push, try to infer from prior checkout
             inferred_from_checkout = False
@@ -152,6 +165,13 @@ def recognize_git_operations(
                 metadata["repo"] = repo_info["repo"]
             if inferred_from_checkout:
                 metadata["branch_inferred"] = True
+            if push_info is not None:
+                metadata["commit_range"] = push_info["commit_range"]
+                metadata["base_commit"] = push_info["base_commit"]
+                metadata["head_commit"] = push_info["head_commit"]
+                metadata["remote_branch"] = push_info["remote_branch"]
+                if push_info["force"]:
+                    metadata["force"] = True
             
             actions.append(
                 ConversationAction(
@@ -202,6 +222,63 @@ def _extract_push_branch(command: str, output: str) -> str | None:
         return match.group(1).strip()
     
     return None
+
+
+def extract_push_info(terminal_output: str) -> dict | None:
+    """Extract commit range and branch info from git push output.
+
+    Parses the per-ref update line emitted by ``git push`` for both
+    fast-forward and force-push updates::
+
+        ``   418680a..6ecae71  main -> main``           (fast-forward)
+        `` + 418680a...6ecae71  main -> main (forced update)``  (force)
+
+    The returned ``commit_range`` is always normalized to use the literal
+    separator from the output (``..`` or ``...``), so a force push is not
+    accidentally de-duplicated against a non-force push with identical
+    base/head SHAs. Push output that creates a new branch (``[new branch]``)
+    or reports ``Everything up-to-date`` has no commit range and yields
+    ``None``.
+
+    Args:
+        terminal_output: Raw output of the ``git push`` command.
+
+    Returns:
+        A dict with ``base_commit``, ``head_commit``, ``commit_range``,
+        ``local_branch``, ``remote_branch``, and ``force`` (bool), or
+        ``None`` if no commit range is present.
+    """
+    if not terminal_output:
+        return None
+    match = PUSH_RANGE_PATTERN.search(terminal_output)
+    if not match:
+        return None
+    base_commit, separator, head_commit, local_branch, remote_branch = match.groups()
+    # A force-push line either uses the three-dot range separator or has a
+    # leading ``+`` flag before the SHAs. Detect both.
+    force = separator == "..." or _line_starts_with_force_marker(
+        terminal_output, match.start()
+    )
+    return {
+        "base_commit": base_commit,
+        "head_commit": head_commit,
+        "commit_range": f"{base_commit}{separator}{head_commit}",
+        "local_branch": local_branch,
+        "remote_branch": remote_branch,
+        "force": force,
+    }
+
+
+def _line_starts_with_force_marker(text: str, match_start: int) -> bool:
+    """Return True if the push-update line at ``match_start`` is prefixed by ``+``.
+
+    git marks force-push update lines with a leading ``+`` (after any
+    indentation). This helper walks back from the regex match to the
+    start of the current line and checks for that marker.
+    """
+    line_start = text.rfind("\n", 0, match_start) + 1
+    prefix = text[line_start:match_start].lstrip()
+    return prefix.startswith("+")
 
 
 def _extract_repo_from_push_target(push_target: str | None) -> dict | None:

--- a/src/ohtv/db/stores/contributions_store.py
+++ b/src/ohtv/db/stores/contributions_store.py
@@ -101,18 +101,23 @@ class ContributionsStore:
         repo_id: int,
         commit_range: str,
         branch: str | None = None,
+        status: str = "pending",
     ) -> int:
         """Return the change_ref ID for a direct push, creating it if needed.
 
         Direct pushes are uniquely identified by ``(repo_id, commit_range)``.
-        This method is provided so a future stage (issue #79) can detect
-        pushes that bypass PRs without needing to add a new store.
+        This method is used by the contributions stage to record pushes
+        that bypass PRs.
 
         Args:
             repo_id: Foreign key into ``repositories``.
             commit_range: A unique identifier for the push - typically the
                 ``oldsha..newsha`` range from ``git push`` output.
             branch: Optional branch name, recorded on creation only.
+            status: Initial change_ref status, recorded on creation only.
+                For direct pushes to main/master the caller typically
+                passes ``"merged"`` since the change has already landed.
+                Defaults to ``"pending"`` for backwards compatibility.
 
         Returns:
             The integer ID of the (existing or newly inserted) change_ref.
@@ -131,10 +136,10 @@ class ContributionsStore:
             """
             INSERT INTO change_refs
                 (repo_id, change_type, commit_range, branch, status)
-            VALUES (?, 'direct_push', ?, ?, 'pending')
+            VALUES (?, 'direct_push', ?, ?, ?)
             RETURNING id
             """,
-            (repo_id, commit_range, branch),
+            (repo_id, commit_range, branch, status),
         )
         return cursor.fetchone()[0]
 

--- a/tests/unit/db/stages/recognizers/test_git_operations.py
+++ b/tests/unit/db/stages/recognizers/test_git_operations.py
@@ -8,6 +8,7 @@ from ohtv.db.stages.recognizers.git_operations import (
     recognize_git_operations,
     _extract_push_branch,
     _extract_repo_from_push_target,
+    extract_push_info,
     extract_working_directory,
     extract_checkout_branch,
     is_checkout_command,
@@ -297,6 +298,205 @@ class TestExtractRepoFromPushTarget:
         """Should return None for non-GitHub URLs."""
         url = "https://gitlab.com/owner/repo.git"
         assert _extract_repo_from_push_target(url) is None
+
+
+class TestExtractPushInfo:
+    """Tests for commit-range extraction from git push output."""
+
+    def test_extracts_fast_forward_push(self):
+        """Standard fast-forward push line yields base/head/range/branch."""
+        output = (
+            "To https://github.com/owner/repo.git\n"
+            "   418680a..6ecae71  main -> main\n"
+        )
+        info = extract_push_info(output)
+        assert info is not None
+        assert info["base_commit"] == "418680a"
+        assert info["head_commit"] == "6ecae71"
+        assert info["commit_range"] == "418680a..6ecae71"
+        assert info["local_branch"] == "main"
+        assert info["remote_branch"] == "main"
+        assert info["force"] is False
+
+    def test_extracts_full_sha_push(self):
+        """40-char SHAs are accepted."""
+        base = "a" * 40
+        head = "b" * 40
+        output = f"   {base}..{head}  develop -> develop"
+        info = extract_push_info(output)
+        assert info is not None
+        assert info["base_commit"] == base
+        assert info["head_commit"] == head
+        assert info["commit_range"] == f"{base}..{head}"
+
+    def test_extracts_feature_branch_push(self):
+        """Branch names with slashes are preserved verbatim."""
+        output = (
+            "To github.com:OpenHands/software-agent-sdk.git\n"
+            "   4e29d53..2a8b342  feature/my-branch -> feature/my-branch\n"
+        )
+        info = extract_push_info(output)
+        assert info is not None
+        assert info["local_branch"] == "feature/my-branch"
+        assert info["remote_branch"] == "feature/my-branch"
+        assert info["force"] is False
+
+    def test_extracts_force_push_three_dot(self):
+        """Force-push lines use ``...`` and set force=True."""
+        output = (
+            "To github.com:owner/repo.git\n"
+            " + 418680a...6ecae71  main -> main (forced update)\n"
+        )
+        info = extract_push_info(output)
+        assert info is not None
+        assert info["base_commit"] == "418680a"
+        assert info["head_commit"] == "6ecae71"
+        assert info["commit_range"] == "418680a...6ecae71"
+        assert info["force"] is True
+
+    def test_force_push_two_dot_with_plus_marker(self):
+        """A leading ``+`` marker also indicates a force push."""
+        output = " + 418680a..6ecae71  main -> main (forced update)\n"
+        info = extract_push_info(output)
+        assert info is not None
+        assert info["force"] is True
+
+    def test_local_and_remote_branch_can_differ(self):
+        """``local -> remote`` is preserved as two distinct fields."""
+        output = "   abc1234..def5678  local-branch -> remote-branch"
+        info = extract_push_info(output)
+        assert info is not None
+        assert info["local_branch"] == "local-branch"
+        assert info["remote_branch"] == "remote-branch"
+
+    def test_returns_none_for_new_branch_output(self):
+        """A new-branch push has no commit range."""
+        output = (
+            "To https://github.com/owner/repo.git\n"
+            " * [new branch]      feature/x -> feature/x\n"
+        )
+        assert extract_push_info(output) is None
+
+    def test_returns_none_for_everything_up_to_date(self):
+        """`Everything up-to-date` has no commit range."""
+        assert extract_push_info("Everything up-to-date\n") is None
+
+    def test_returns_none_for_empty_output(self):
+        """Empty or ``None`` output returns ``None``."""
+        assert extract_push_info("") is None
+        assert extract_push_info(None) is None  # type: ignore[arg-type]
+
+    def test_returns_none_for_unrelated_output(self):
+        """Unrelated terminal output yields ``None``."""
+        assert extract_push_info("fatal: bad config line\n") is None
+
+
+class TestRecognizeGitPushPopulatesCommitRange:
+    """The GIT_PUSH recognizer surfaces commit_range metadata when present."""
+
+    @pytest.fixture
+    def make_context(self):
+        def _make(events, current_index=0):
+            return RecognizerContext(
+                conversation_id="test-conv",
+                events=events,
+                current_index=current_index,
+            )
+        return _make
+
+    def test_push_to_main_adds_commit_range_metadata(self, make_context):
+        """A direct push to main adds commit_range/base/head/remote_branch."""
+        action_event = {
+            "id": "evt-1",
+            "kind": "ActionEvent",
+            "tool_name": "terminal",
+            "action": {"command": "git push origin main"},
+        }
+        obs_event = {
+            "kind": "ObservationEvent",
+            "observation": {
+                "exit_code": 0,
+                "content": [{
+                    "type": "text",
+                    "text": (
+                        "To https://github.com/owner/repo.git\n"
+                        "   418680a..6ecae71  main -> main\n"
+                    ),
+                }],
+            },
+        }
+        context = make_context([action_event, obs_event])
+        actions = recognize_git_operations(action_event, context)
+
+        assert len(actions) == 1
+        meta = actions[0].metadata
+        assert meta is not None
+        assert meta["branch"] == "main"
+        assert meta["remote_branch"] == "main"
+        assert meta["commit_range"] == "418680a..6ecae71"
+        assert meta["base_commit"] == "418680a"
+        assert meta["head_commit"] == "6ecae71"
+        assert "force" not in meta  # not a force push
+
+    def test_force_push_to_main_sets_force_flag(self, make_context):
+        """A force push to main sets force=True in metadata."""
+        action_event = {
+            "id": "evt-2",
+            "kind": "ActionEvent",
+            "tool_name": "terminal",
+            "action": {"command": "git push --force origin main"},
+        }
+        obs_event = {
+            "kind": "ObservationEvent",
+            "observation": {
+                "exit_code": 0,
+                "content": [{
+                    "type": "text",
+                    "text": (
+                        "To github.com:owner/repo.git\n"
+                        " + aaaaaaa...bbbbbbb  main -> main (forced update)\n"
+                    ),
+                }],
+            },
+        }
+        context = make_context([action_event, obs_event])
+        actions = recognize_git_operations(action_event, context)
+
+        assert len(actions) == 1
+        meta = actions[0].metadata
+        assert meta is not None
+        assert meta["commit_range"] == "aaaaaaa...bbbbbbb"
+        assert meta["force"] is True
+
+    def test_new_branch_push_has_no_commit_range(self, make_context):
+        """A new-branch push records the branch but no commit_range."""
+        action_event = {
+            "id": "evt-3",
+            "kind": "ActionEvent",
+            "tool_name": "terminal",
+            "action": {"command": "git push -u origin feature/x"},
+        }
+        obs_event = {
+            "kind": "ObservationEvent",
+            "observation": {
+                "exit_code": 0,
+                "content": [{
+                    "type": "text",
+                    "text": (
+                        "To https://github.com/owner/repo.git\n"
+                        " * [new branch]      feature/x -> feature/x\n"
+                    ),
+                }],
+            },
+        }
+        context = make_context([action_event, obs_event])
+        actions = recognize_git_operations(action_event, context)
+
+        assert len(actions) == 1
+        meta = actions[0].metadata
+        assert meta is not None
+        assert meta["branch"] == "feature/x"
+        assert "commit_range" not in meta
 
 
 class TestExtractWorkingDirectory:

--- a/tests/unit/db/stages/test_contributions.py
+++ b/tests/unit/db/stages/test_contributions.py
@@ -775,6 +775,332 @@ class TestProcessContributions:
 
 
 # ---------------------------------------------------------------------------
+# Direct-push-to-main detection (issue #79)
+# ---------------------------------------------------------------------------
+
+
+def _push_metadata(
+    *,
+    branch: str,
+    remote_branch: str | None = None,
+    commit_range: str | None = "418680a..6ecae71",
+    owner: str = "acme",
+    repo: str = "widgets",
+    force: bool = False,
+) -> dict:
+    """Build GIT_PUSH metadata as the recognizer would emit it."""
+    meta: dict = {"branch": branch, "owner": owner, "repo": repo}
+    if remote_branch is not None:
+        meta["remote_branch"] = remote_branch
+    if commit_range is not None:
+        meta["commit_range"] = commit_range
+        # base/head are surfaced by the recognizer but the contributions
+        # stage only consumes commit_range; we still set them so the
+        # fixture stays close to real-world metadata.
+        base, _sep, head = commit_range.partition("..")
+        if not head:
+            base, _sep, head = commit_range.partition("...")
+        meta["base_commit"] = base
+        meta["head_commit"] = head
+    if force:
+        meta["force"] = True
+    return meta
+
+
+class TestDirectPushDetection:
+    """Issue #79 acceptance criteria: detect direct pushes to main/master."""
+
+    def test_push_to_main_creates_direct_push_change_ref(self, db_conn):
+        """Acceptance: change_ref with change_type='direct_push', status='merged'."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="main", remote_branch="main", commit_range="418680a..6ecae71"
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        store = ContributionsStore(db_conn)
+        contributions = store.get_contributions_for_conversation(conv.id)
+        assert [c.contribution_type for c in contributions] == ["pushed"]
+
+        change_ref = store.get_change_ref(contributions[0].change_ref_id)
+        assert change_ref is not None
+        assert change_ref.change_type == "direct_push"
+        assert change_ref.status == "merged"
+        assert change_ref.commit_range == "418680a..6ecae71"
+        assert change_ref.branch == "main"
+        assert change_ref.pr_number is None
+
+    def test_push_to_master_also_detected(self, db_conn):
+        """Both ``main`` and ``master`` count as direct-push targets."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="master",
+                remote_branch="master",
+                commit_range="aaa1111..bbb2222",
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        store = ContributionsStore(db_conn)
+        contributions = store.get_contributions_for_conversation(conv.id)
+        assert len(contributions) == 1
+        change_ref = store.get_change_ref(contributions[0].change_ref_id)
+        assert change_ref is not None
+        assert change_ref.change_type == "direct_push"
+        assert change_ref.branch == "master"
+
+    def test_push_to_feature_branch_does_not_create_direct_push(self, db_conn):
+        """Pushes to non-main branches must not create direct_push change_refs."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="feature/x",
+                remote_branch="feature/x",
+                commit_range="abc1234..def5678",
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs WHERE change_type = 'direct_push'"
+        )
+        assert cursor.fetchone()[0] == 0
+
+    def test_push_to_main_without_commit_range_is_ignored(self, db_conn):
+        """Without a commit range we cannot deduplicate; skip silently."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="main", remote_branch="main", commit_range=None
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        assert (
+            ContributionsStore(db_conn).get_contributions_for_conversation(conv.id)
+            == []
+        )
+
+    def test_duplicate_pushes_within_conversation_share_change_ref(self, db_conn):
+        """Acceptance: dedup change_refs on (repo_id, commit_range)."""
+        conv = _register_conversation(db_conn)
+        for _ in range(2):
+            _insert_action(
+                db_conn,
+                conv.id,
+                ActionType.GIT_PUSH,
+                target="https://github.com/acme/widgets.git",
+                metadata=_push_metadata(
+                    branch="main",
+                    remote_branch="main",
+                    commit_range="418680a..6ecae71",
+                ),
+            )
+
+        process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs "
+            "WHERE change_type = 'direct_push' AND commit_range = '418680a..6ecae71'"
+        )
+        assert cursor.fetchone()[0] == 1
+
+    def test_duplicate_pushes_across_conversations_share_change_ref(self, db_conn):
+        """Two conversations pushing the same range share one change_ref."""
+        conv_a = _register_conversation(db_conn, conv_id="conv-a")
+        conv_b = _register_conversation(db_conn, conv_id="conv-b")
+        for conv in (conv_a, conv_b):
+            _insert_action(
+                db_conn,
+                conv.id,
+                ActionType.GIT_PUSH,
+                target="https://github.com/acme/widgets.git",
+                metadata=_push_metadata(
+                    branch="main",
+                    remote_branch="main",
+                    commit_range="418680a..6ecae71",
+                ),
+            )
+            process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs WHERE change_type = 'direct_push'"
+        )
+        assert cursor.fetchone()[0] == 1
+
+        # Both conversations are credited.
+        cursor = db_conn.execute(
+            "SELECT DISTINCT conversation_id FROM conversation_contributions "
+            "WHERE contribution_type = 'pushed'"
+        )
+        assert {row[0] for row in cursor.fetchall()} == {"conv-a", "conv-b"}
+
+    def test_links_repo_correctly(self, db_conn):
+        """Acceptance: change_ref's repo_id resolves to the pushed repo."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="main",
+                remote_branch="main",
+                commit_range="418680a..6ecae71",
+                owner="acme",
+                repo="widgets",
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            """
+            SELECT r.fqn, r.canonical_url
+            FROM change_refs cr
+            JOIN repositories r ON cr.repo_id = r.id
+            WHERE cr.change_type = 'direct_push'
+            """
+        )
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["fqn"] == "acme/widgets"
+        assert rows[0]["canonical_url"] == "https://github.com/acme/widgets"
+
+    def test_force_push_to_main_records_distinct_change_ref(self, db_conn):
+        """Force-push (``...`` separator) is a separate commit_range from ff-push."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="main",
+                remote_branch="main",
+                commit_range="aaa1111..bbb2222",
+            ),
+        )
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="main",
+                remote_branch="main",
+                commit_range="bbb2222...ccc3333",
+                force=True,
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            "SELECT commit_range FROM change_refs "
+            "WHERE change_type = 'direct_push' ORDER BY commit_range"
+        )
+        ranges = [row[0] for row in cursor.fetchall()]
+        assert ranges == ["aaa1111..bbb2222", "bbb2222...ccc3333"]
+
+    def test_push_to_main_without_owner_metadata_is_ignored(self, db_conn):
+        """Without owner/repo we can't link to a repository; skip conservatively."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target=None,
+            metadata={
+                "branch": "main",
+                "remote_branch": "main",
+                "commit_range": "418680a..6ecae71",
+            },
+        )
+
+        process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute("SELECT COUNT(*) FROM change_refs")
+        assert cursor.fetchone()[0] == 0
+
+    def test_remote_branch_metadata_takes_precedence_over_local_branch(self, db_conn):
+        """When local and remote differ, the remote branch decides direct-push status."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="hotfix",  # local
+                remote_branch="main",  # actually pushing to main
+                commit_range="418680a..6ecae71",
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+
+        cursor = db_conn.execute(
+            "SELECT change_type, branch FROM change_refs"
+        )
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["change_type"] == "direct_push"
+        # The recorded branch reflects what was actually updated on remote.
+        assert rows[0]["branch"] == "main"
+
+    def test_reprocessing_direct_push_preserves_change_ref(self, db_conn):
+        """Reprocessing clears contributions but reuses the existing change_ref."""
+        conv = _register_conversation(db_conn)
+        _insert_action(
+            db_conn,
+            conv.id,
+            ActionType.GIT_PUSH,
+            target="https://github.com/acme/widgets.git",
+            metadata=_push_metadata(
+                branch="main",
+                remote_branch="main",
+                commit_range="418680a..6ecae71",
+            ),
+        )
+
+        process_contributions(db_conn, conv)
+        process_contributions(db_conn, conv)  # replay
+
+        cursor = db_conn.execute(
+            "SELECT COUNT(*) FROM change_refs WHERE change_type = 'direct_push'"
+        )
+        assert cursor.fetchone()[0] == 1
+        contributions = ContributionsStore(
+            db_conn
+        ).get_contributions_for_conversation(conv.id)
+        assert len(contributions) == 1
+
+
+# ---------------------------------------------------------------------------
 # Stage registry
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/db/stores/test_contributions_store.py
+++ b/tests/unit/db/stores/test_contributions_store.py
@@ -149,6 +149,31 @@ class TestGetOrCreateDirectPushChangeRef:
         push = store.get_or_create_direct_push_change_ref(repo_id, "aaa..bbb")
         assert pr != push
 
+    def test_creates_with_explicit_status_merged(self, db_conn, repo_id):
+        """Direct-push detection (#79) creates change_refs with status='merged'."""
+        store = ContributionsStore(db_conn)
+        cr_id = store.get_or_create_direct_push_change_ref(
+            repo_id, "abc..def", branch="main", status="merged"
+        )
+        change_ref = store.get_change_ref(cr_id)
+        assert change_ref is not None
+        assert change_ref.status == "merged"
+
+    def test_status_preserved_across_dedup_lookup(self, db_conn, repo_id):
+        """Re-calling with a different status returns the existing row unchanged."""
+        store = ContributionsStore(db_conn)
+        first = store.get_or_create_direct_push_change_ref(
+            repo_id, "abc..def", status="merged"
+        )
+        second = store.get_or_create_direct_push_change_ref(
+            repo_id, "abc..def", status="pending"
+        )
+        assert first == second
+        change_ref = store.get_change_ref(first)
+        assert change_ref is not None
+        # First insert wins: status stays 'merged'.
+        assert change_ref.status == "merged"
+
 
 # ---------------------------------------------------------------------------
 # record_contribution / get_*_for_*


### PR DESCRIPTION
Fixes #79

## Summary

Extends the contributions stage to recognize `git push` actions that land changes directly on `main` or `master` without going through a PR, recording them as `change_refs` with `change_type="direct_push"` and `status="merged"` (the change has already landed).

## What changed

### `src/ohtv/db/stages/recognizers/git_operations.py`
- New public helper **`extract_push_info(terminal_output)`** parses git's per-ref update line. Handles both fast-forward updates (`oldsha..newsha`) and force pushes (either the `...` three-dot separator or the leading `+` marker, both of which git uses for forced updates). Returns `base_commit`, `head_commit`, `commit_range`, `local_branch`, `remote_branch`, and a `force` boolean — or `None` for new-branch pushes / `Everything up-to-date` / unrelated output.
- The recognizer now surfaces these in `GIT_PUSH` action `metadata`: `commit_range`, `base_commit`, `head_commit`, `remote_branch`, and `force` (when true). `branch` is kept for backwards compatibility with the existing PR-link path.

### `src/ohtv/db/stages/contributions.py`
- `_handle_git_push` gains a direct-push branch: if `remote_branch` (or the local `branch` fallback) is `main`/`master` **and** the push has a `commit_range`, the stage upserts a `direct_push` `change_ref` with `status="merged"` and records a `pushed` contribution.
- Match is case-sensitive lowercase only — virtually all real-world repos use lowercase `main`/`master`, and case-insensitive matching would hit unrelated branches like `mainline`.
- Conservative: skips silently when `owner`/`repo` are missing (can't link to a repo) or when `commit_range` is missing (can't dedup).
- Direct pushes are completely disjoint from the existing PR-link forward/backward pass — they have already landed, so they never participate in orphan-push collection.

### `src/ohtv/db/stores/contributions_store.py`
- `get_or_create_direct_push_change_ref` gains an optional `status` parameter (defaults to `"pending"` for backwards compat). The stage passes `"merged"`.

## Acceptance criteria

- [x] **Detects git-push actions to main/master branches** — `test_push_to_main_creates_direct_push_change_ref`, `test_push_to_master_also_detected`
- [x] **Extracts commit range from push output** (e.g. `418680a..6ecae71`) — `TestExtractPushInfo` (10 unit tests including fast-forward, full-SHA, and force-push variants)
- [x] **Creates change_ref with `change_type="direct_push"`, `status="merged"`** — `test_push_to_main_creates_direct_push_change_ref`, `test_creates_with_explicit_status_merged`
- [x] **Stores `commit_range` and `branch` fields** — `test_push_to_main_creates_direct_push_change_ref` asserts both
- [x] **Does not duplicate change_refs for same commit range** — `test_duplicate_pushes_within_conversation_share_change_ref`, `test_duplicate_pushes_across_conversations_share_change_ref`, `test_reprocessing_direct_push_preserves_change_ref`, `test_status_preserved_across_dedup_lookup`
- [x] **Links to repository correctly** — `test_links_repo_correctly` (verifies JOIN with `repositories` returns the expected `fqn` and `canonical_url`)

## Test coverage

26 new tests, all passing alongside the existing 1349 unit tests (full suite: **1375 passing**).

**Unit tests on `extract_push_info`** (10): fast-forward, 40-char SHAs, branch names with slashes, force-push three-dot, force-push two-dot with `+` marker, differing local/remote branches, new-branch output, `Everything up-to-date`, empty/None input, unrelated output.

**Recognizer integration** (3): verifies metadata is populated for direct push, force push, and new-branch push.

**Contributions stage integration** (11): direct push to main, direct push to master, ignored on feature branches, ignored without commit range, dedup within conversation, dedup across conversations, force vs. fast-forward are distinct change_refs, ignored without owner/repo metadata, `remote_branch` precedence over local `branch`, idempotent reprocessing, plus the basic shape assertions.

**Store** (2): `status="merged"` creation, status preserved across dedup lookups (first-insert-wins semantics).

## Notes

- Per AGENTS.md, this is an internal indexing-stage extension with no new CLI flags or env vars, so README has intentionally not been updated.
- The push-target recognizer currently only emits `owner`/`repo` for `github.com`. Direct-push detection consequently only fires for GitHub pushes today. When `_extract_repo_from_push_target` grows GitLab/Bitbucket support, the host can be threaded through; a code comment documents this in `contributions.py`.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._


@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/94ff3870-1888-4320-8fb5-67a1ebadc57b)