### PR TITLE
feat: add fetch-loc command to backfill LOC from GitHub API (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ ohtv sync
 # Build embeddings for search (requires LLM_API_KEY)
 ohtv db embed
 
+# Backfill PR/push LOC from GitHub (requires GITHUB_TOKEN)
+GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc
+
 # Search conversations semantically
 ohtv search "fix authentication bugs"
 
@@ -1192,6 +1195,58 @@ ohtv db embed --yes
 
 ---
 
+### `ohtv fetch-loc` - Backfill PR/Push LOC from GitHub
+
+Reads pending `change_refs` rows produced by `db process contributions` (PR creations, PR merges, and direct pushes) and calls the GitHub REST API to populate `lines_added`, `lines_removed`, `files_changed`, `merged_at`, and `status`. This is the network-bound, cached, idempotent backfill that powers velocity and human-words-per-LOC reports.
+
+Requires a `GITHUB_TOKEN` (a read-only PAT or the output of `gh auth token`) on non-dry-run invocations. The token is read from the environment and is never logged or printed.
+
+`fetch-loc` slots in after the indexing pipeline once the `actions` and `contributions` stages have populated `change_refs`:
+
+```
+sync → db scan → db process all → fetch-loc → db embed
+```
+
+```bash
+# Preview which rows would be fetched (no token required, no HTTP, no DB writes)
+ohtv fetch-loc --dry-run
+
+# Real run — populate LOC for every pending change_ref across all repos
+GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc
+
+# Restrict to a single repo (same FQN-aware matcher as `list` / `refs`)
+GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc --repo myorg/myrepo
+
+# Re-fetch rows that are already populated (e.g. after a schema fix)
+GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc --repo myorg/myrepo --force
+
+# Cap work per invocation (useful for first-time backfills on large indexes)
+GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc --limit 50
+
+# Quiet mode for cron jobs (no progress bar, no summary)
+GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc --quiet
+```
+
+**Options:**
+| Flag | Description |
+|------|-------------|
+| `--repo TEXT` | Restrict to one repo (URL, `owner/repo`, or short name — same matcher as `list` / `refs`) |
+| `--force` | Re-fetch rows even if `lines_added` is already populated |
+| `--dry-run` | Show what would be fetched without making API calls or DB writes |
+| `--limit N` | Cap rows processed this run (default: unlimited) |
+| `-q, --quiet` | Minimal output (no progress bar, no end-of-run summary) |
+| `-v, --verbose` | Show debug output |
+
+**Behavioral notes:**
+- **Idempotent by default.** Rows where `lines_added` and `fetched_at` are both populated are skipped on subsequent runs. Use `--force` to override.
+- **Open-PR cache window.** Rows with `status='open'` are re-fetched after a 1 h cache window so they can transition to `merged` or `closed`. Open and closed-unmerged PRs update `status` only — no LOC numbers are written.
+- **Rate-limit aware.** Honors `Retry-After`, falls back to `X-RateLimit-Reset`, then exponential backoff + jitter capped at 60 s. Warns when `X-RateLimit-Remaining < 100`.
+- **Graceful per-row errors.** A 401, 404, or 5xx on a single row marks that row as "tried" (`fetched_at = now()`) and the run continues. The command only exits non-zero when *every* attempt failed.
+- **Non-GitHub repos skipped.** `change_refs` whose canonical URL points at GitLab / Bitbucket / etc. are logged and skipped — only GitHub is supported in v1.
+- **Missing token.** On a non-dry-run, if `GITHUB_TOKEN` is unset the command exits non-zero with a pointer to `gh auth token`. The token value is never written to logs.
+
+---
+
 ### `ohtv search` - Semantic Search
 
 Searches conversations using embedding-based semantic search or keyword matching. Finds conversations by concept/intent rather than exact matches.
@@ -1421,6 +1476,7 @@ Investigation mode is useful for:
 | `LLM_BASE_URL` | Custom LLM base URL | Provider default |
 | `LLM_TIMEOUT` | LLM request timeout in seconds | `300` |
 | `EMBEDDING_MODEL` | Model for embeddings (`db embed`, `search`) | `openai/text-embedding-3-small` |
+| `GITHUB_TOKEN` | GitHub PAT (read-only is fine) or `gh auth token` output | Required for `fetch-loc` (non-dry-run) |
 
 ## Data Directories
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -7843,6 +7843,288 @@ def _show_prompts_status(prompts_list: list[dict], user_dir) -> None:
 
 
 # =============================================================================
+# fetch-loc — backfill LOC for change_refs from GitHub (Issue #80)
+# =============================================================================
+
+
+def _error_no_github_token() -> None:
+    """Surface a friendly error when GITHUB_TOKEN is missing.
+
+    Never logs the token value itself. Points the user at the two
+    common ways to populate it (``gh auth token`` and direct export).
+    """
+    console.print(
+        "[red]Error:[/red] GITHUB_TOKEN is required to call the GitHub API.\n"
+        "  - If you have the GitHub CLI: "
+        "[cyan]export GITHUB_TOKEN=$(gh auth token)[/cyan]\n"
+        "  - Or create a fine-grained token at "
+        "https://github.com/settings/tokens?type=beta and "
+        "[cyan]export GITHUB_TOKEN=...[/cyan]"
+    )
+    raise SystemExit(1)
+
+
+@main.command("fetch-loc")
+@click.option("--repo", "repo_filter", help="Restrict to one repo (URL, owner/repo, or short name)")
+@click.option("--force", is_flag=True, help="Re-fetch even if lines_added is already populated")
+@click.option("--dry-run", is_flag=True, help="Show what would be fetched without making API calls")
+@click.option("--limit", type=int, help="Cap rows processed this run (default: unlimited)")
+@click.option("--quiet", "-q", is_flag=True, help="Minimal output (no progress bar)")
+@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+def fetch_loc_cmd(
+    repo_filter: str | None,
+    force: bool,
+    dry_run: bool,
+    limit: int | None,
+    quiet: bool,
+    verbose: bool,
+) -> None:
+    """Backfill lines-added / lines-removed for ``change_refs`` from the GitHub API.
+
+    Reads pending ``change_refs`` rows produced by the contributions
+    stages (#78 / #79), calls the GitHub REST API (``/pulls`` for PRs,
+    ``/compare`` for direct pushes), and updates the row in place.
+    Idempotent by default: rows already fully populated are skipped on
+    subsequent runs (use ``--force`` to refresh).
+
+    \b
+    Requires GITHUB_TOKEN in env (e.g. ``export GITHUB_TOKEN=$(gh auth token)``).
+    Never logs or prints the token value.
+
+    \b
+    Examples:
+      ohtv fetch-loc                          # Fetch all pending across all repos
+      ohtv fetch-loc --repo jpshackelford/ohtv
+      ohtv fetch-loc --dry-run                # Preview only
+      ohtv fetch-loc --force --repo foo/bar   # Refresh stale data
+    """
+    import os
+
+    _init_logging(verbose=verbose)
+    _run_fetch_loc(
+        repo_filter=repo_filter,
+        force=force,
+        dry_run=dry_run,
+        limit=limit,
+        quiet=quiet,
+        token=os.environ.get("GITHUB_TOKEN"),
+    )
+
+
+def _run_fetch_loc(
+    *,
+    repo_filter: str | None,
+    force: bool,
+    dry_run: bool,
+    limit: int | None,
+    quiet: bool,
+    token: str | None,
+    client_factory=None,
+) -> None:
+    """Core ``fetch-loc`` pipeline. Split out for testability.
+
+    ``client_factory`` is an optional ``Callable[[str], GitHubClient]``
+    test hook. When ``None`` we build a real :class:`GitHubClient`.
+    """
+    from ohtv.db import ensure_db_ready, get_connection
+    from ohtv.db.stores import RepoStore
+    from ohtv.github_api import GitHubClient, RateLimitExceededError
+
+    if not dry_run and not token:
+        _error_no_github_token()
+
+    # Resolve repo filter (if any) to a single repo_id. We accept the
+    # same shapes as the `list` / `refs` filters: URL, FQN, short name.
+    repo_id: int | None = None
+    repo_label: str | None = None
+    with get_connection() as conn:
+        ensure_db_ready(conn, show_progress=not quiet)
+        if repo_filter:
+            repo_store = RepoStore(conn)
+            target = repo_filter.strip()
+            repo = None
+            if "://" in target:
+                repo = repo_store.get_by_url(target)
+            if repo is None:
+                candidates = list(repo_store.search_by_name(target))
+                if len(candidates) == 1:
+                    repo = candidates[0]
+                elif len(candidates) > 1:
+                    console.print(
+                        f"[red]Error:[/red] --repo {target!r} matched "
+                        f"{len(candidates)} repos: "
+                        + ", ".join(c.fqn for c in candidates[:5])
+                    )
+                    raise SystemExit(2)
+            if repo is None:
+                console.print(
+                    f"[red]Error:[/red] --repo {target!r} did not match any "
+                    "known repository. Run `ohtv db scan` first."
+                )
+                raise SystemExit(2)
+            repo_id = repo.id
+            repo_label = repo.fqn
+
+        # Build the client (or pull from the factory in tests). The
+        # factory is the dependency-injection seam for `pytest-httpx`.
+        if client_factory is not None:
+            client = client_factory(token or "")
+        elif dry_run and not token:
+            client = None  # No HTTP will happen anyway.
+        else:
+            client = GitHubClient(token or "")
+
+        try:
+            result = _execute_fetch_loc(
+                conn,
+                client=client,
+                repo_id=repo_id,
+                repo_label=repo_label,
+                force=force,
+                dry_run=dry_run,
+                limit=limit,
+                quiet=quiet,
+            )
+        except RateLimitExceededError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise SystemExit(1) from exc
+        finally:
+            if client is not None and hasattr(client, "close"):
+                client.close()
+
+    _print_fetch_loc_summary(result, dry_run=dry_run, quiet=quiet)
+    if result.exit_code != 0:
+        raise SystemExit(result.exit_code)
+
+
+def _execute_fetch_loc(
+    conn,
+    *,
+    client,
+    repo_id: int | None,
+    repo_label: str | None,
+    force: bool,
+    dry_run: bool,
+    limit: int | None,
+    quiet: bool,
+):
+    """Run the orchestrator with (or without) a progress bar."""
+    from ohtv.fetch_loc import fetch_loc
+    from ohtv.parallel import format_rate, format_remaining
+
+    # Dry-run path: no HTTP, no DB writes. Skip the progress bar to
+    # match other commands' UX (we have nothing meaningful to animate).
+    if dry_run:
+        return fetch_loc(
+            conn,
+            client=client,  # may be None — fetch_loc never calls in dry-run
+            repo_id=repo_id,
+            force=force,
+            dry_run=True,
+            limit=limit,
+        )
+
+    if quiet:
+        return fetch_loc(
+            conn,
+            client=client,
+            repo_id=repo_id,
+            force=force,
+            dry_run=False,
+            limit=limit,
+        )
+
+    from ohtv.progress import make_progress
+
+    bar_label = "Fetching LOC"
+    if repo_label:
+        bar_label = f"Fetching LOC ({repo_label})"
+
+    import time
+
+    with make_progress(
+        console=console,
+        show_rate=True,
+        show_remaining=True,
+        show_eta=True,
+        show_current=True,
+    ) as progress:
+        task = progress.add_task(
+            bar_label,
+            total=0,
+            remaining="",
+            rate="",
+            current="",
+        )
+        start_time = time.monotonic()
+        last_total = [0]
+
+        def on_progress(completed: int, total: int, message: str) -> None:
+            if last_total[0] != total:
+                progress.update(task, total=total)
+                last_total[0] = total
+            elapsed = time.monotonic() - start_time
+            progress.update(
+                task,
+                completed=completed,
+                remaining=format_remaining(total, completed),
+                rate=format_rate(completed, elapsed, unit="rows"),
+                current=message[:40],
+            )
+
+        return fetch_loc(
+            conn,
+            client=client,
+            repo_id=repo_id,
+            force=force,
+            dry_run=False,
+            limit=limit,
+            on_progress=on_progress,
+        )
+
+
+def _print_fetch_loc_summary(result, *, dry_run: bool, quiet: bool) -> None:
+    """Render a one-block summary after the run."""
+    if quiet:
+        # Even quiet mode emits one line so cron jobs see something.
+        log.info(
+            "fetch-loc: candidates=%d fetched=%d failed=%d "
+            "skipped_cached=%d skipped_non_github=%d still_open=%d",
+            result.total_candidates,
+            result.fetched,
+            result.failed,
+            result.skipped_cached,
+            result.skipped_non_github,
+            result.still_open,
+        )
+        return
+
+    console.print()
+    if dry_run:
+        console.print(
+            f"[yellow]Dry-run:[/yellow] would fetch {result.total_candidates} row(s)"
+        )
+        if result.repo_names:
+            sample = ", ".join(result.repo_names[:5])
+            more = "" if len(result.repo_names) <= 5 else f" (+ {len(result.repo_names) - 5} more)"
+            console.print(f"  Repos: {sample}{more}")
+        return
+
+    console.print("[green]fetch-loc complete:[/green]")
+    console.print(f"  Candidates:        {result.total_candidates}")
+    console.print(f"  Fetched:           {result.fetched}")
+    console.print(f"  Failed:            {result.failed}")
+    console.print(f"  Skipped (cached):  {result.skipped_cached}")
+    console.print(f"  Skipped (non-GH):  {result.skipped_non_github}")
+    if result.skipped_unparseable:
+        console.print(f"  Skipped (bad data):{result.skipped_unparseable}")
+    if result.still_open:
+        console.print(f"  PRs still open:    {result.still_open}")
+    if result.closed_unmerged:
+        console.print(f"  PRs closed unmerged: {result.closed_unmerged}")
+
+
+# =============================================================================
 # Gen Commands (new unified interface)
 # =============================================================================
 

--- a/src/ohtv/db/migrations/017_change_refs_status_open.py
+++ b/src/ohtv/db/migrations/017_change_refs_status_open.py
@@ -1,0 +1,120 @@
+"""Widen ``change_refs.status`` CHECK constraint to include ``'open'``.
+
+PR #76 / migration 016 added the ``change_refs`` table with a CHECK
+constraint of ``status IN ('pending', 'fetched', 'merged', 'closed')``.
+
+Issue #80 (this PR) requires the ``ohtv fetch-loc`` command to set
+``status='open'`` for PRs that are still open on GitHub, both because:
+
+1. The issue body explicitly requires AC #11: *"For non-merged PRs the
+   row's ``status`` is updated to ``open`` or ``closed``."*
+2. The idempotency cache predicate also references ``open``:
+   ``(change_type='pr' AND status IN ('merged','open','closed'))``.
+   Without this status value, open PRs would never be considered
+   "cached" and would be re-fetched on every run, breaking AC #5.
+
+SQLite does not support ``ALTER TABLE ... DROP CHECK``, and renaming
+the table breaks foreign-key references in dependent tables. We use
+the canonical "12-step ALTER TABLE" pattern from
+https://sqlite.org/lang_altertable.html#otheralter:
+
+1. Disable FK enforcement (``PRAGMA foreign_keys = OFF``).
+2. Create a *new* table under a temporary name with the wider CHECK.
+3. Copy data from the original table.
+4. Drop the original table.
+5. Rename the new table to the original name. Because no other table
+   references the temp name, this rename does not perturb any FKs.
+6. Recreate the original indexes.
+7. Re-enable FK enforcement.
+
+Row IDs are preserved verbatim so any existing
+``conversation_contributions.change_ref_id`` rows resolve correctly
+after the swap.
+
+This migration is intentionally minimal — no new columns, no new
+indexes, no behavioural changes for already-stored rows. The only
+delta is the broader value enum.
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Recreate ``change_refs`` with a widened ``status`` CHECK constraint."""
+
+    fk_enabled = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    conn.execute("PRAGMA foreign_keys = OFF")
+
+    try:
+        # 1. Create the replacement table under a temporary name.
+        #    Same shape as migration 016, plus ``'open'`` in the CHECK.
+        conn.execute("""
+            CREATE TABLE change_refs_new (
+                id INTEGER PRIMARY KEY,
+                repo_id INTEGER NOT NULL,
+                change_type TEXT NOT NULL CHECK(change_type IN ('pr', 'direct_push')),
+                pr_number INTEGER,
+                commit_range TEXT,
+                branch TEXT,
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(status IN ('pending', 'fetched', 'merged', 'closed', 'open')),
+                merged_at TEXT,
+                lines_added INTEGER,
+                lines_removed INTEGER,
+                files_changed INTEGER,
+                fetched_at TEXT,
+                FOREIGN KEY (repo_id) REFERENCES repositories(id) ON DELETE CASCADE,
+                CHECK (
+                    (change_type = 'pr' AND pr_number IS NOT NULL) OR
+                    (change_type = 'direct_push' AND commit_range IS NOT NULL)
+                )
+            )
+        """)
+
+        # 2. Copy data, preserving primary keys.
+        conn.execute("""
+            INSERT INTO change_refs_new
+                (id, repo_id, change_type, pr_number, commit_range, branch,
+                 status, merged_at, lines_added, lines_removed,
+                 files_changed, fetched_at)
+            SELECT
+                id, repo_id, change_type, pr_number, commit_range, branch,
+                status, merged_at, lines_added, lines_removed,
+                files_changed, fetched_at
+            FROM change_refs
+        """)
+
+        # 3. Drop the original. This also drops the indexes attached to it.
+        conn.execute("DROP TABLE change_refs")
+
+        # 4. Rename the new table into place. No other table references
+        #    ``change_refs_new``, so this rename does not modify any FK
+        #    references in dependent tables.
+        conn.execute("ALTER TABLE change_refs_new RENAME TO change_refs")
+
+        # 5. Recreate the original indexes (they were dropped with the
+        #    original table).
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_change_refs_pr_unique "
+            "ON change_refs(repo_id, pr_number) WHERE change_type = 'pr'"
+        )
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_change_refs_push_unique "
+            "ON change_refs(repo_id, commit_range) "
+            "WHERE change_type = 'direct_push'"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_change_refs_repo "
+            "ON change_refs(repo_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_change_refs_type "
+            "ON change_refs(change_type)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_change_refs_status "
+            "ON change_refs(status)"
+        )
+    finally:
+        if fk_enabled:
+            conn.execute("PRAGMA foreign_keys = ON")

--- a/src/ohtv/fetch_loc.py
+++ b/src/ohtv/fetch_loc.py
@@ -1,0 +1,539 @@
+"""Backfill ``change_refs`` LOC columns from the GitHub API (Issue #80).
+
+This module orchestrates the row-by-row LOC backfill that powers the
+Conversation Metrics velocity report (#81). It is intentionally split
+from :mod:`ohtv.github_api` so the CLI can swap the HTTP client in
+tests via dependency injection without monkey-patching.
+
+Design highlights
+-----------------
+
+* **Source of truth is GitHub** — never compute LOC from local
+  trajectory events (see issue body for rationale).
+* **Idempotent by default** — rows where ``fetched_at`` is set and
+  ``lines_added`` is populated (or status is a non-pending PR status)
+  are skipped. ``--force`` ignores this. PRs whose previous status was
+  ``open`` are re-fetched if older than 1 hour, since they may have
+  merged since.
+* **Graceful per-row errors** — 404/401/5xx do NOT abort the run; the
+  row is marked as "tried" via ``fetched_at = now()`` and the loop
+  continues. Exit non-zero only when every request failed.
+* **Non-GitHub repos are skipped** without touching the row at all
+  (we don't currently support GitLab / Bitbucket LOC).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Protocol
+
+import httpx
+
+log = logging.getLogger("ohtv")
+
+
+# Re-fetch threshold for ``status='open'`` PRs — they may have merged
+# since the last attempt, but we don't want to hammer the API for
+# never-merged stale PRs.
+OPEN_PR_REFETCH_AGE = timedelta(hours=1)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class GitHubClientProtocol(Protocol):
+    """Subset of :class:`ohtv.github_api.GitHubClient` we depend on."""
+
+    def get_pr(self, owner: str, repo: str, pr_number: int) -> dict | None: ...
+
+    def get_compare(
+        self, owner: str, repo: str, base: str, head: str
+    ) -> dict | None: ...
+
+
+@dataclass
+class FetchResult:
+    """Summary of a single ``fetch_loc`` run."""
+
+    total_candidates: int = 0  # rows considered (after filter + cache predicate)
+    fetched: int = 0  # successful HTTP -> DB write (incl. open/closed PRs)
+    skipped_cached: int = 0  # cached, not re-fetched
+    skipped_non_github: int = 0  # repos like gitlab.com / bitbucket
+    skipped_unparseable: int = 0  # missing pr_number / commit_range / bad commit_range
+    failed: int = 0  # HTTP error -> we still wrote fetched_at
+    still_open: int = 0  # PRs that came back as still-open
+    closed_unmerged: int = 0  # PRs that closed without merging
+    repo_names: list[str] = field(default_factory=list)
+
+    @property
+    def exit_code(self) -> int:
+        """Return a CLI exit code.
+
+        Returns 0 unless we actually attempted HTTP and every attempt
+        failed. A run with zero candidates exits 0 — that's "nothing to
+        do", not "broken".
+        """
+        attempted = self.fetched + self.failed
+        if attempted == 0:
+            return 0
+        if self.fetched == 0 and self.failed > 0:
+            return 1
+        return 0
+
+
+@dataclass(frozen=True)
+class _CandidateRow:
+    """A single row pulled from the ``change_refs`` join."""
+
+    id: int
+    repo_id: int
+    canonical_url: str
+    fqn: str
+    change_type: str
+    pr_number: int | None
+    commit_range: str | None
+    status: str
+    fetched_at: str | None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_GITHUB_HOST_RE = re.compile(r"^https?://(?:www\.)?github\.com/", re.IGNORECASE)
+_OWNER_REPO_RE = re.compile(
+    r"^https?://(?:www\.)?github\.com/([^/]+)/([^/#?]+?)(?:\.git)?(?:[/#?]|$)",
+    re.IGNORECASE,
+)
+
+
+def is_github_url(canonical_url: str | None) -> bool:
+    """Return True iff ``canonical_url`` points at github.com."""
+    if not canonical_url:
+        return False
+    return bool(_GITHUB_HOST_RE.match(canonical_url))
+
+
+def parse_github_owner_repo(canonical_url: str) -> tuple[str, str] | None:
+    """Extract ``(owner, repo)`` from a GitHub canonical URL."""
+    match = _OWNER_REPO_RE.match(canonical_url)
+    if not match:
+        return None
+    owner, repo = match.group(1), match.group(2)
+    repo = repo.removesuffix(".git")
+    return owner, repo
+
+
+def split_commit_range(commit_range: str) -> tuple[str, str] | None:
+    """Split ``"abc..def"`` (our storage format) into ``("abc", "def")``."""
+    if ".." not in commit_range:
+        return None
+    parts = commit_range.split("..", 1)
+    if len(parts) != 2 or not all(parts):
+        return None
+    return parts[0], parts[1]
+
+
+def _now_iso() -> str:
+    """Return UTC now() in ISO-8601 (matches SQLite ``datetime('now')``)."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _parse_fetched_at(fetched_at: str | None) -> datetime | None:
+    if not fetched_at:
+        return None
+    try:
+        # SQLite ``datetime('now')`` returns ``YYYY-MM-DD HH:MM:SS`` (no tz);
+        # our own writer uses ISO with offset. Handle both.
+        cleaned = fetched_at.replace("Z", "+00:00")
+        if " " in cleaned and "T" not in cleaned:
+            cleaned = cleaned.replace(" ", "T")
+        dt = datetime.fromisoformat(cleaned)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _is_cached(row: _CandidateRow, now: datetime) -> bool:
+    """Idempotency predicate.
+
+    Mirrors the issue body's spec:
+
+    .. code::
+
+        fetched_at IS NOT NULL AND (
+            (change_type = 'pr'          AND status IN ('merged','open','closed')) OR
+            (change_type = 'direct_push' AND lines_added IS NOT NULL)
+        )
+
+    Plus: ``status='open'`` rows older than ``OPEN_PR_REFETCH_AGE`` are
+    treated as NOT cached (they may have merged since).
+    """
+    if row.fetched_at is None:
+        return False
+    if row.change_type == "pr":
+        if row.status not in {"merged", "open", "closed"}:
+            return False
+        if row.status == "open":
+            fetched = _parse_fetched_at(row.fetched_at)
+            if fetched is None or now - fetched >= OPEN_PR_REFETCH_AGE:
+                return False
+        return True
+    # direct_push
+    # We piggy-back on lines_added IS NOT NULL via the candidate query —
+    # so if a direct_push row is in our list, it's not cached.
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Candidate selection
+# ---------------------------------------------------------------------------
+
+
+def _select_candidates(
+    conn: sqlite3.Connection,
+    *,
+    repo_id: int | None,
+    force: bool,
+    limit: int | None,
+) -> list[_CandidateRow]:
+    """Pull candidate rows from ``change_refs`` ⨝ ``repositories``.
+
+    The ``force=True`` mode selects all rows for the repo filter (or all
+    repos). Default mode applies the cache predicate at the SQL level
+    so we don't pay the round-trip for trivially-skipped rows. The
+    open-PR re-fetch heuristic is applied in Python (we don't want to
+    bake ``now()`` arithmetic into the SQL).
+    """
+    sql = [
+        "SELECT cr.id, cr.repo_id, r.canonical_url, r.fqn,",
+        "       cr.change_type, cr.pr_number, cr.commit_range,",
+        "       cr.status, cr.fetched_at, cr.lines_added",
+        "FROM change_refs cr",
+        "JOIN repositories r ON r.id = cr.repo_id",
+        "WHERE 1=1",
+    ]
+    params: list[object] = []
+
+    if repo_id is not None:
+        sql.append("AND cr.repo_id = ?")
+        params.append(repo_id)
+
+    if not force:
+        # Cache predicate (SQL-side). Note we DO NOT filter out rows
+        # with ``status='open'`` here, even though they have
+        # ``fetched_at`` set — the "open-PR re-fetch after 1 hour"
+        # heuristic is applied in Python (see :func:`_is_cached`) and
+        # needs the row in hand to compare timestamps. We do include
+        # them in the candidate set so the orchestrator can choose
+        # to skip them or re-fetch them.
+        sql.append("""
+            AND NOT (
+                cr.fetched_at IS NOT NULL AND (
+                    (cr.change_type = 'pr' AND cr.status IN ('merged','closed'))
+                    OR
+                    (cr.change_type = 'direct_push' AND cr.lines_added IS NOT NULL)
+                )
+            )
+        """)
+
+    sql.append("ORDER BY cr.id ASC")
+    if limit is not None:
+        sql.append("LIMIT ?")
+        params.append(limit)
+
+    cursor = conn.execute("\n".join(sql), params)
+    return [
+        _CandidateRow(
+            id=row["id"],
+            repo_id=row["repo_id"],
+            canonical_url=row["canonical_url"],
+            fqn=row["fqn"],
+            change_type=row["change_type"],
+            pr_number=row["pr_number"],
+            commit_range=row["commit_range"],
+            status=row["status"],
+            fetched_at=row["fetched_at"],
+        )
+        for row in cursor.fetchall()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-row processing
+# ---------------------------------------------------------------------------
+
+
+def _update_pr_row(
+    conn: sqlite3.Connection,
+    row_id: int,
+    pr_data: dict,
+    now: str,
+) -> str:
+    """Apply a PR API response to ``change_refs``.
+
+    Returns one of ``"merged"``, ``"open"``, ``"closed"`` so the caller
+    can keep running counts.
+    """
+    merged = bool(pr_data.get("merged"))
+    state = pr_data.get("state", "open")
+    if merged:
+        status = "merged"
+        conn.execute(
+            """
+            UPDATE change_refs
+            SET status = ?, merged_at = ?, lines_added = ?,
+                lines_removed = ?, files_changed = ?, fetched_at = ?
+            WHERE id = ?
+            """,
+            (
+                status,
+                pr_data.get("merged_at"),
+                pr_data.get("additions"),
+                pr_data.get("deletions"),
+                pr_data.get("changed_files"),
+                now,
+                row_id,
+            ),
+        )
+        return status
+
+    status = "open" if state == "open" else "closed"
+    conn.execute(
+        """
+        UPDATE change_refs
+        SET status = ?, merged_at = NULL, lines_added = NULL,
+            lines_removed = NULL, files_changed = NULL, fetched_at = ?
+        WHERE id = ?
+        """,
+        (status, now, row_id),
+    )
+    return status
+
+
+def _update_compare_row(
+    conn: sqlite3.Connection,
+    row_id: int,
+    compare_data: dict,
+    now: str,
+) -> None:
+    """Apply a compare API response to a ``direct_push`` row."""
+    files = compare_data.get("files") or []
+    lines_added = sum(int(f.get("additions") or 0) for f in files)
+    lines_removed = sum(int(f.get("deletions") or 0) for f in files)
+    files_changed = len(files)
+
+    conn.execute(
+        """
+        UPDATE change_refs
+        SET status = 'merged', lines_added = ?, lines_removed = ?,
+            files_changed = ?, fetched_at = ?
+        WHERE id = ?
+        """,
+        (lines_added, lines_removed, files_changed, now, row_id),
+    )
+
+
+def _mark_tried(conn: sqlite3.Connection, row_id: int, now: str) -> None:
+    """Record an HTTP failure as "tried" so we don't retry every run.
+
+    We leave LOC columns untouched so a future ``--force`` run can
+    repopulate them once the issue is resolved.
+    """
+    conn.execute(
+        "UPDATE change_refs SET fetched_at = ? WHERE id = ?",
+        (now, row_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public orchestrator
+# ---------------------------------------------------------------------------
+
+
+ProgressCallback = Callable[[int, int, str], None]
+
+
+def fetch_loc(
+    conn: sqlite3.Connection,
+    *,
+    client: GitHubClientProtocol,
+    repo_id: int | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+    limit: int | None = None,
+    on_progress: ProgressCallback | None = None,
+    now_provider: Callable[[], datetime] | None = None,
+) -> FetchResult:
+    """Backfill LOC columns for ``change_refs`` rows.
+
+    Args:
+        conn: SQLite connection (with ``row_factory = sqlite3.Row``).
+        client: GitHub client (implements :class:`GitHubClientProtocol`).
+            In tests this is the real :class:`ohtv.github_api.GitHubClient`
+            wired up against ``pytest-httpx``.
+        repo_id: If provided, restrict to one repo.
+        force: Ignore the cache predicate; re-fetch all matching rows.
+        dry_run: Do not call HTTP and do not write to the DB; just count.
+        limit: Cap the number of rows processed.
+        on_progress: Optional callback ``(completed, total, message)``
+            for progress-bar wiring.
+        now_provider: Inject a clock for deterministic tests.
+
+    Returns:
+        :class:`FetchResult` summarising the run.
+    """
+    now_dt = (now_provider or (lambda: datetime.now(timezone.utc)))()
+    now_iso = now_dt.replace(microsecond=0).isoformat()
+
+    candidates = _select_candidates(
+        conn, repo_id=repo_id, force=force, limit=limit
+    )
+    result = FetchResult()
+    result.total_candidates = len(candidates)
+    result.repo_names = sorted({row.fqn for row in candidates})
+
+    if not candidates:
+        if on_progress is not None:
+            on_progress(0, 0, "no candidates")
+        return result
+
+    if dry_run:
+        # No HTTP, no DB writes — just count and return.
+        if on_progress is not None:
+            on_progress(len(candidates), len(candidates), "dry-run")
+        return result
+
+    total = len(candidates)
+    for index, row in enumerate(candidates, start=1):
+        # Cache predicate (post-SQL): respects open-PR refetch window.
+        if not force and _is_cached(row, now_dt):
+            result.skipped_cached += 1
+            if on_progress is not None:
+                on_progress(index, total, f"cached {row.fqn}")
+            continue
+
+        # Non-GitHub repo — skip entirely (do not touch fetched_at).
+        if not is_github_url(row.canonical_url):
+            log.info(
+                "fetch-loc: skipping non-GitHub repo %s (%s)",
+                row.fqn,
+                row.canonical_url,
+            )
+            result.skipped_non_github += 1
+            if on_progress is not None:
+                on_progress(index, total, f"non-github {row.fqn}")
+            continue
+
+        parsed = parse_github_owner_repo(row.canonical_url)
+        if parsed is None:
+            log.warning(
+                "fetch-loc: cannot parse owner/repo from %s — skipping",
+                row.canonical_url,
+            )
+            result.skipped_unparseable += 1
+            if on_progress is not None:
+                on_progress(index, total, f"unparseable {row.canonical_url}")
+            continue
+        owner, repo = parsed
+
+        try:
+            if row.change_type == "pr":
+                if row.pr_number is None:
+                    log.warning(
+                        "fetch-loc: PR row %d missing pr_number — skipping",
+                        row.id,
+                    )
+                    result.skipped_unparseable += 1
+                    continue
+                msg = f"{owner}/{repo}#{row.pr_number}"
+                pr_data = client.get_pr(owner, repo, row.pr_number)
+                if pr_data is None:
+                    _mark_tried(conn, row.id, now_iso)
+                    result.failed += 1
+                    log.warning("fetch-loc: %s returned 404 — marked tried", msg)
+                else:
+                    new_status = _update_pr_row(conn, row.id, pr_data, now_iso)
+                    result.fetched += 1
+                    if new_status == "open":
+                        result.still_open += 1
+                    elif new_status == "closed":
+                        result.closed_unmerged += 1
+                if on_progress is not None:
+                    on_progress(index, total, msg)
+
+            elif row.change_type == "direct_push":
+                if row.commit_range is None:
+                    log.warning(
+                        "fetch-loc: direct_push row %d missing commit_range",
+                        row.id,
+                    )
+                    result.skipped_unparseable += 1
+                    continue
+                shas = split_commit_range(row.commit_range)
+                if shas is None:
+                    log.warning(
+                        "fetch-loc: malformed commit_range %r — skipping",
+                        row.commit_range,
+                    )
+                    result.skipped_unparseable += 1
+                    continue
+                base, head = shas
+                msg = f"{owner}/{repo} {base[:7]}..{head[:7]}"
+                cmp_data = client.get_compare(owner, repo, base, head)
+                if cmp_data is None:
+                    _mark_tried(conn, row.id, now_iso)
+                    result.failed += 1
+                    log.warning("fetch-loc: %s returned 404 — marked tried", msg)
+                else:
+                    _update_compare_row(conn, row.id, cmp_data, now_iso)
+                    result.fetched += 1
+                if on_progress is not None:
+                    on_progress(index, total, msg)
+
+            else:  # pragma: no cover — schema CHECK constraint prevents this
+                log.warning(
+                    "fetch-loc: unknown change_type %r — skipping",
+                    row.change_type,
+                )
+                result.skipped_unparseable += 1
+                continue
+
+        except httpx.HTTPStatusError as exc:
+            # 401/5xx: mark as tried, log, continue.
+            status = exc.response.status_code if exc.response is not None else 0
+            log.warning(
+                "fetch-loc: HTTP %d on change_ref %d (%s) — marked tried",
+                status,
+                row.id,
+                row.fqn,
+            )
+            _mark_tried(conn, row.id, now_iso)
+            result.failed += 1
+            if on_progress is not None:
+                on_progress(index, total, f"HTTP {status}")
+
+        # Commit after each row so a SIGINT mid-run doesn't lose work.
+        conn.commit()
+
+    return result
+
+
+__all__ = [
+    "FetchResult",
+    "GitHubClientProtocol",
+    "OPEN_PR_REFETCH_AGE",
+    "fetch_loc",
+    "is_github_url",
+    "parse_github_owner_repo",
+    "split_commit_range",
+]

--- a/src/ohtv/fetch_loc.py
+++ b/src/ohtv/fetch_loc.py
@@ -355,6 +355,102 @@ def _mark_tried(conn: sqlite3.Connection, row_id: int, now: str) -> None:
     )
 
 
+def _process_pr_row(
+    conn: sqlite3.Connection,
+    client: GitHubClientProtocol,
+    row: _CandidateRow,
+    owner: str,
+    repo: str,
+    now_iso: str,
+    result: FetchResult,
+) -> tuple[str | None, str | None]:
+    """Process a single ``change_type='pr'`` row.
+
+    Returns ``(msg, new_status)`` where ``msg`` is the progress label to
+    display (or ``None`` if the row was skipped before any HTTP call) and
+    ``new_status`` is the post-update PR status (or ``None`` on 404).
+
+    Behavior mirrors the original inline branch in :func:`fetch_loc`:
+    missing ``pr_number`` is logged + counted as ``skipped_unparseable``
+    and returns ``(None, None)`` so the caller does not emit a progress
+    update. May raise ``httpx.HTTPStatusError`` (handled by the caller).
+    """
+    if row.pr_number is None:
+        log.warning(
+            "fetch-loc: PR row %d missing pr_number — skipping",
+            row.id,
+        )
+        result.skipped_unparseable += 1
+        return None, None
+
+    msg = f"{owner}/{repo}#{row.pr_number}"
+    pr_data = client.get_pr(owner, repo, row.pr_number)
+    if pr_data is None:
+        _mark_tried(conn, row.id, now_iso)
+        result.failed += 1
+        log.warning("fetch-loc: %s returned 404 — marked tried", msg)
+        return msg, None
+
+    new_status = _update_pr_row(conn, row.id, pr_data, now_iso)
+    result.fetched += 1
+    if new_status == "open":
+        result.still_open += 1
+    elif new_status == "closed":
+        result.closed_unmerged += 1
+    return msg, new_status
+
+
+def _process_push_row(
+    conn: sqlite3.Connection,
+    client: GitHubClientProtocol,
+    row: _CandidateRow,
+    owner: str,
+    repo: str,
+    now_iso: str,
+    result: FetchResult,
+) -> tuple[str | None, str | None]:
+    """Process a single ``change_type='direct_push'`` row.
+
+    Returns ``(msg, new_status)``. ``new_status`` is always ``None`` for
+    direct pushes (there is no PR-style status to surface) but is
+    included for symmetry with :func:`_process_pr_row`.
+
+    Skips (missing ``commit_range`` or malformed range) return
+    ``(None, None)`` so the caller does not emit a progress update,
+    matching the pre-refactor ``continue`` behavior. May raise
+    ``httpx.HTTPStatusError`` (handled by the caller).
+    """
+    if row.commit_range is None:
+        log.warning(
+            "fetch-loc: direct_push row %d missing commit_range",
+            row.id,
+        )
+        result.skipped_unparseable += 1
+        return None, None
+
+    shas = split_commit_range(row.commit_range)
+    if shas is None:
+        log.warning(
+            "fetch-loc: malformed commit_range %r — skipping",
+            row.commit_range,
+        )
+        result.skipped_unparseable += 1
+        return None, None
+
+    base, head = shas
+    msg = f"{owner}/{repo} {base[:7]}..{head[:7]}"
+    cmp_data = client.get_compare(owner, repo, base, head)
+    if cmp_data is None:
+        _mark_tried(conn, row.id, now_iso)
+        result.failed += 1
+        log.warning("fetch-loc: %s returned 404 — marked tried", msg)
+        return msg, None
+
+    _update_compare_row(conn, row.id, cmp_data, now_iso)
+    result.fetched += 1
+    return msg, None
+
+
 # ---------------------------------------------------------------------------
 # Public orchestrator
 # ---------------------------------------------------------------------------
@@ -448,58 +544,17 @@ def fetch_loc(
 
         try:
             if row.change_type == "pr":
-                if row.pr_number is None:
-                    log.warning(
-                        "fetch-loc: PR row %d missing pr_number — skipping",
-                        row.id,
-                    )
-                    result.skipped_unparseable += 1
-                    continue
-                msg = f"{owner}/{repo}#{row.pr_number}"
-                pr_data = client.get_pr(owner, repo, row.pr_number)
-                if pr_data is None:
-                    _mark_tried(conn, row.id, now_iso)
-                    result.failed += 1
-                    log.warning("fetch-loc: %s returned 404 — marked tried", msg)
-                else:
-                    new_status = _update_pr_row(conn, row.id, pr_data, now_iso)
-                    result.fetched += 1
-                    if new_status == "open":
-                        result.still_open += 1
-                    elif new_status == "closed":
-                        result.closed_unmerged += 1
-                if on_progress is not None:
+                msg, _ = _process_pr_row(
+                    conn, client, row, owner, repo, now_iso, result
+                )
+                if msg and on_progress is not None:
                     on_progress(index, total, msg)
-
             elif row.change_type == "direct_push":
-                if row.commit_range is None:
-                    log.warning(
-                        "fetch-loc: direct_push row %d missing commit_range",
-                        row.id,
-                    )
-                    result.skipped_unparseable += 1
-                    continue
-                shas = split_commit_range(row.commit_range)
-                if shas is None:
-                    log.warning(
-                        "fetch-loc: malformed commit_range %r — skipping",
-                        row.commit_range,
-                    )
-                    result.skipped_unparseable += 1
-                    continue
-                base, head = shas
-                msg = f"{owner}/{repo} {base[:7]}..{head[:7]}"
-                cmp_data = client.get_compare(owner, repo, base, head)
-                if cmp_data is None:
-                    _mark_tried(conn, row.id, now_iso)
-                    result.failed += 1
-                    log.warning("fetch-loc: %s returned 404 — marked tried", msg)
-                else:
-                    _update_compare_row(conn, row.id, cmp_data, now_iso)
-                    result.fetched += 1
-                if on_progress is not None:
+                msg, _ = _process_push_row(
+                    conn, client, row, owner, repo, now_iso, result
+                )
+                if msg and on_progress is not None:
                     on_progress(index, total, msg)
-
             else:  # pragma: no cover — schema CHECK constraint prevents this
                 log.warning(
                     "fetch-loc: unknown change_type %r — skipping",

--- a/src/ohtv/github_api.py
+++ b/src/ohtv/github_api.py
@@ -1,0 +1,268 @@
+"""GitHub REST API client for fetching PR / compare stats (Issue #80).
+
+This module is the HTTP boundary for ``ohtv fetch-loc``. It deliberately
+sticks to a thin wrapper around ``httpx.Client`` so ``pytest-httpx`` can
+mock all requests in unit tests without any code path being replaced.
+
+Endpoints used:
+
+* ``GET /repos/{owner}/{repo}/pulls/{pr_number}`` — PR LOC + merge state.
+* ``GET /repos/{owner}/{repo}/compare/{base}...{head}`` — direct-push
+  LOC (sum of ``files[].additions`` / ``files[].deletions``).
+
+Rate-limit strategy mirrors :class:`ohtv.sources.cloud.CloudClient`:
+
+1. On 429 (or 403 with rate-limit signal) honor ``Retry-After``, falling
+   back to ``X-RateLimit-Reset`` (unix epoch − now()), then exponential
+   backoff with jitter capped at 60 s.
+2. After every successful response, peek ``X-RateLimit-Remaining``; if
+   below 100, emit a ``WARNING``-level log line.
+3. On exhausted retries raise :class:`RateLimitExceededError` — the
+   orchestrator catches it and exits with the usual error path.
+
+Auth tokens are never logged. The token is supplied at construction
+time and only ever flows out via the ``Authorization`` header.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import Any, Mapping
+
+import httpx
+
+log = logging.getLogger("ohtv")
+
+GITHUB_API_BASE = "https://api.github.com"
+USER_AGENT = "ohtv/0.1"
+RATE_LIMIT_WARN_THRESHOLD = 100
+
+
+class RateLimitExceededError(Exception):
+    """Raised when GitHub rate-limit retries are exhausted."""
+
+
+class GitHubClient:
+    """Thin synchronous client over the GitHub REST API.
+
+    Only the two endpoints needed for ``ohtv fetch-loc`` are exposed.
+    Everything else (auth headers, rate-limit handling, retry backoff)
+    is shared via :meth:`_request_with_retry`.
+
+    Args:
+        token: Personal access token / fine-grained token. Required; if
+            the caller has none, the CLI should error before reaching
+            this class so we never log a token-less request.
+        base_url: Override the GitHub API root (only used in tests so
+            ``pytest-httpx`` can pin URLs).
+        timeout: Per-request timeout in seconds. Default 30 s — GitHub
+            responses are usually < 1 s; we mostly need this in case of
+            transient network hangs.
+        max_retries: Maximum 429/rate-limit retries per request.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        base_url: str = GITHUB_API_BASE,
+        timeout: float = 30.0,
+        max_retries: int = 6,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._max_retries = max_retries
+        self._client = httpx.Client(
+            base_url=self._base_url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": USER_AGENT,
+            },
+            timeout=timeout,
+        )
+
+    # ------------------------------------------------------------------
+    # Context manager / lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "GitHubClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Public endpoints
+    # ------------------------------------------------------------------
+
+    def get_pr(self, owner: str, repo: str, pr_number: int) -> dict[str, Any] | None:
+        """Fetch a PR's metadata + LOC stats.
+
+        Returns ``None`` if the PR is 404 (deleted or private) so the
+        caller can record a "tried" attempt without aborting the run.
+        All other non-2xx responses raise :class:`httpx.HTTPStatusError`
+        via :meth:`_request_with_retry`.
+        """
+        path = f"/repos/{owner}/{repo}/pulls/{pr_number}"
+        response = self._request_with_retry("GET", path)
+        if response is None:
+            return None
+        return response.json()
+
+    def get_compare(
+        self, owner: str, repo: str, base: str, head: str
+    ) -> dict[str, Any] | None:
+        """Fetch ``compare`` data between two SHAs (used for direct pushes).
+
+        Note GitHub's compare URL uses **three** dots between SHAs even
+        though our internal ``commit_range`` stores them with two.
+        Returns ``None`` on 404.
+        """
+        path = f"/repos/{owner}/{repo}/compare/{base}...{head}"
+        response = self._request_with_retry("GET", path)
+        if response is None:
+            return None
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> httpx.Response | None:
+        """Issue a request, retrying on 429 / rate-limited 403.
+
+        Returns the successful response, or ``None`` if the server
+        returned 404. All other non-2xx responses raise via
+        ``response.raise_for_status()``.
+        """
+        base_delay = 2.0
+        max_delay = 60.0
+
+        for attempt in range(self._max_retries):
+            response = self._client.request(method, path, **kwargs)
+
+            # 404 is a recoverable signal — the orchestrator marks
+            # the row as "tried" and moves on.
+            if response.status_code == 404:
+                log.warning("GitHub 404 for %s — treating as missing", path)
+                return None
+
+            if _is_rate_limited(response):
+                delay = self._get_retry_delay(response, base_delay, attempt, max_delay)
+                log.warning(
+                    "GitHub rate-limited on %s (status=%d), sleeping %.1fs "
+                    "(attempt %d/%d)",
+                    path,
+                    response.status_code,
+                    delay,
+                    attempt + 1,
+                    self._max_retries,
+                )
+                time.sleep(delay)
+                continue
+
+            # Any other non-2xx — surface to caller, do not retry.
+            response.raise_for_status()
+            _maybe_warn_low_rate_limit(response.headers)
+            return response
+
+        log.error(
+            "GitHub rate-limit retries exhausted for %s after %d attempts",
+            path,
+            self._max_retries,
+        )
+        raise RateLimitExceededError(
+            f"Rate-limit retries exhausted for {path} after {self._max_retries} attempts"
+        )
+
+    @staticmethod
+    def _get_retry_delay(
+        response: httpx.Response,
+        base_delay: float,
+        attempt: int,
+        max_delay: float,
+    ) -> float:
+        """Pick a sleep duration honoring server hints first."""
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return min(float(retry_after), max_delay)
+            except ValueError:
+                pass
+
+        # X-RateLimit-Reset is a unix epoch; compute time-to-reset.
+        reset = response.headers.get("X-RateLimit-Reset")
+        if reset:
+            try:
+                delta = float(reset) - time.time()
+                if 0 < delta <= max_delay:
+                    return delta
+            except ValueError:
+                pass
+
+        # Exponential backoff + ±10% jitter.
+        delay = min(base_delay * (2 ** attempt), max_delay)
+        jitter = delay * 0.1 * (2 * random.random() - 1)
+        return max(0.0, delay + jitter)
+
+
+def _is_rate_limited(response: httpx.Response) -> bool:
+    """Detect 429 and 403-with-rate-limit-signal responses.
+
+    GitHub uses 403 for secondary rate limits with a message body
+    containing "rate limit"; the auth-failure path also returns 403,
+    so we additionally guard on ``X-RateLimit-Remaining == 0`` /
+    presence of ``Retry-After`` to avoid retrying real 403s forever.
+    """
+    if response.status_code == 429:
+        return True
+    if response.status_code != 403:
+        return False
+    if response.headers.get("Retry-After"):
+        return True
+    remaining = response.headers.get("X-RateLimit-Remaining")
+    if remaining is not None:
+        try:
+            if int(remaining) <= 0:
+                return True
+        except ValueError:
+            pass
+    return False
+
+
+def _maybe_warn_low_rate_limit(headers: Mapping[str, str]) -> None:
+    """Emit a WARNING if the user is close to their hourly quota."""
+    remaining = headers.get("X-RateLimit-Remaining")
+    if remaining is None:
+        return
+    try:
+        remaining_int = int(remaining)
+    except ValueError:
+        return
+    if remaining_int < RATE_LIMIT_WARN_THRESHOLD:
+        log.warning(
+            "GitHub rate-limit low: %d requests remaining (threshold=%d). "
+            "Reset header: %s",
+            remaining_int,
+            RATE_LIMIT_WARN_THRESHOLD,
+            headers.get("X-RateLimit-Reset", "unknown"),
+        )
+
+
+__all__ = [
+    "GitHubClient",
+    "RateLimitExceededError",
+    "GITHUB_API_BASE",
+    "RATE_LIMIT_WARN_THRESHOLD",
+]

--- a/tests/unit/test_cli_fetch_loc.py
+++ b/tests/unit/test_cli_fetch_loc.py
@@ -1,0 +1,285 @@
+"""End-to-end CLI smoke tests for ``ohtv fetch-loc`` (Issue #80).
+
+These exercise the full Click entry point with a temp ``OHTV_DIR``
+and a fully-migrated SQLite DB. HTTP is mocked via ``pytest-httpx``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from pytest_httpx import HTTPXMock
+
+from ohtv.cli import main as ohtv_main
+from ohtv.db.migrations import migrate
+from ohtv.github_api import GITHUB_API_BASE
+
+
+PR_MERGED = {
+    "merged": True,
+    "state": "closed",
+    "merged_at": "2024-05-01T12:34:56Z",
+    "additions": 100,
+    "deletions": 25,
+    "changed_files": 3,
+}
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Force the CLI to use a temp DB at ``$OHTV_DIR/index.db``."""
+    ohtv_dir = tmp_path / "ohtv"
+    ohtv_dir.mkdir()
+    db_path = ohtv_dir / "index.db"
+
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_dir))
+    monkeypatch.setenv("OHTV_DB_PATH", str(db_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Initialise the DB once so the `db scan` step the user normally runs
+    # before ``fetch-loc`` is implicit here.
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    migrate(conn)
+    conn.close()
+    return db_path
+
+
+def _seed_pr_row(
+    db_path: Path,
+    canonical_url: str,
+    pr_number: int,
+) -> tuple[int, int]:
+    """Insert a repo + a pending PR change_ref. Return ``(repo_id, row_id)``."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    fqn = canonical_url.split("//", 1)[-1]
+    short = fqn.split("/")[-1]
+    repo_id = conn.execute(
+        "INSERT INTO repositories (canonical_url, fqn, short_name) "
+        "VALUES (?, ?, ?) RETURNING id",
+        (canonical_url, fqn, short),
+    ).fetchone()["id"]
+    row_id = conn.execute(
+        "INSERT INTO change_refs (repo_id, change_type, pr_number, status) "
+        "VALUES (?, 'pr', ?, 'pending') RETURNING id",
+        (repo_id, pr_number),
+    ).fetchone()["id"]
+    conn.commit()
+    conn.close()
+    return repo_id, row_id
+
+
+# ---------------------------------------------------------------------------
+# Discoverability / help
+# ---------------------------------------------------------------------------
+
+
+def test_help_is_discoverable(runner: CliRunner) -> None:
+    """AC #1: ``ohtv fetch-loc --help`` works and is listed in ``ohtv --help``."""
+    top = runner.invoke(ohtv_main, ["--help"])
+    assert top.exit_code == 0
+    assert "fetch-loc" in top.output
+
+    sub = runner.invoke(ohtv_main, ["fetch-loc", "--help"])
+    assert sub.exit_code == 0
+    assert "Backfill" in sub.output
+    assert "GITHUB_TOKEN" in sub.output
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_missing_github_token_exits_nonzero(
+    runner: CliRunner,
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #2: missing GITHUB_TOKEN → non-zero exit + helpful message."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    result = runner.invoke(ohtv_main, ["fetch-loc"])
+    assert result.exit_code != 0
+    assert "GITHUB_TOKEN" in result.output
+    assert "gh auth token" in result.output
+
+
+def test_token_value_never_logged(
+    runner: CliRunner,
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_supersecrettokenvalue123")
+    # No PR rows seeded → zero candidates → no HTTP. Just verify the
+    # token value doesn't leak into stdout/stderr.
+    result = runner.invoke(ohtv_main, ["fetch-loc", "--quiet"])
+    assert "ghp_supersecrettokenvalue123" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_writes_nothing_and_makes_zero_http(
+    runner: CliRunner,
+    isolated_db: Path,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #7: ``--dry-run`` does not call HTTP and does not write to the DB."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    _seed_pr_row(isolated_db, "https://github.com/owner/repo", 76)
+
+    # No GITHUB_TOKEN — dry-run still works.
+    result = runner.invoke(ohtv_main, ["fetch-loc", "--dry-run"])
+    assert result.exit_code == 0
+    assert "Dry-run" in result.output
+    assert "1 row" in result.output
+
+    assert httpx_mock.get_requests() == []
+
+    # Row state is unchanged.
+    conn = sqlite3.connect(isolated_db)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM change_refs").fetchone()
+    conn.close()
+    assert row["status"] == "pending"
+    assert row["fetched_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fetch
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_pr_fetch_populates_row(
+    runner: CliRunner,
+    isolated_db: Path,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #13: integration smoke. PR row ends up populated."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    _seed_pr_row(isolated_db, "https://github.com/owner/repo", 76)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/76",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    result = runner.invoke(ohtv_main, ["fetch-loc", "--quiet"])
+    assert result.exit_code == 0
+
+    conn = sqlite3.connect(isolated_db)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM change_refs").fetchone()
+    conn.close()
+    assert row["status"] == "merged"
+    assert row["lines_added"] == 100
+    assert row["lines_removed"] == 25
+    assert row["files_changed"] == 3
+    assert row["fetched_at"] is not None
+
+
+def test_progress_bar_present_by_default_suppressed_under_quiet(
+    runner: CliRunner,
+    isolated_db: Path,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #12: progress bar present by default; --quiet suppresses it.
+
+    We can't easily inspect the live Rich progress widget, but we can
+    assert that the post-run summary block is the only visible output
+    under --quiet (no `Fetching LOC ...` line), and that the default
+    run includes some progress affordance.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    _seed_pr_row(isolated_db, "https://github.com/owner/repo", 76)
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/76",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    # Quiet: no "fetch-loc complete" block, no "Fetching LOC".
+    result_quiet = runner.invoke(ohtv_main, ["fetch-loc", "-q"])
+    assert result_quiet.exit_code == 0
+    assert "Fetching LOC" not in result_quiet.output
+    assert "fetch-loc complete" not in result_quiet.output
+
+
+def test_repo_filter_restricts_to_one_repo(
+    runner: CliRunner,
+    isolated_db: Path,
+    httpx_mock: HTTPXMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #8: ``--repo`` filter resolves through repo store and restricts rows."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    _seed_pr_row(isolated_db, "https://github.com/owner/repo-a", 10)
+    _seed_pr_row(isolated_db, "https://github.com/owner/repo-b", 20)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo-a/pulls/10",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    result = runner.invoke(ohtv_main, ["fetch-loc", "--repo", "owner/repo-a", "-q"])
+    assert result.exit_code == 0
+    assert len(httpx_mock.get_requests()) == 1
+    assert "/repos/owner/repo-a/" in str(httpx_mock.get_requests()[0].url)
+
+    # repo-b row was untouched.
+    conn = sqlite3.connect(isolated_db)
+    conn.row_factory = sqlite3.Row
+    rows = list(conn.execute(
+        "SELECT cr.* FROM change_refs cr JOIN repositories r ON r.id=cr.repo_id "
+        "WHERE r.fqn = 'github.com/owner/repo-b'"
+    ))
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0]["fetched_at"] is None
+
+
+def test_unknown_repo_filter_exits_nonzero(
+    runner: CliRunner,
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    result = runner.invoke(
+        ohtv_main, ["fetch-loc", "--repo", "totally/unknown-repo"]
+    )
+    assert result.exit_code != 0
+    assert "did not match any known repository" in result.output
+
+
+def test_dry_run_works_without_token(
+    runner: CliRunner,
+    isolated_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dry-run should not require GITHUB_TOKEN — it never calls HTTP."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    _seed_pr_row(isolated_db, "https://github.com/owner/repo", 1)
+    result = runner.invoke(ohtv_main, ["fetch-loc", "--dry-run"])
+    assert result.exit_code == 0

--- a/tests/unit/test_fetch_loc.py
+++ b/tests/unit/test_fetch_loc.py
@@ -1,0 +1,626 @@
+"""Unit tests for ``ohtv.fetch_loc.fetch_loc`` (Issue #80).
+
+These tests use a real in-memory SQLite connection (migration 016 runs
+against it) plus a real :class:`ohtv.github_api.GitHubClient` wired up
+against ``pytest-httpx``. No mocks except at the HTTP boundary, per
+project policy.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from ohtv.db.migrations import migrate
+from ohtv.fetch_loc import (
+    fetch_loc,
+    is_github_url,
+    parse_github_owner_repo,
+    split_commit_range,
+)
+from ohtv.github_api import GITHUB_API_BASE, GitHubClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    """A fresh in-memory DB with all migrations applied."""
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA foreign_keys = ON")
+    migrate(c)
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def client() -> GitHubClient:
+    return GitHubClient("test-token", max_retries=3)
+
+
+def _add_repo(
+    conn: sqlite3.Connection,
+    canonical_url: str,
+    fqn: str | None = None,
+    short_name: str | None = None,
+) -> int:
+    """Insert a row in ``repositories`` and return its id."""
+    if fqn is None:
+        # Derive a reasonable FQN from the URL.
+        fqn = canonical_url.split("//", 1)[-1]
+    if short_name is None:
+        short_name = fqn.split("/")[-1]
+    cursor = conn.execute(
+        "INSERT INTO repositories (canonical_url, fqn, short_name) "
+        "VALUES (?, ?, ?) RETURNING id",
+        (canonical_url, fqn, short_name),
+    )
+    return cursor.fetchone()[0]
+
+
+def _add_pr_row(
+    conn: sqlite3.Connection,
+    repo_id: int,
+    pr_number: int,
+    *,
+    status: str = "pending",
+    fetched_at: str | None = None,
+    lines_added: int | None = None,
+) -> int:
+    cursor = conn.execute(
+        """
+        INSERT INTO change_refs (repo_id, change_type, pr_number, status,
+                                 fetched_at, lines_added)
+        VALUES (?, 'pr', ?, ?, ?, ?) RETURNING id
+        """,
+        (repo_id, pr_number, status, fetched_at, lines_added),
+    )
+    return cursor.fetchone()[0]
+
+
+def _add_push_row(
+    conn: sqlite3.Connection,
+    repo_id: int,
+    commit_range: str,
+    *,
+    status: str = "pending",
+    fetched_at: str | None = None,
+    lines_added: int | None = None,
+) -> int:
+    cursor = conn.execute(
+        """
+        INSERT INTO change_refs (repo_id, change_type, commit_range, status,
+                                 fetched_at, lines_added)
+        VALUES (?, 'direct_push', ?, ?, ?, ?) RETURNING id
+        """,
+        (repo_id, commit_range, status, fetched_at, lines_added),
+    )
+    return cursor.fetchone()[0]
+
+
+def _read_row(conn: sqlite3.Connection, row_id: int) -> dict:
+    cur = conn.execute("SELECT * FROM change_refs WHERE id = ?", (row_id,))
+    return dict(cur.fetchone())
+
+
+# Canned API responses ------------------------------------------------------
+
+PR_MERGED = {
+    "merged": True,
+    "state": "closed",
+    "merged_at": "2024-05-01T12:34:56Z",
+    "additions": 120,
+    "deletions": 30,
+    "changed_files": 4,
+}
+
+PR_OPEN = {
+    "merged": False,
+    "state": "open",
+    "merged_at": None,
+    "additions": 0,
+    "deletions": 0,
+    "changed_files": 0,
+}
+
+PR_CLOSED_UNMERGED = {
+    "merged": False,
+    "state": "closed",
+    "merged_at": None,
+    "additions": 0,
+    "deletions": 0,
+    "changed_files": 0,
+}
+
+COMPARE_RESPONSE = {
+    "files": [
+        {"filename": "a.py", "additions": 10, "deletions": 5},
+        {"filename": "b.py", "additions": 3, "deletions": 0},
+        {"filename": "c.md", "additions": 1, "deletions": 1},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_github_url_classifier() -> None:
+    assert is_github_url("https://github.com/owner/repo") is True
+    assert is_github_url("https://github.com/owner/repo.git") is True
+    assert is_github_url("https://www.github.com/owner/repo") is True
+    assert is_github_url("http://github.com/owner/repo") is True
+    assert is_github_url("https://gitlab.com/owner/repo") is False
+    assert is_github_url("https://bitbucket.org/owner/repo") is False
+    assert is_github_url("") is False
+    assert is_github_url(None) is False
+
+
+def test_parse_github_owner_repo() -> None:
+    assert parse_github_owner_repo("https://github.com/foo/bar") == ("foo", "bar")
+    assert parse_github_owner_repo("https://github.com/foo/bar.git") == ("foo", "bar")
+    assert parse_github_owner_repo("https://github.com/foo/bar/") == ("foo", "bar")
+    assert parse_github_owner_repo("https://github.com/foo/bar/issues/1") == (
+        "foo",
+        "bar",
+    )
+    assert parse_github_owner_repo("https://github.com/") is None
+
+
+def test_split_commit_range() -> None:
+    assert split_commit_range("abc..def") == ("abc", "def")
+    assert split_commit_range("abc123..def456") == ("abc123", "def456")
+    assert split_commit_range("abc") is None
+    assert split_commit_range("..def") is None
+    assert split_commit_range("abc..") is None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: PR path
+# ---------------------------------------------------------------------------
+
+
+def test_pr_merged_path_updates_loc_and_status(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_pr_row(conn, repo_id, 76)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/76",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    assert result.failed == 0
+    assert result.total_candidates == 1
+
+    row = _read_row(conn, row_id)
+    assert row["status"] == "merged"
+    assert row["lines_added"] == 120
+    assert row["lines_removed"] == 30
+    assert row["files_changed"] == 4
+    assert row["merged_at"] == "2024-05-01T12:34:56Z"
+    assert row["fetched_at"] is not None
+
+
+def test_pr_open_path_updates_status_only(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_pr_row(conn, repo_id, 77)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/77",
+        status_code=200,
+        json=PR_OPEN,
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    assert result.still_open == 1
+
+    row = _read_row(conn, row_id)
+    assert row["status"] == "open"
+    assert row["lines_added"] is None
+    assert row["lines_removed"] is None
+    assert row["files_changed"] is None
+    assert row["merged_at"] is None
+    assert row["fetched_at"] is not None
+
+
+def test_pr_closed_unmerged_updates_status_only(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_pr_row(conn, repo_id, 78)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/78",
+        status_code=200,
+        json=PR_CLOSED_UNMERGED,
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    assert result.closed_unmerged == 1
+
+    row = _read_row(conn, row_id)
+    assert row["status"] == "closed"
+    assert row["lines_added"] is None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: direct_push path
+# ---------------------------------------------------------------------------
+
+
+def test_direct_push_path_sums_file_stats(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_push_row(conn, repo_id, "abc..def")
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/compare/abc...def",
+        status_code=200,
+        json=COMPARE_RESPONSE,
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+
+    row = _read_row(conn, row_id)
+    assert row["status"] == "merged"
+    assert row["lines_added"] == 14  # 10 + 3 + 1
+    assert row["lines_removed"] == 6  # 5 + 0 + 1
+    assert row["files_changed"] == 3
+    assert row["fetched_at"] is not None
+
+
+def test_direct_push_empty_files_is_zero_loc(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_push_row(conn, repo_id, "abc..def")
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/compare/abc...def",
+        status_code=200,
+        json={"files": []},
+    )
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    row = _read_row(conn, row_id)
+    assert row["lines_added"] == 0
+    assert row["files_changed"] == 0
+
+
+def test_direct_push_malformed_commit_range_skipped(
+    conn: sqlite3.Connection, client: GitHubClient, httpx_mock: HTTPXMock
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    _add_push_row(conn, repo_id, "no-dots-here")
+
+    result = fetch_loc(conn, client=client)
+    assert result.skipped_unparseable == 1
+    assert httpx_mock.get_requests() == []
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + force + dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_second_run_makes_zero_requests(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    _add_pr_row(conn, repo_id, 76)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/76",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    # First run populates the row.
+    fetch_loc(conn, client=client)
+    assert len(httpx_mock.get_requests()) == 1
+
+    # Second run must make ZERO additional requests. The merged row is
+    # filtered out at the SQL level, so it never even reaches the
+    # Python orchestrator — ``total_candidates`` is 0 and HTTP is silent.
+    result2 = fetch_loc(conn, client=client)
+    assert len(httpx_mock.get_requests()) == 1  # still the original
+    assert result2.total_candidates == 0
+    assert result2.fetched == 0
+
+
+def test_force_refetches_populated_rows(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    # Pre-populated row — should be skipped without --force.
+    row_id = _add_pr_row(
+        conn, repo_id, 76, status="merged",
+        fetched_at="2024-01-01T00:00:00+00:00",
+        lines_added=10,
+    )
+
+    # Sanity: default run sees zero candidates.
+    result_default = fetch_loc(conn, client=client)
+    assert result_default.total_candidates == 0
+    assert httpx_mock.get_requests() == []
+
+    # --force gets one HTTP call.
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/76",
+        status_code=200,
+        json=PR_MERGED,
+    )
+    result_force = fetch_loc(conn, client=client, force=True)
+    assert result_force.fetched == 1
+    row = _read_row(conn, row_id)
+    assert row["lines_added"] == 120  # updated to new value
+
+
+def test_dry_run_makes_no_http_calls_and_no_db_writes(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_pr_row(conn, repo_id, 76)
+    before = _read_row(conn, row_id)
+
+    result = fetch_loc(conn, client=client, dry_run=True)
+    assert result.total_candidates == 1
+    assert result.fetched == 0
+    assert httpx_mock.get_requests() == []
+
+    after = _read_row(conn, row_id)
+    assert after == before
+
+
+# ---------------------------------------------------------------------------
+# Repo filter
+# ---------------------------------------------------------------------------
+
+
+def test_repo_filter_restricts_rows(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_a = _add_repo(conn, "https://github.com/owner/repo-a")
+    repo_b = _add_repo(conn, "https://github.com/owner/repo-b")
+    _add_pr_row(conn, repo_a, 10)
+    _add_pr_row(conn, repo_b, 20)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo-a/pulls/10",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    result = fetch_loc(conn, client=client, repo_id=repo_a)
+    assert result.total_candidates == 1
+    assert result.fetched == 1
+    assert len(httpx_mock.get_requests()) == 1
+    assert "/repos/owner/repo-a/" in str(httpx_mock.get_requests()[0].url)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_404_marks_fetched_and_continues(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_a = _add_pr_row(conn, repo_id, 1)
+    row_b = _add_pr_row(conn, repo_id, 2)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/2",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    assert result.failed == 1
+    assert result.exit_code == 0  # mixed success/failure -> exit 0
+
+    # Row a was marked tried; row b was populated.
+    row_a_after = _read_row(conn, row_a)
+    assert row_a_after["fetched_at"] is not None
+    assert row_a_after["lines_added"] is None  # 404 leaves LOC NULL
+
+    row_b_after = _read_row(conn, row_b)
+    assert row_b_after["lines_added"] == 120
+
+
+def test_500_marks_tried_and_continues(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_a = _add_pr_row(conn, repo_id, 1)
+    _add_pr_row(conn, repo_id, 2)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=500,
+        json={"message": "boom"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/2",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    assert result.failed == 1
+    assert result.exit_code == 0
+
+    row_a_after = _read_row(conn, row_a)
+    assert row_a_after["fetched_at"] is not None  # marked tried
+    assert row_a_after["lines_added"] is None
+
+
+def test_all_requests_fail_exits_nonzero(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    _add_pr_row(conn, repo_id, 1)
+    _add_pr_row(conn, repo_id, 2)
+
+    for n in (1, 2):
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/{n}",
+            status_code=404,
+            json={"message": "Not Found"},
+        )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 0
+    assert result.failed == 2
+    assert result.exit_code == 1
+
+
+def test_zero_candidates_exits_zero(
+    conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    result = fetch_loc(conn, client=client)
+    assert result.total_candidates == 0
+    assert result.exit_code == 0
+
+
+def test_401_marks_tried_and_continues(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    row_id = _add_pr_row(conn, repo_id, 1)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=401,
+        json={"message": "Bad credentials"},
+    )
+    result = fetch_loc(conn, client=client)
+    assert result.failed == 1
+    assert _read_row(conn, row_id)["fetched_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Non-GitHub + edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_non_github_repo_skipped_without_touching_row(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://gitlab.com/group/proj")
+    row_id = _add_pr_row(conn, repo_id, 1)
+    before = _read_row(conn, row_id)
+
+    result = fetch_loc(conn, client=client)
+    assert result.skipped_non_github == 1
+    assert result.fetched == 0
+    assert httpx_mock.get_requests() == []
+
+    after = _read_row(conn, row_id)
+    assert after == before  # no fetched_at, no status change
+
+
+def test_open_pr_re_fetches_after_one_hour(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    """An open PR fetched >1 h ago is re-fetched even without --force."""
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    two_hours_ago = (
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ).replace(microsecond=0).isoformat()
+    row_id = _add_pr_row(
+        conn, repo_id, 1, status="open", fetched_at=two_hours_ago
+    )
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=200,
+        json=PR_MERGED,  # has merged since
+    )
+
+    result = fetch_loc(conn, client=client)
+    assert result.fetched == 1
+    assert _read_row(conn, row_id)["status"] == "merged"
+
+
+def test_recent_open_pr_not_re_fetched(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    five_min_ago = (
+        datetime.now(timezone.utc) - timedelta(minutes=5)
+    ).replace(microsecond=0).isoformat()
+    _add_pr_row(conn, repo_id, 1, status="open", fetched_at=five_min_ago)
+
+    result = fetch_loc(conn, client=client)
+    assert result.skipped_cached == 1
+    assert httpx_mock.get_requests() == []
+
+
+# ---------------------------------------------------------------------------
+# Progress callback
+# ---------------------------------------------------------------------------
+
+
+def test_progress_callback_fires_for_each_row(
+    httpx_mock: HTTPXMock, conn: sqlite3.Connection, client: GitHubClient
+) -> None:
+    repo_id = _add_repo(conn, "https://github.com/owner/repo")
+    for n in (1, 2):
+        _add_pr_row(conn, repo_id, n)
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/{n}",
+            status_code=200,
+            json=PR_MERGED,
+        )
+
+    events: list[tuple[int, int, str]] = []
+    fetch_loc(conn, client=client, on_progress=lambda i, t, m: events.append((i, t, m)))
+
+    assert len(events) == 2
+    assert events[0][:2] == (1, 2)
+    assert events[1][:2] == (2, 2)
+    assert "owner/repo#1" in events[0][2]
+    assert "owner/repo#2" in events[1][2]

--- a/tests/unit/test_github_api.py
+++ b/tests/unit/test_github_api.py
@@ -1,0 +1,368 @@
+"""Unit tests for ``ohtv.github_api.GitHubClient`` (Issue #80).
+
+Uses ``pytest-httpx`` to mock all outbound HTTP. The client must:
+
+* Always send the auth + accept + API-version headers.
+* Translate 404 to ``None`` (graceful — the orchestrator records "tried").
+* Sleep + retry on 429 / rate-limited 403; honor ``Retry-After``.
+* Raise :class:`RateLimitExceededError` when retries are exhausted.
+* Log a WARNING when ``X-RateLimit-Remaining`` falls below 100.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from ohtv.github_api import (
+    GITHUB_API_BASE,
+    GitHubClient,
+    RateLimitExceededError,
+    _is_rate_limited,
+    _maybe_warn_low_rate_limit,
+)
+
+
+# A merged PR fixture. Trimmed down to the fields we read.
+PR_MERGED = {
+    "number": 76,
+    "state": "closed",
+    "merged": True,
+    "merged_at": "2024-05-01T12:34:56Z",
+    "additions": 120,
+    "deletions": 30,
+    "changed_files": 4,
+}
+
+PR_OPEN = {
+    "number": 77,
+    "state": "open",
+    "merged": False,
+    "merged_at": None,
+    "additions": 0,
+    "deletions": 0,
+    "changed_files": 0,
+}
+
+PR_CLOSED_UNMERGED = {
+    "number": 78,
+    "state": "closed",
+    "merged": False,
+    "merged_at": None,
+    "additions": 0,
+    "deletions": 0,
+    "changed_files": 0,
+}
+
+COMPARE_RESPONSE = {
+    "base_commit": {"sha": "abc1234"},
+    "merge_base_commit": {"sha": "abc1234"},
+    "files": [
+        {"filename": "a.py", "additions": 10, "deletions": 5},
+        {"filename": "b.py", "additions": 3, "deletions": 0},
+        {"filename": "c.md", "additions": 1, "deletions": 1},
+    ],
+}
+
+
+@pytest.fixture
+def client() -> GitHubClient:
+    return GitHubClient("test-token-do-not-log")
+
+
+def test_get_pr_parses_merged_response(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/76",
+        status_code=200,
+        json=PR_MERGED,
+    )
+    data = client.get_pr("owner", "repo", 76)
+    assert data is not None
+    assert data["merged"] is True
+    assert data["additions"] == 120
+    assert data["deletions"] == 30
+    assert data["changed_files"] == 4
+    assert data["merged_at"] == "2024-05-01T12:34:56Z"
+
+
+def test_get_pr_parses_open_response(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/77",
+        status_code=200,
+        json=PR_OPEN,
+    )
+    data = client.get_pr("owner", "repo", 77)
+    assert data is not None
+    assert data["merged"] is False
+    assert data["state"] == "open"
+
+
+def test_get_pr_parses_closed_unmerged(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/78",
+        status_code=200,
+        json=PR_CLOSED_UNMERGED,
+    )
+    data = client.get_pr("owner", "repo", 78)
+    assert data is not None
+    assert data["merged"] is False
+    assert data["state"] == "closed"
+
+
+def test_get_pr_handles_404(httpx_mock: HTTPXMock, client: GitHubClient) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/9999",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
+    # 404 → None (graceful), not an exception.
+    assert client.get_pr("owner", "repo", 9999) is None
+
+
+def test_get_compare_sums_file_stats_and_uses_triple_dot(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    """Compare URL must use three dots between SHAs, not two."""
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/compare/abc123...def456",
+        status_code=200,
+        json=COMPARE_RESPONSE,
+    )
+    data = client.get_compare("owner", "repo", "abc123", "def456")
+    assert data is not None
+    assert len(data["files"]) == 3
+    # Caller does the summing; client just returns the raw response.
+    total_add = sum(f["additions"] for f in data["files"])
+    total_del = sum(f["deletions"] for f in data["files"])
+    assert total_add == 14
+    assert total_del == 6
+
+
+def test_get_compare_handles_404(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/compare/xxx...yyy",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
+    assert client.get_compare("owner", "repo", "xxx", "yyy") is None
+
+
+def test_auth_and_versioning_headers_present(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    """All three GitHub-mandated headers must be on every outbound request.
+
+    This is also the test that proves we send a Bearer token *but* does
+    not log it: we read it from the request object, never from the
+    GitHubClient's internal state.
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=200,
+        json=PR_MERGED,
+    )
+    client.get_pr("owner", "repo", 1)
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+    headers = requests[0].headers
+    assert headers["authorization"] == "Bearer test-token-do-not-log"
+    assert headers["accept"] == "application/vnd.github+json"
+    assert headers["x-github-api-version"] == "2022-11-28"
+    assert headers["user-agent"].startswith("ohtv/")
+
+
+def test_rate_limit_retry_honors_retry_after(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch, client: GitHubClient
+) -> None:
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "ohtv.github_api.time.sleep",
+        lambda s: sleep_calls.append(s),
+    )
+
+    # First response: 429 with Retry-After 0.1.
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=429,
+        headers={"Retry-After": "0.1", "X-RateLimit-Remaining": "0"},
+        json={"message": "rate limited"},
+    )
+    # Second response: 200.
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    data = client.get_pr("owner", "repo", 1)
+    assert data is not None
+    assert data["additions"] == 120
+    assert len(httpx_mock.get_requests()) == 2
+    # Sleep was called once, with ≤ 0.1 s (the Retry-After hint).
+    assert len(sleep_calls) == 1
+    assert sleep_calls[0] <= 0.1 + 0.01  # tiny float tolerance
+
+
+def test_rate_limit_403_with_remaining_zero_is_retried(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GitHub returns 403 with X-RateLimit-Remaining=0 for primary limits."""
+    client = GitHubClient("t", max_retries=3)
+    monkeypatch.setattr("ohtv.github_api.time.sleep", lambda s: None)
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=403,
+        headers={"X-RateLimit-Remaining": "0", "Retry-After": "0"},
+        json={"message": "API rate limit exceeded"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=200,
+        json=PR_MERGED,
+    )
+
+    assert client.get_pr("owner", "repo", 1) is not None
+    assert len(httpx_mock.get_requests()) == 2
+    client.close()
+
+
+def test_rate_limit_exhausted_raises(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = GitHubClient("t", max_retries=2)
+    monkeypatch.setattr("ohtv.github_api.time.sleep", lambda s: None)
+
+    # Both attempts return 429.
+    for _ in range(2):
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+            status_code=429,
+            headers={"Retry-After": "0"},
+            json={"message": "rate limited"},
+        )
+
+    with pytest.raises(RateLimitExceededError):
+        client.get_pr("owner", "repo", 1)
+    assert len(httpx_mock.get_requests()) == 2
+    client.close()
+
+
+def test_low_rate_limit_logs_warning(
+    httpx_mock: HTTPXMock,
+    client: GitHubClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=200,
+        json=PR_MERGED,
+        headers={"X-RateLimit-Remaining": "50", "X-RateLimit-Reset": "9999999999"},
+    )
+    with caplog.at_level(logging.WARNING, logger="ohtv"):
+        client.get_pr("owner", "repo", 1)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("rate-limit low" in r.getMessage() for r in warnings)
+
+
+def test_high_rate_limit_no_warning(
+    httpx_mock: HTTPXMock,
+    client: GitHubClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=200,
+        json=PR_MERGED,
+        headers={"X-RateLimit-Remaining": "4500"},
+    )
+    with caplog.at_level(logging.WARNING, logger="ohtv"):
+        client.get_pr("owner", "repo", 1)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("rate-limit low" in r.getMessage() for r in warnings)
+
+
+def test_non_404_non_rate_limit_5xx_raises(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=500,
+        json={"message": "server error"},
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        client.get_pr("owner", "repo", 1)
+
+
+def test_real_403_without_rate_limit_signal_is_not_retried(
+    httpx_mock: HTTPXMock, client: GitHubClient
+) -> None:
+    """Auth-failure 403 must propagate, not loop forever."""
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{GITHUB_API_BASE}/repos/owner/repo/pulls/1",
+        status_code=403,
+        json={"message": "Forbidden"},
+        headers={"X-RateLimit-Remaining": "4500"},
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        client.get_pr("owner", "repo", 1)
+
+
+# ---------------------------------------------------------------------------
+# Helper-function tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_rate_limited_classifier() -> None:
+    def _make(status: int, headers: dict[str, str] | None = None) -> httpx.Response:
+        return httpx.Response(status, headers=headers or {})
+
+    assert _is_rate_limited(_make(429)) is True
+    assert _is_rate_limited(_make(403, {"X-RateLimit-Remaining": "0"})) is True
+    assert _is_rate_limited(_make(403, {"Retry-After": "5"})) is True
+    assert _is_rate_limited(_make(403, {"X-RateLimit-Remaining": "1000"})) is False
+    assert _is_rate_limited(_make(200)) is False
+    assert _is_rate_limited(_make(500)) is False
+
+
+def test_maybe_warn_low_rate_limit_ignores_missing_header(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="ohtv"):
+        _maybe_warn_low_rate_limit({})
+    assert not any("rate-limit low" in r.getMessage() for r in caplog.records)
+
+
+def test_maybe_warn_low_rate_limit_invalid_header_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="ohtv"):
+        _maybe_warn_low_rate_limit({"X-RateLimit-Remaining": "not-a-number"})
+    assert not any("rate-limit low" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Closes #80.

Adds `ohtv fetch-loc`: reads pending `change_refs` rows produced by the contributions stages (#78 / #79) and calls the GitHub REST API to populate `lines_added`, `lines_removed`, `files_changed`, `merged_at`, and `status`. This is the network-bound, cached, idempotent backfill that unblocks the velocity report (#81) and the human-words-per-LOC ratios in `docs/DESIGN_CONVERSATION_METRICS.md`.

## What's in the box

### New modules
- **`src/ohtv/github_api.py`** — thin `httpx.Client` wrapper exposing `get_pr(owner, repo, n)` and `get_compare(owner, repo, base, head)`. Shared rate-limit handling honors `Retry-After`, falls back to `X-RateLimit-Reset`, then exponential backoff + jitter capped at 60 s. Warns when `X-RateLimit-Remaining < 100`. 404 maps to `None` so the orchestrator can record a "tried" attempt. `RateLimitExceededError` is raised when retries are exhausted. Auth tokens never appear in logs.
- **`src/ohtv/fetch_loc.py`** — pure-Python orchestrator. Selects candidate rows via SQL cache predicate, applies the open-PR refetch-after-1-hour heuristic in Python (so `status='open'` rows aren't filtered out of the candidate set), dispatches to the right endpoint per `change_type`, writes back inside the same connection (commit per row so SIGINT doesn't lose work). Per-row HTTP errors (401 / 404 / 5xx) mark the row as "tried" (`fetched_at = now()`) and continue; exits non-zero only when every attempt failed.

### CLI
- `@main.command("fetch-loc")` wired in `src/ohtv/cli.py` with options `--repo / --force / --dry-run / --limit / --quiet / -v`. `--repo` is resolved through the same FQN matcher as `list` / `refs`.
- Progress bar uses `make_progress(...)` from `src/ohtv/progress.py` (no direct `rich.progress` import — `test_progress_lint.py` still passes).
- Token read from `GITHUB_TOKEN`; if missing on a non-dry-run, exits non-zero with a pointer to `gh auth token`. Token value is never logged or printed.

### Schema (one tiny migration — please review)
Migration **017** widens the `change_refs.status` CHECK constraint to include `'open'`. PR #76 / migration 016 created the table with `status IN ('pending', 'fetched', 'merged', 'closed')`, but issue #80's own AC #11 ("the row's `status` is updated to `open` or `closed`") and its cache predicate (`status IN ('merged','open','closed')`) both require `'open'` as a valid value. Without it, AC #11 fails and AC #5 (idempotency) breaks for open PRs (they'd be re-fetched every run).

The migration uses the canonical SQLite create-new / copy / drop-old / rename pattern so that:
- Foreign-key references in `conversation_contributions.change_ref_id` are not disturbed (a plain `ALTER TABLE … RENAME` would rewrite them to point at our scratch table — even with `legacy_alter_table=ON` — and break cascade deletes).
- Row IDs are preserved verbatim so any existing contribution links continue to resolve.
- No new columns, no new indexes, no behavioural change for stored rows. Only the value enum changes.

This is the minimum-impact schema change needed to honor the issue's acceptance criteria. Happy to drop it and re-spec the cache predicate differently if reviewers prefer.

## Tests

48 new tests across three files. All HTTP is mocked via `pytest-httpx` (the boundary — no production code is mocked). DB is a real in-memory SQLite with full migration replay; the only injected stub anywhere is the `GitHubClient` in CLI tests, and even that is via a `client_factory` dependency-injection seam (not monkey-patching).

| File | Coverage focus |
| --- | --- |
| `tests/unit/test_github_api.py` | Auth + version headers on every request; 404 → `None`; `Retry-After` honoured; 429 retry then success; 403 + `X-RateLimit-Remaining: 0` retried; real 403 (auth fail) propagates; low-rate-limit `WARNING` log; rate-limit exhaustion raises. |
| `tests/unit/test_fetch_loc.py` | PR merged path populates LOC + merged_at; PR open / closed-unmerged updates status only; direct-push sums `files[].additions/deletions`; idempotent 2nd run = 0 HTTP calls; `--force` re-fetches; `--dry-run` writes nothing; `--repo` filter; 404 / 401 / 500 graceful (loop continues, `fetched_at` set); all-fail run exits 1; non-GitHub repo skipped without touching row; open-PR re-fetches after 1 h, not before; progress callback fires per row. |
| `tests/unit/test_cli_fetch_loc.py` | `--help` discoverability (top-level + subcommand); missing `GITHUB_TOKEN` exits non-zero with helpful pointer; token value never appears in stdout; `--dry-run` works without a token; end-to-end PR populate via real Click runner; `-q` suppresses the progress bar + summary; `--repo` restricts to one repo; unknown `--repo` exits 2. |

Coverage on the new modules (combined 85%):

```
src/ohtv/fetch_loc.py      208     30    86%
src/ohtv/github_api.py      97     17    82%
```

Both individual modules clear AC #13's ≥80% bar.

Full suite: **1577 / 1577 pass** (1529 baseline + 48 new). `test_progress_lint.py` continues to pass.

## Acceptance-criteria coverage map

| AC | Verified by |
| --- | --- |
| 1. Command exists, listed in `ohtv --help` | `test_cli_fetch_loc.py::test_help_is_discoverable` |
| 2. Reads `GITHUB_TOKEN`, friendly error if missing, never logs token | `test_missing_github_token_exits_nonzero`, `test_token_value_never_logged` |
| 3. PR path → LOC + merged_at + status='merged' | `test_pr_merged_path_updates_loc_and_status` + integration smoke |
| 4. Direct-push path → summed LOC | `test_direct_push_path_sums_file_stats` |
| 5. Idempotent (0 HTTP on 2nd run) | `test_idempotent_second_run_makes_zero_requests` |
| 6. `--force` re-fetches | `test_force_refetches_populated_rows` |
| 7. `--dry-run` → 0 HTTP, 0 DB writes | `test_dry_run_makes_no_http_calls_and_no_db_writes` + CLI smoke |
| 8. `--repo` filter | `test_repo_filter_restricts_rows` + `test_repo_filter_restricts_to_one_repo` |
| 9. Rate-limit aware (`Retry-After` / `X-RateLimit-Remaining`) | `test_rate_limit_retry_honors_retry_after`, `test_low_rate_limit_logs_warning`, `test_rate_limit_403_with_remaining_zero_is_retried` |
| 10. Graceful 404/401/5xx (continues, exit 0) | `test_404_marks_fetched_and_continues`, `test_500_marks_tried_and_continues`, `test_401_marks_tried_and_continues`, `test_all_requests_fail_exits_nonzero` |
| 11. PR open/closed updates status without LOC | `test_pr_open_path_updates_status_only`, `test_pr_closed_unmerged_updates_status_only` |
| 12. Progress bar by default, suppressed under `-q` | `test_progress_bar_present_by_default_suppressed_under_quiet` |
| 13. `pytest-httpx` boundary + in-memory SQLite + ≥80% coverage | This whole test suite |

## Out of scope (follow-ups)

- Concurrency / parallel workers — single-threaded HTTP is fine for v1 (PRs per week scale, not per minute).
- GitLab / Bitbucket support — only GitHub. Non-GitHub repos are skipped with a clear log line.
- Reports / CSV export — that's #81.
- Re-classifying PRs as `direct_push` when the PR record is deleted — we leave the row as `change_type='pr'` and set `status='closed'`.

## Evidence

Manual blackbox test results: [comment #4548205904](https://github.com/jpshackelford/ohtv/pull/97#issuecomment-4548205904) — 18 scenarios, real seed data against `jpshackelford/ohtv` PRs #95/#96/#97, with HTTP isolation (blackhole proxy) for the "should make zero HTTP" cases.

Representative excerpt — missing-token exit path (AC #2):

```bash
$ unset GITHUB_TOKEN; uv run ohtv fetch-loc
Error: GITHUB_TOKEN is required to call the GitHub API.
  - If you have the GitHub CLI: export GITHUB_TOKEN=$(gh auth token)
  - Or create a fine-grained token at https://github.com/settings/tokens?type=beta and export GITHUB_TOKEN=...
EXIT: 1
```

And `--help` discoverability (AC #1):

```bash
$ uv run ohtv --help | grep fetch-loc
  fetch-loc     Backfill lines-added / lines-removed for ``change_refs``...
```

Full results in the linked comment. Rating: ✅ Pass. Full unit suite: 1577/1577.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6a10472a-ce38-47ca-9e81-6f9623fedcfe)
