### PR TITLE
feat: add report velocity command (#81)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,14 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - **Direct DB write**: `ConversationStore.update_metadata(conv_id, *, title, labels)` writes only the `title` and `labels` columns; uses a sentinel to distinguish "leave unchanged" from "clear" and normalizes empty-dict labels to NULL (matching `parse_conversation_info`).
     - **#87 / #89 follow-ups**: This is the foundational metadata-refresh path. Issue #87 extends the manifest to cache `selected_repository`/`selected_branch`/`created_at` and widens `ConversationStore.update_metadata`. Issue #89's `gen titles` command will PATCH back to the cloud API and then reuse this same write path.
 
+28. **Reports module (`ohtv.reports`, Issue #81)**: The `report` Click group hosts read-only aggregate reports built on top of `~/.ohtv/index.db`. Each report is split into a pure-Python module (no Click imports) plus a thin CLI wrapper in `cli.py`, so downstream consumers (e.g. issue #82 charting) can import the row-shaping function directly.
+    - **First report**: `report velocity` joins `change_refs` × `conversation_contributions` × `conversation_human_input` and buckets by ISO week.
+    - **ISO week rule**: SQLite's `strftime('%W', ...)` is GNU/POSIX, not ISO 8601. The SQL fetches per-`change_ref` rows; Python computes the bucket key with `datetime.isocalendar()` and formats `f"{year}-W{week:02d}"`. Regression-tested via `test_iso_week_boundary_2024_12_30` (2024-12-30 → `2025-W01`, not `2024-W53`).
+    - **DISTINCT (change_ref, conv) sub-select**: One conversation contributing as `created` + `pushed` + `merged` to the same PR would otherwise triple-count its human words. The query collapses `conversation_contributions` to DISTINCT `(change_ref_id, conversation_id)` pairs before joining `conversation_human_input`.
+    - **`initial_prompt_source` policy**: `human` and `unknown` both include the initial prompt + followups; `automation` excludes the initial prompt (and the implicit `+1` initial message). `unknown` is the optimistic default until issue #83 lands proper classification.
+    - **LOC NULL handling**: All-NULL bucket → `-` (table) / empty (CSV). Mixed → sum knowns + `partial_loc=True` (surfaced by `--verbose`). Words/LOC denominator zero → `-` / empty.
+    - **Reusable surface**: `ohtv.reports.velocity.aggregate_velocity(conn=..., since=..., until=..., repo=..., include_empty=...)` returns a `VelocityReport(rows, totals, metadata)` and is the entry point that issue #82 should consume.
+
 ## Troubleshooting
 
 ### Terminal shows `^M^M^M` when typing input

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ ohtv db embed
 # Backfill PR/push LOC from GitHub (requires GITHUB_TOKEN)
 GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc
 
+# Weekly velocity report (merged PRs x LOC x human input, grouped by ISO week)
+ohtv report velocity
+ohtv report velocity --format csv > velocity.csv
+
 # Search conversations semantically
 ohtv search "fix authentication bugs"
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10075,5 +10075,204 @@ def _display_aggregate_results_table(
     console.print(table)
 
 
+# =============================================================================
+# Reports — weekly aggregates for research analysis (Issue #81+)
+# =============================================================================
+
+
+@main.group()
+def report() -> None:
+    """Generate periodic reports (velocity, etc.).
+
+    These commands read from the existing ``~/.ohtv/index.db`` index
+    and emit human-friendly tables or CSV. They do not invoke the LLM
+    and do not consume tokens.
+    """
+
+
+@report.command("velocity")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["table", "csv"]),
+    default="table",
+    help="Output format (default: table)",
+)
+@click.option(
+    "--since",
+    "since_str",
+    help="Lower bound on merged_at; YYYY-MM-DD or relative (7d, 2w, 1m)",
+)
+@click.option(
+    "--until",
+    "until_str",
+    help="Upper bound on merged_at; YYYY-MM-DD",
+)
+@click.option(
+    "--repo",
+    "repo_filter",
+    help="Restrict to one repo (URL, owner/repo, or short name)",
+)
+@click.option(
+    "--include-empty",
+    is_flag=True,
+    help="Emit weeks with zero merged PRs (default: omit)",
+)
+@click.option(
+    "--no-totals",
+    is_flag=True,
+    help="Suppress the totals row (table format only; CSV never has one)",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Show the rendered SQL and per-week row counts")
+def report_velocity(
+    fmt: str,
+    since_str: str | None,
+    until_str: str | None,
+    repo_filter: str | None,
+    include_empty: bool,
+    no_totals: bool,
+    verbose: bool,
+) -> None:
+    """Show merged PRs / direct-pushes aggregated by ISO week.
+
+    Joins ``change_refs`` × ``conversation_contributions`` ×
+    ``conversation_human_input`` (see migration 016/017). The ISO week
+    label ``YYYY-Www`` is computed in Python (SQLite's ``%W`` is not
+    ISO-compliant). LOC cells render ``-`` (table) or empty (CSV)
+    when ``lines_added`` is NULL for every row in the bucket.
+
+    Caveat: rows with ``initial_prompt_source = 'unknown'`` (currently
+    100% of rows until issue #83 lands) are treated as if they were
+    ``'human'``.
+
+    \b
+    Examples:
+      ohtv report velocity
+      ohtv report velocity --format csv > velocity.csv
+      ohtv report velocity --since 2024-01-01 --repo jpshackelford/ohtv
+      ohtv report velocity --since 12w --include-empty
+    """
+    from ohtv.db import ensure_db_ready, get_connection, get_db_path
+    from ohtv.filters import parse_date_filter
+    from ohtv.reports.velocity import (
+        aggregate_velocity,
+        format_csv,
+        format_table,
+    )
+
+    _init_logging(verbose=verbose)
+
+    since_dt = None
+    if since_str:
+        since_dt = parse_date_filter(since_str)
+        if since_dt is None:
+            console.print(
+                f"[red]Error:[/red] could not parse --since {since_str!r}. "
+                "Use YYYY-MM-DD or relative (e.g., 7d, 2w, 1m)."
+            )
+            raise SystemExit(2)
+
+    until_dt = None
+    if until_str:
+        until_dt = parse_date_filter(until_str)
+        if until_dt is None:
+            console.print(
+                f"[red]Error:[/red] could not parse --until {until_str!r}. "
+                "Use YYYY-MM-DD or relative (e.g., 7d, 2w, 1m)."
+            )
+            raise SystemExit(2)
+
+    # Open the DB and confirm there is something to aggregate before
+    # we run the join (lets us print the friendly empty-state hint).
+    db_path = get_db_path()
+    if not db_path.exists():
+        if fmt == "csv":
+            import sys
+
+            format_csv([], sys.stdout)
+        else:
+            console.print(
+                "[dim]No index database found. Run "
+                "`ohtv db scan && ohtv db process all` first.[/dim]"
+            )
+        return
+
+    with get_connection(db_path) as conn:
+        ensure_db_ready(conn, show_progress=False)
+
+        # If there are no change_refs at all, point the user at the
+        # producer commands and exit 0 (graceful missing-deps state).
+        any_change_refs = conn.execute(
+            "SELECT 1 FROM change_refs LIMIT 1"
+        ).fetchone()
+        if any_change_refs is None:
+            if fmt == "csv":
+                import sys
+
+                format_csv([], sys.stdout)
+            else:
+                console.print(
+                    "[yellow]No change_refs rows found.[/yellow]\n"
+                    "  - Run [cyan]ohtv db process all[/cyan] to populate "
+                    "PR / push contribution records (issues #78 / #79).\n"
+                    "  - Run [cyan]ohtv fetch-loc[/cyan] to backfill "
+                    "lines-added / lines-removed from GitHub (issue #80)."
+                )
+            return
+
+        try:
+            report_data = aggregate_velocity(
+                conn=conn,
+                since=since_dt,
+                until=until_dt,
+                repo=repo_filter,
+                include_empty=include_empty,
+            )
+        except LookupError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise SystemExit(2) from None
+
+    if verbose:
+        console.print("[dim]-- SQL --[/dim]")
+        console.print(report_data.metadata["sql"].strip())
+        console.print(f"[dim]params: {report_data.metadata['params']}[/dim]")
+        console.print(
+            f"[dim]raw rows fetched: {report_data.metadata['raw_row_count']}, "
+            f"buckets: {report_data.metadata['bucket_count']}, "
+            f"buckets-with-partial-LOC: "
+            f"{sum(1 for r in report_data.rows if r.partial_loc)}, "
+            f"PRs missing LOC: {report_data.metadata['missing_loc_total']}[/dim]"
+        )
+        for row in report_data.rows:
+            flag = " [partial LOC]" if row.partial_loc else ""
+            console.print(
+                f"[dim]  {row.week}: {row.prs_merged} PRs"
+                f"{flag} (missing_loc={row.missing_loc_count})[/dim]"
+            )
+
+    # No matching merged PRs at all → friendly empty state.
+    productive = [r for r in report_data.rows if r.prs_merged > 0]
+    if not productive and not include_empty:
+        if fmt == "csv":
+            import sys
+
+            format_csv([], sys.stdout)
+        else:
+            console.print("[dim]No merged PRs in range.[/dim]")
+        return
+
+    if fmt == "csv":
+        import sys
+
+        format_csv(report_data.rows, sys.stdout)
+    else:
+        format_table(
+            report_data.rows,
+            report_data.totals,
+            console,
+            show_totals=not no_totals,
+        )
+
+
 if __name__ == "__main__":
     main()

--- a/src/ohtv/reports/__init__.py
+++ b/src/ohtv/reports/__init__.py
@@ -1,0 +1,12 @@
+"""Periodic reports built on top of the ohtv database index.
+
+Each report is a pure-Python module that fetches data from
+``~/.ohtv/index.db`` (the existing index DB used by every other
+command) and shapes it into reusable rows. The Click CLI wrappers
+live in ``ohtv.cli`` and call into these modules for both
+human-facing (Rich table) and machine-readable (CSV) output.
+
+The row-shaping entry points (e.g. ``velocity.aggregate_velocity``)
+are intentionally importable from non-CLI code so downstream
+features such as charting (issue #82) can reuse them.
+"""

--- a/src/ohtv/reports/velocity.py
+++ b/src/ohtv/reports/velocity.py
@@ -1,0 +1,682 @@
+"""Weekly velocity report: merged PRs/pushes × LOC × human input.
+
+Aggregates rows from the contributions schema (migration 016 +
+migration 017's wider status enum) into ISO-week buckets. Pure data
+layer — no Click imports, no Rich imports beyond the optional
+``format_table`` helper, no filesystem state. The bucketing entry
+point :func:`aggregate_velocity` is the importable surface that
+charting (issue #82) reuses.
+
+Design notes:
+
+* The week label is always ISO 8601 (``YYYY-Www``). SQLite's
+  ``strftime('%W', ...)`` is the GNU/POSIX week number, not ISO —
+  e.g., 2024-12-30 is ``2024-W53`` under ``%W`` but ``2025-W01``
+  under ISO. We always compute the label in Python via
+  :meth:`datetime.date.isocalendar`.
+
+* ``conversation_contributions`` can have multiple rows for the same
+  ``(change_ref_id, conversation_id)`` pair (one per ``contribution_type``:
+  created / pushed / merged). To avoid triple-counting one
+  conversation's words against a single PR we collapse the join to
+  DISTINCT ``(change_ref_id, conversation_id)`` pairs in a sub-select
+  before joining ``conversation_human_input``.
+
+* ``initial_prompt_source`` policy:
+
+  - ``'human'``     → words = ``initial_prompt_words + followup_word_count``,
+                     msgs  = ``1 + followup_message_count``
+  - ``'automation'``→ words = ``followup_word_count``,
+                     msgs  = ``followup_message_count``
+  - ``'unknown'``   → treated as ``'human'`` (optimistic default;
+                     see issue #83 for proper classification)
+
+* LOC NULL handling per bucket:
+
+  - All rows NULL → ``+Lines / -Lines / Total`` are *None* (callers
+    render this as ``-`` / empty).
+  - Some rows NULL, some populated → sum what is known and set
+    ``partial_loc=True`` so ``--verbose`` can flag the bucket.
+  - All rows populated → straight sum, ``partial_loc=False``.
+
+* ``Words/LOC`` ratio is ``None`` whenever ``total_loc`` is ``0`` /
+  ``None``. The totals row recomputes the ratio from
+  ``sum(words) / sum(total_loc)`` rather than averaging per-week
+  ratios (per the issue acceptance criteria).
+"""
+
+from __future__ import annotations
+
+import csv
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import IO, Iterable, Sequence
+
+from ohtv.analysis.periods import iterate_periods
+
+
+# Pure SQL query — Python performs ISO-week bucketing afterwards.
+# The DISTINCT sub-select collapses (created / pushed / merged) rows
+# for the same conversation against the same change_ref to one row,
+# which is the natural de-dup boundary the issue calls out.
+_VELOCITY_SQL = """
+SELECT
+    cr.id           AS change_ref_id,
+    cr.merged_at    AS merged_at,
+    cr.lines_added  AS lines_added,
+    cr.lines_removed AS lines_removed,
+    cr.repo_id      AS repo_id,
+    r.fqn           AS repo_fqn,
+    COALESCE(SUM(
+        CASE chi.initial_prompt_source
+            WHEN 'human'      THEN chi.initial_prompt_words + chi.followup_word_count
+            WHEN 'automation' THEN chi.followup_word_count
+            WHEN 'unknown'    THEN chi.initial_prompt_words + chi.followup_word_count
+            ELSE 0
+        END
+    ), 0) AS human_words,
+    COALESCE(SUM(
+        CASE chi.initial_prompt_source
+            WHEN 'human'      THEN 1 + chi.followup_message_count
+            WHEN 'automation' THEN chi.followup_message_count
+            WHEN 'unknown'    THEN 1 + chi.followup_message_count
+            ELSE 0
+        END
+    ), 0) AS human_messages
+FROM change_refs cr
+JOIN repositories r ON r.id = cr.repo_id
+LEFT JOIN (
+    SELECT DISTINCT change_ref_id, conversation_id
+    FROM conversation_contributions
+) dcc ON dcc.change_ref_id = cr.id
+LEFT JOIN conversation_human_input chi
+       ON chi.conversation_id = dcc.conversation_id
+WHERE cr.status = 'merged'
+  AND cr.change_type IN ('pr', 'direct_push')
+  AND (:repo_id IS NULL OR cr.repo_id = :repo_id)
+  AND (:since   IS NULL OR cr.merged_at >= :since)
+  AND (:until   IS NULL OR cr.merged_at <  :until)
+GROUP BY cr.id
+ORDER BY cr.merged_at
+"""
+
+
+@dataclass
+class VelocityRow:
+    """One aggregated bucket of merged changes (or the totals row).
+
+    For per-week rows, ``week`` is the ISO label ``YYYY-Www``. For the
+    totals row, ``week`` is ``"Total"``.
+
+    Numeric fields use ``None`` to mean "unknown / undefined" (cell
+    renders as ``-`` / empty). ``0`` is a real value (e.g., a real
+    week with zero merged PRs under ``--include-empty``).
+    """
+
+    week: str
+    prs_merged: int
+    lines_added: int | None
+    lines_removed: int | None
+    total_loc: int | None
+    human_words: int
+    human_messages: int
+    words_per_loc: float | None
+    partial_loc: bool = False
+    # Number of merged change_refs in the bucket with NULL lines_added.
+    # Useful for --verbose footnotes; defaults to 0.
+    missing_loc_count: int = 0
+
+
+@dataclass
+class VelocityReport:
+    """Container returned by :func:`aggregate_velocity`.
+
+    Bundles per-week rows, the optional totals row, and a metadata
+    bag that the ``--verbose`` CLI path consumes (raw SQL, per-week
+    raw counts, total raw PR count, etc.).
+    """
+
+    rows: list[VelocityRow]
+    totals: VelocityRow | None
+    metadata: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Data fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_raw_rows(
+    conn: sqlite3.Connection,
+    *,
+    repo_id: int | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> list[sqlite3.Row]:
+    """Fetch one row per merged ``change_ref`` joined to human-input.
+
+    Args:
+        conn: SQLite connection (must have row_factory = sqlite3.Row
+            for dict-style access).
+        repo_id: Optional ``repositories.id`` to restrict to a single
+            repo. ``None`` includes all repos.
+        since: Optional ISO-format lower bound on ``merged_at``
+            (inclusive). Strings compare lexicographically when both
+            sides are ISO 8601 with consistent timezone offsets.
+        until: Optional ISO-format upper bound on ``merged_at``
+            (exclusive — see issue spec).
+
+    Returns:
+        List of ``sqlite3.Row`` rows in ``merged_at`` ascending order.
+    """
+    # Bind on raw=None when the caller is dict-style only.
+    if conn.row_factory is None:
+        conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        _VELOCITY_SQL,
+        {"repo_id": repo_id, "since": since, "until": until},
+    )
+    return list(cursor.fetchall())
+
+
+# ---------------------------------------------------------------------------
+# Bucketing
+# ---------------------------------------------------------------------------
+
+
+def _parse_merged_at(value: str | None) -> datetime | None:
+    """Parse a ``merged_at`` ISO timestamp into a tz-aware UTC datetime.
+
+    GitHub timestamps look like ``2024-05-01T12:34:56Z``. We accept
+    that and also the ``+00:00`` form. Naive timestamps (no tz info)
+    are assumed UTC because every producer in this codebase normalises
+    to UTC before persistence.
+    """
+    if value is None:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    # Python 3.11+ handles "Z" via fromisoformat. Older 3.10 doesn't,
+    # but we can't tell which is in use — be defensive.
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        # Fall back: split off tz if odd format.
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _iso_week_label(dt: datetime) -> str:
+    """Return ISO-8601 week label ``YYYY-Www`` (zero-padded)."""
+    iso = dt.isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def _ratio_or_none(numerator: int | float | None, denominator: int | float | None) -> float | None:
+    """Return ``numerator / denominator`` rounded to 2 decimals, or ``None``."""
+    if numerator is None or denominator is None:
+        return None
+    if denominator == 0:
+        return None
+    return round(numerator / denominator, 2)
+
+
+def bucket_by_iso_week(
+    raw_rows: Iterable[sqlite3.Row],
+    *,
+    include_empty: bool = False,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> list[VelocityRow]:
+    """Fold per-change_ref rows into ISO-week buckets.
+
+    Args:
+        raw_rows: Iterable of rows produced by :func:`fetch_raw_rows`.
+        include_empty: When True, emit zero-rows for weeks in the
+            iteration range that have no merged changes.
+        since: Iteration lower bound (UTC datetime). Only used when
+            ``include_empty`` is True. Defaults to the week of the
+            earliest row.
+        until: Iteration upper bound (UTC datetime, exclusive). Only
+            used when ``include_empty`` is True. Defaults to the week
+            of the latest row (or "today" if no rows).
+
+    Returns:
+        List of :class:`VelocityRow` in ascending week order.
+    """
+    buckets: dict[str, dict] = {}
+    earliest: datetime | None = None
+    latest: datetime | None = None
+
+    for row in raw_rows:
+        merged_at = _parse_merged_at(row["merged_at"])
+        if merged_at is None:
+            # A merged change_ref should always have merged_at populated,
+            # but skip defensively rather than crashing on bad data.
+            continue
+        if earliest is None or merged_at < earliest:
+            earliest = merged_at
+        if latest is None or merged_at > latest:
+            latest = merged_at
+        label = _iso_week_label(merged_at)
+        bucket = buckets.setdefault(
+            label,
+            {
+                "prs_merged": 0,
+                "lines_added_sum": 0,
+                "lines_removed_sum": 0,
+                "any_loc": False,
+                "missing_loc": 0,
+                "human_words": 0,
+                "human_messages": 0,
+            },
+        )
+        bucket["prs_merged"] += 1
+        if row["lines_added"] is None:
+            bucket["missing_loc"] += 1
+        else:
+            bucket["any_loc"] = True
+            bucket["lines_added_sum"] += int(row["lines_added"])
+            bucket["lines_removed_sum"] += int(row["lines_removed"] or 0)
+        bucket["human_words"] += int(row["human_words"] or 0)
+        bucket["human_messages"] += int(row["human_messages"] or 0)
+
+    if include_empty:
+        # Determine iteration range. Honour explicit bounds first;
+        # otherwise span the actual data.
+        if since is not None:
+            range_start = since.astimezone(timezone.utc).date()
+        elif earliest is not None:
+            range_start = earliest.astimezone(timezone.utc).date()
+        else:
+            range_start = date.today()
+        if until is not None:
+            # `until` is the exclusive upper bound; back off one day
+            # so the final week of the range is included in iteration.
+            end_dt = until.astimezone(timezone.utc) - timedelta(days=1)
+            range_end = end_dt.date()
+        elif latest is not None:
+            range_end = latest.astimezone(timezone.utc).date()
+        else:
+            range_end = date.today()
+        if range_end < range_start:
+            range_end = range_start
+        for period in iterate_periods(range_start, range_end, "week"):
+            label = period.iso
+            if label not in buckets:
+                buckets[label] = {
+                    "prs_merged": 0,
+                    "lines_added_sum": 0,
+                    "lines_removed_sum": 0,
+                    "any_loc": False,
+                    "missing_loc": 0,
+                    "human_words": 0,
+                    "human_messages": 0,
+                }
+
+    out: list[VelocityRow] = []
+    for label in sorted(buckets):
+        b = buckets[label]
+        prs = b["prs_merged"]
+        if prs == 0:
+            # An include-empty filler week — keep LOC unknown rather
+            # than reporting 0, to avoid implying we know the answer.
+            lines_added: int | None = None
+            lines_removed: int | None = None
+            total_loc: int | None = None
+            partial = False
+        elif not b["any_loc"]:
+            # Every row in the bucket had NULL lines_added.
+            lines_added = None
+            lines_removed = None
+            total_loc = None
+            partial = False
+        else:
+            lines_added = b["lines_added_sum"]
+            lines_removed = b["lines_removed_sum"]
+            total_loc = lines_added + lines_removed
+            partial = b["missing_loc"] > 0
+        out.append(
+            VelocityRow(
+                week=label,
+                prs_merged=prs,
+                lines_added=lines_added,
+                lines_removed=lines_removed,
+                total_loc=total_loc,
+                human_words=b["human_words"],
+                human_messages=b["human_messages"],
+                words_per_loc=_ratio_or_none(b["human_words"], total_loc),
+                partial_loc=partial,
+                missing_loc_count=b["missing_loc"],
+            )
+        )
+    return out
+
+
+def compute_totals(rows: Sequence[VelocityRow]) -> VelocityRow:
+    """Roll a list of week rows into a single totals row.
+
+    ``words_per_loc`` is ``sum(words) / sum(total_loc)`` — NOT the
+    mean of per-week ratios — per the issue acceptance criteria.
+    """
+    if not rows:
+        return VelocityRow(
+            week="Total",
+            prs_merged=0,
+            lines_added=None,
+            lines_removed=None,
+            total_loc=None,
+            human_words=0,
+            human_messages=0,
+            words_per_loc=None,
+        )
+    prs = sum(r.prs_merged for r in rows)
+    words = sum(r.human_words for r in rows)
+    msgs = sum(r.human_messages for r in rows)
+    # If any week has a populated LOC sum, fold it in; if every week
+    # is None, leave totals as None too. partial_loc bubbles up if
+    # ANY week was partial OR if we have a mix of populated and None.
+    populated = [r for r in rows if r.lines_added is not None]
+    if not populated:
+        return VelocityRow(
+            week="Total",
+            prs_merged=prs,
+            lines_added=None,
+            lines_removed=None,
+            total_loc=None,
+            human_words=words,
+            human_messages=msgs,
+            words_per_loc=None,
+        )
+    lines_added = sum(int(r.lines_added or 0) for r in populated)
+    lines_removed = sum(int(r.lines_removed or 0) for r in populated)
+    total_loc = lines_added + lines_removed
+    partial = any(r.partial_loc for r in rows) or len(populated) < len(
+        [r for r in rows if r.prs_merged > 0]
+    )
+    return VelocityRow(
+        week="Total",
+        prs_merged=prs,
+        lines_added=lines_added,
+        lines_removed=lines_removed,
+        total_loc=total_loc,
+        human_words=words,
+        human_messages=msgs,
+        words_per_loc=_ratio_or_none(words, total_loc),
+        partial_loc=partial,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point (importable from non-CLI code, e.g. issue #82)
+# ---------------------------------------------------------------------------
+
+
+def aggregate_velocity(
+    db_path: Path | str | None = None,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    repo: str | None = None,
+    include_empty: bool = False,
+    conn: sqlite3.Connection | None = None,
+) -> VelocityReport:
+    """Aggregate merged PRs/pushes into weekly velocity rows.
+
+    Either ``conn`` *or* ``db_path`` must be provided. Passing
+    ``conn`` is the path tests + downstream callers (like the
+    charting command, issue #82) use to avoid re-opening the
+    SQLite file.
+
+    Args:
+        db_path: Path to ``index.db``. Ignored if ``conn`` is set.
+        since: Lower bound on ``merged_at`` (inclusive, UTC).
+        until: Upper bound on ``merged_at`` (exclusive, UTC).
+        repo: Optional repo filter. Accepts URL, FQN, or short name —
+            normalised through the same path used by ``list --repo``
+            / ``refs --repo`` (:class:`RepoStore`).
+        include_empty: If True, emit zero-rows for weeks with no
+            merged changes (still bounded by ``since`` / ``until``).
+        conn: Optional pre-opened SQLite connection.
+
+    Returns:
+        :class:`VelocityReport` containing per-week rows, totals row,
+        and ``metadata`` with the rendered SQL and raw row counts
+        (useful for ``--verbose``).
+
+    Raises:
+        ValueError: If neither ``conn`` nor ``db_path`` is provided.
+        LookupError: If ``repo`` is given but does not resolve to a
+            unique known repository.
+    """
+    if conn is None and db_path is None:
+        raise ValueError("aggregate_velocity requires conn or db_path")
+
+    owns_conn = conn is None
+    if conn is None:
+        assert db_path is not None  # for type-checkers
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+
+    try:
+        repo_id, repo_label = _resolve_repo(conn, repo)
+
+        # SQLite stores merged_at as ISO-8601 strings. Compare as
+        # strings — both sides must share the same Z/offset format,
+        # so normalise to "Z" (the GitHub canonical form).
+        since_str = _to_iso_z(since)
+        until_str = _to_iso_z(until)
+
+        raw_rows = fetch_raw_rows(
+            conn,
+            repo_id=repo_id,
+            since=since_str,
+            until=until_str,
+        )
+
+        rows = bucket_by_iso_week(
+            raw_rows,
+            include_empty=include_empty,
+            since=since,
+            until=until,
+        )
+        totals = compute_totals([r for r in rows if r.prs_merged > 0])
+
+        metadata = {
+            "sql": _VELOCITY_SQL,
+            "params": {
+                "repo_id": repo_id,
+                "since": since_str,
+                "until": until_str,
+            },
+            "repo_label": repo_label,
+            "raw_row_count": len(raw_rows),
+            "bucket_count": len(rows),
+            "missing_loc_total": sum(r.missing_loc_count for r in rows),
+        }
+        return VelocityReport(rows=rows, totals=totals, metadata=metadata)
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def _to_iso_z(dt: datetime | None) -> str | None:
+    """Format a UTC datetime as ``YYYY-MM-DDTHH:MM:SSZ`` for SQL bind.
+
+    Returning ``None`` short-circuits the WHERE clause via the
+    ``IS NULL`` guard.
+    """
+    if dt is None:
+        return None
+    dt_utc = dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    return dt_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _resolve_repo(
+    conn: sqlite3.Connection, repo: str | None
+) -> tuple[int | None, str | None]:
+    """Resolve a user-provided repo filter to ``(repo_id, fqn)``.
+
+    Accepts the same shapes as ``list --repo`` and ``refs --repo``:
+    canonical URL, FQN (``owner/repo``), or a short name. Single
+    match → its ``id``; zero matches → :class:`LookupError`;
+    multiple matches → :class:`LookupError` listing candidates.
+    """
+    if repo is None:
+        return None, None
+
+    from ohtv.db.stores import RepoStore
+
+    target = repo.strip()
+    repo_store = RepoStore(conn)
+    matched = None
+    if "://" in target:
+        matched = repo_store.get_by_url(target)
+        candidates = [matched] if matched else []
+    else:
+        candidates = list(repo_store.search_by_name(target))
+        if len(candidates) == 1:
+            matched = candidates[0]
+
+    if not candidates:
+        raise LookupError(
+            f"--repo {target!r} did not match any known repository "
+            "(run `ohtv db scan` first)."
+        )
+    if matched is None:
+        # >1 candidates
+        names = ", ".join(c.fqn for c in candidates[:5])
+        raise LookupError(
+            f"--repo {target!r} matched {len(candidates)} repos: {names}"
+        )
+    return matched.id, matched.fqn
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+_TABLE_HEADERS = ["Week", "PRs", "+Lines", "-Lines", "Total", "Words", "Msgs", "Words/LOC"]
+_CSV_HEADERS = [
+    "week",
+    "prs_merged",
+    "lines_added",
+    "lines_removed",
+    "total_loc",
+    "human_words",
+    "human_messages",
+    "words_per_loc",
+]
+
+
+def _fmt_int(value: int | None, blank: str) -> str:
+    if value is None:
+        return blank
+    return f"{value}"
+
+
+def _fmt_ratio(value: float | None, blank: str) -> str:
+    if value is None:
+        return blank
+    return f"{value:.2f}"
+
+
+def format_table(
+    rows: Sequence[VelocityRow],
+    totals: VelocityRow | None,
+    console,
+    *,
+    show_totals: bool = True,
+) -> None:
+    """Render a Rich table to ``console``.
+
+    Numeric columns are right-aligned. ``-`` is used for unknown
+    cells (NULL LOC, undefined ratio). When ``show_totals`` is True
+    AND ``totals`` is non-None, a totals row is appended with a
+    separator.
+    """
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold", show_lines=False)
+    table.add_column("Week", style="cyan", no_wrap=True)
+    table.add_column("PRs", justify="right")
+    table.add_column("+Lines", justify="right")
+    table.add_column("-Lines", justify="right")
+    table.add_column("Total", justify="right")
+    table.add_column("Words", justify="right")
+    table.add_column("Msgs", justify="right")
+    table.add_column("Words/LOC", justify="right")
+
+    blank = "-"
+    for r in rows:
+        table.add_row(
+            r.week,
+            _fmt_int(r.prs_merged, blank),
+            _fmt_int(r.lines_added, blank),
+            _fmt_int(r.lines_removed, blank),
+            _fmt_int(r.total_loc, blank),
+            _fmt_int(r.human_words, blank),
+            _fmt_int(r.human_messages, blank),
+            _fmt_ratio(r.words_per_loc, blank),
+        )
+    if show_totals and totals is not None and rows:
+        # `end_section=True` on the previous row would draw the
+        # separator; easier: re-add a styled total row with the
+        # section divider via a Rich rule above it.
+        table.add_section()
+        table.add_row(
+            f"[bold]{totals.week}[/bold]",
+            f"[bold]{_fmt_int(totals.prs_merged, blank)}[/bold]",
+            f"[bold]{_fmt_int(totals.lines_added, blank)}[/bold]",
+            f"[bold]{_fmt_int(totals.lines_removed, blank)}[/bold]",
+            f"[bold]{_fmt_int(totals.total_loc, blank)}[/bold]",
+            f"[bold]{_fmt_int(totals.human_words, blank)}[/bold]",
+            f"[bold]{_fmt_int(totals.human_messages, blank)}[/bold]",
+            f"[bold]{_fmt_ratio(totals.words_per_loc, blank)}[/bold]",
+        )
+    console.print(table)
+
+
+def format_csv(rows: Sequence[VelocityRow], stream: IO[str]) -> None:
+    """Write a header-only-style CSV (no totals row, no separators).
+
+    Empty / unknown cells render as the empty string (RFC 4180
+    friendly). Caller is responsible for passing a writable stream
+    (e.g., ``sys.stdout`` or a file opened with ``newline=""``).
+    """
+    writer = csv.writer(stream)
+    writer.writerow(_CSV_HEADERS)
+    for r in rows:
+        writer.writerow(
+            [
+                r.week,
+                r.prs_merged,
+                "" if r.lines_added is None else r.lines_added,
+                "" if r.lines_removed is None else r.lines_removed,
+                "" if r.total_loc is None else r.total_loc,
+                r.human_words,
+                r.human_messages,
+                "" if r.words_per_loc is None else f"{r.words_per_loc:.2f}",
+            ]
+        )
+
+
+__all__ = [
+    "VelocityRow",
+    "VelocityReport",
+    "fetch_raw_rows",
+    "bucket_by_iso_week",
+    "compute_totals",
+    "aggregate_velocity",
+    "format_table",
+    "format_csv",
+]

--- a/tests/unit/reports/__init__.py
+++ b/tests/unit/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ohtv.reports.* (issue #81 and follow-ups)."""

--- a/tests/unit/reports/conftest.py
+++ b/tests/unit/reports/conftest.py
@@ -1,0 +1,174 @@
+"""Test fixtures for ohtv.reports.
+
+Each test gets a fresh in-memory SQLite database with the full
+migration history applied. There is no mocking of the DB layer —
+real schema, real foreign keys, real CHECK constraints.
+
+Helper functions ``seed_repo``, ``seed_conversation``, ``seed_pr``,
+``seed_contribution`` and ``seed_human_input`` make per-test setup
+surgical.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+from ohtv.db.migrations import migrate
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    """Fresh in-memory DB with migrations applied."""
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA foreign_keys = ON")
+    migrate(c)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def seed_repo(
+    conn: sqlite3.Connection,
+    *,
+    canonical_url: str,
+    fqn: str | None = None,
+    short_name: str | None = None,
+) -> int:
+    """Insert a repository and return its id."""
+    fqn = fqn or canonical_url.rsplit("/", 2)[-2] + "/" + canonical_url.rsplit("/", 1)[-1]
+    short_name = short_name or fqn.split("/")[-1]
+    cur = conn.execute(
+        "INSERT INTO repositories (canonical_url, fqn, short_name) "
+        "VALUES (?, ?, ?) RETURNING id",
+        (canonical_url, fqn, short_name),
+    )
+    repo_id = cur.fetchone()["id"]
+    conn.commit()
+    return repo_id
+
+
+def seed_conversation(conn: sqlite3.Connection, conv_id: str) -> None:
+    """Insert a minimal conversations row."""
+    conn.execute(
+        "INSERT INTO conversations (id, location) VALUES (?, ?)",
+        (conv_id, f"/tmp/{conv_id}"),
+    )
+    conn.commit()
+
+
+def seed_pr(
+    conn: sqlite3.Connection,
+    *,
+    repo_id: int,
+    pr_number: int,
+    status: str = "merged",
+    merged_at: str | datetime | None = None,
+    lines_added: int | None = 100,
+    lines_removed: int | None = 25,
+    files_changed: int | None = 3,
+) -> int:
+    """Insert a change_refs row (PR) and return its id.
+
+    Defaults produce a merged PR with sensible LOC numbers. Pass
+    ``lines_added=None`` to model the "LOC not yet fetched" case.
+    """
+    if isinstance(merged_at, datetime):
+        merged_at = merged_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    cur = conn.execute(
+        """
+        INSERT INTO change_refs
+            (repo_id, change_type, pr_number, status, merged_at,
+             lines_added, lines_removed, files_changed)
+        VALUES (?, 'pr', ?, ?, ?, ?, ?, ?)
+        RETURNING id
+        """,
+        (repo_id, pr_number, status, merged_at, lines_added, lines_removed, files_changed),
+    )
+    row_id = cur.fetchone()["id"]
+    conn.commit()
+    return row_id
+
+
+def seed_direct_push(
+    conn: sqlite3.Connection,
+    *,
+    repo_id: int,
+    commit_range: str,
+    status: str = "merged",
+    merged_at: str | datetime | None = None,
+    lines_added: int | None = 50,
+    lines_removed: int | None = 5,
+) -> int:
+    """Insert a direct-push change_refs row."""
+    if isinstance(merged_at, datetime):
+        merged_at = merged_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    cur = conn.execute(
+        """
+        INSERT INTO change_refs
+            (repo_id, change_type, commit_range, status, merged_at,
+             lines_added, lines_removed)
+        VALUES (?, 'direct_push', ?, ?, ?, ?, ?)
+        RETURNING id
+        """,
+        (repo_id, commit_range, status, merged_at, lines_added, lines_removed),
+    )
+    row_id = cur.fetchone()["id"]
+    conn.commit()
+    return row_id
+
+
+def seed_contribution(
+    conn: sqlite3.Connection,
+    *,
+    conversation_id: str,
+    change_ref_id: int,
+    contribution_type: str = "merged",
+) -> None:
+    """Insert a conversation_contributions row."""
+    conn.execute(
+        """
+        INSERT INTO conversation_contributions
+            (conversation_id, change_ref_id, contribution_type)
+        VALUES (?, ?, ?)
+        """,
+        (conversation_id, change_ref_id, contribution_type),
+    )
+    conn.commit()
+
+
+def seed_human_input(
+    conn: sqlite3.Connection,
+    *,
+    conversation_id: str,
+    initial_prompt_words: int = 0,
+    initial_prompt_source: str = "human",
+    followup_word_count: int = 0,
+    followup_message_count: int = 0,
+    processed_at: str = "2024-05-01T00:00:00Z",
+    event_count: int = 1,
+) -> None:
+    """Insert a conversation_human_input row."""
+    conn.execute(
+        """
+        INSERT INTO conversation_human_input
+            (conversation_id, initial_prompt_words, initial_prompt_source,
+             followup_word_count, followup_message_count,
+             processed_at, event_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            conversation_id,
+            initial_prompt_words,
+            initial_prompt_source,
+            followup_word_count,
+            followup_message_count,
+            processed_at,
+            event_count,
+        ),
+    )
+    conn.commit()

--- a/tests/unit/reports/test_cli_report.py
+++ b/tests/unit/reports/test_cli_report.py
@@ -1,0 +1,276 @@
+"""CLI smoke tests for ``ohtv report velocity`` (issue #81).
+
+These exercise the full Click entry point against an isolated
+``OHTV_DIR`` with a fully-migrated SQLite DB. The DB is not mocked.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main as ohtv_main
+from ohtv.db.migrations import migrate
+
+from tests.unit.reports.conftest import (
+    seed_contribution,
+    seed_conversation,
+    seed_human_input,
+    seed_pr,
+    seed_repo,
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Force the CLI to use a temp DB at ``$OHTV_DIR/index.db``."""
+    ohtv_dir = tmp_path / "ohtv"
+    ohtv_dir.mkdir()
+    db_path = ohtv_dir / "index.db"
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_dir))
+    monkeypatch.setenv("OHTV_DB_PATH", str(db_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    migrate(conn)
+    conn.close()
+    return db_path
+
+
+def _open(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _seed_two_weeks(db_path: Path) -> None:
+    """Seed two PRs in two different ISO weeks for the same repo."""
+    conn = _open(db_path)
+    try:
+        repo_id = seed_repo(conn, canonical_url="https://github.com/jpshackelford/ohtv")
+        for i, when in enumerate(
+            ["2024-03-05T12:00:00Z", "2024-03-12T12:00:00Z"], start=1
+        ):
+            seed_conversation(conn, f"c{i}")
+            seed_human_input(
+                conn,
+                conversation_id=f"c{i}",
+                initial_prompt_words=50 * i,
+                initial_prompt_source="human",
+                followup_word_count=0,
+                followup_message_count=0,
+            )
+            pr_id = seed_pr(
+                conn,
+                repo_id=repo_id,
+                pr_number=i,
+                merged_at=when,
+                lines_added=100 * i,
+                lines_removed=10 * i,
+            )
+            seed_contribution(conn, conversation_id=f"c{i}", change_ref_id=pr_id)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# C-1: report --help lists velocity.
+# ---------------------------------------------------------------------------
+
+
+def test_report_group_help_lists_velocity(runner: CliRunner) -> None:
+    result = runner.invoke(ohtv_main, ["report", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "velocity" in result.output
+
+
+def test_report_velocity_help_shows_options(runner: CliRunner) -> None:
+    result = runner.invoke(ohtv_main, ["report", "velocity", "--help"])
+    assert result.exit_code == 0, result.output
+    for option in ("--format", "--since", "--until", "--repo", "--include-empty", "--no-totals", "--verbose"):
+        assert option in result.output, f"missing {option} in help"
+
+
+# ---------------------------------------------------------------------------
+# C-2: table output prints the seeded week labels.
+# ---------------------------------------------------------------------------
+
+
+def test_velocity_table_output(runner: CliRunner, isolated_db: Path) -> None:
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(ohtv_main, ["report", "velocity"])
+    assert result.exit_code == 0, result.output
+    assert "2024-W10" in result.output
+    assert "2024-W11" in result.output
+    # Totals row present by default.
+    assert "Total" in result.output
+
+
+def test_velocity_table_no_totals(runner: CliRunner, isolated_db: Path) -> None:
+    """--no-totals suppresses the totals row."""
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(ohtv_main, ["report", "velocity", "--no-totals"])
+    assert result.exit_code == 0, result.output
+    assert "2024-W10" in result.output
+    # The totals row should not show up; "Total" appears as a string but
+    # the per-week PRs should still render.
+    # We assert the totals body doesn't appear: with totals, the totals
+    # PRs count is the sum (2). Without, only the per-week rows show.
+    lines = [ln for ln in result.output.splitlines() if "Total" in ln]
+    assert all("PRs" in ln or "Total" not in ln for ln in lines), lines
+
+
+# ---------------------------------------------------------------------------
+# C-3: CSV output starts with the canonical header, no totals row.
+# ---------------------------------------------------------------------------
+
+
+def test_velocity_csv_output(runner: CliRunner, isolated_db: Path) -> None:
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(ohtv_main, ["report", "velocity", "--format", "csv"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().splitlines()
+    assert lines[0] == (
+        "week,prs_merged,lines_added,lines_removed,total_loc,"
+        "human_words,human_messages,words_per_loc"
+    )
+    # Exactly 2 data rows, no totals row.
+    data_rows = [ln for ln in lines[1:] if ln.strip()]
+    assert len(data_rows) == 2
+    assert all(not ln.startswith("Total") for ln in data_rows)
+
+
+# ---------------------------------------------------------------------------
+# C-4: empty DB hint (no change_refs).
+# ---------------------------------------------------------------------------
+
+
+def test_velocity_empty_db_hint(runner: CliRunner, isolated_db: Path) -> None:
+    """No change_refs rows → friendly hint, exit 0."""
+    result = runner.invoke(ohtv_main, ["report", "velocity"])
+    assert result.exit_code == 0
+    assert "No change_refs" in result.output
+    assert "ohtv db process all" in result.output
+
+
+def test_velocity_empty_db_hint_csv(runner: CliRunner, isolated_db: Path) -> None:
+    """Empty DB in CSV mode prints just the header."""
+    result = runner.invoke(ohtv_main, ["report", "velocity", "--format", "csv"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert len(lines) == 1
+    assert lines[0].startswith("week,prs_merged")
+
+
+# ---------------------------------------------------------------------------
+# C-5: --since / --until / --repo / --include-empty / --verbose
+# ---------------------------------------------------------------------------
+
+
+def test_velocity_since_filter(runner: CliRunner, isolated_db: Path) -> None:
+    _seed_two_weeks(isolated_db)
+    # Drop the first week (2024-03-05) by setting --since after it.
+    result = runner.invoke(
+        ohtv_main, ["report", "velocity", "--since", "2024-03-10"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "2024-W11" in result.output
+    assert "2024-W10" not in result.output
+
+
+def test_velocity_until_filter(runner: CliRunner, isolated_db: Path) -> None:
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(
+        ohtv_main, ["report", "velocity", "--until", "2024-03-11"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "2024-W10" in result.output
+    assert "2024-W11" not in result.output
+
+
+def test_velocity_repo_filter(runner: CliRunner, isolated_db: Path) -> None:
+    """--repo restricts to one repo; mismatching repo yields exit 2."""
+    _seed_two_weeks(isolated_db)
+    # Match.
+    result = runner.invoke(
+        ohtv_main, ["report", "velocity", "--repo", "jpshackelford/ohtv"]
+    )
+    assert result.exit_code == 0
+    assert "2024-W10" in result.output
+
+    # Mismatch → exit 2.
+    result = runner.invoke(
+        ohtv_main, ["report", "velocity", "--repo", "unknown/repo"]
+    )
+    assert result.exit_code == 2
+    assert "did not match" in result.output
+
+
+def test_velocity_include_empty(runner: CliRunner, isolated_db: Path) -> None:
+    """--include-empty fills gap weeks between seeded weeks."""
+    conn = _open(isolated_db)
+    repo_id = seed_repo(conn, canonical_url="https://github.com/jpshackelford/ohtv")
+    seed_conversation(conn, "c1")
+    seed_conversation(conn, "c2")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=10)
+    seed_human_input(conn, conversation_id="c2", initial_prompt_words=10)
+    pr1 = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    pr2 = seed_pr(conn, repo_id=repo_id, pr_number=2, merged_at="2024-03-19T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr1)
+    seed_contribution(conn, conversation_id="c2", change_ref_id=pr2)
+    conn.close()
+
+    result = runner.invoke(
+        ohtv_main, ["report", "velocity", "--include-empty"]
+    )
+    assert result.exit_code == 0, result.output
+    for week in ("2024-W10", "2024-W11", "2024-W12"):
+        assert week in result.output
+
+
+def test_velocity_verbose_shows_sql(runner: CliRunner, isolated_db: Path) -> None:
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(ohtv_main, ["report", "velocity", "--verbose"])
+    assert result.exit_code == 0, result.output
+    assert "-- SQL --" in result.output
+    assert "raw rows fetched" in result.output
+
+
+def test_velocity_bad_since_value(runner: CliRunner, isolated_db: Path) -> None:
+    """An unparseable --since value exits 2 with a friendly message."""
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(
+        ohtv_main, ["report", "velocity", "--since", "not-a-date"]
+    )
+    assert result.exit_code == 2
+    assert "could not parse --since" in result.output
+
+
+def test_velocity_no_merged_prs_message(runner: CliRunner, isolated_db: Path) -> None:
+    """When change_refs exists but none match the filters, print the empty hint."""
+    # Seed only a *pending* PR (no merged ones).
+    conn = _open(isolated_db)
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at=None,
+        status="pending",
+    )
+    conn.close()
+
+    result = runner.invoke(ohtv_main, ["report", "velocity"])
+    assert result.exit_code == 0
+    assert "No merged PRs" in result.output

--- a/tests/unit/reports/test_velocity.py
+++ b/tests/unit/reports/test_velocity.py
@@ -1,0 +1,628 @@
+"""Unit tests for :mod:`ohtv.reports.velocity` (issue #81).
+
+These tests exercise the row-shaping logic against an in-memory
+SQLite DB with the real migration history applied. No mocks for
+the DB.
+
+The fixtures live in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from ohtv.reports.velocity import (
+    VelocityReport,
+    VelocityRow,
+    aggregate_velocity,
+    bucket_by_iso_week,
+    compute_totals,
+    fetch_raw_rows,
+    format_csv,
+)
+
+from tests.unit.reports.conftest import (
+    seed_contribution,
+    seed_conversation,
+    seed_direct_push,
+    seed_human_input,
+    seed_pr,
+    seed_repo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(rows: list[VelocityRow], week: str) -> VelocityRow:
+    for r in rows:
+        if r.week == week:
+            return r
+    raise AssertionError(f"week {week!r} not found in {[r.week for r in rows]}")
+
+
+# ---------------------------------------------------------------------------
+# T-1 .. T-12
+# ---------------------------------------------------------------------------
+
+
+def test_single_merged_pr_one_week(conn: sqlite3.Connection) -> None:
+    """One merged PR, one conversation → one bucket with correct totals."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/jpshackelford/ohtv")
+    seed_conversation(conn, "c1")
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",  # ISO week 10 of 2024
+        lines_added=100,
+        lines_removed=20,
+    )
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+    seed_human_input(
+        conn,
+        conversation_id="c1",
+        initial_prompt_words=50,
+        initial_prompt_source="human",
+        followup_word_count=0,
+        followup_message_count=0,
+    )
+
+    report = aggregate_velocity(conn=conn)
+
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week == "2024-W10"
+    assert row.prs_merged == 1
+    assert row.lines_added == 100
+    assert row.lines_removed == 20
+    assert row.total_loc == 120
+    assert row.human_words == 50
+    assert row.human_messages == 1  # 1 + 0 followups
+    assert row.words_per_loc == pytest.approx(0.42, abs=0.01)
+    assert row.partial_loc is False
+
+
+def test_multiple_prs_same_week_aggregate(conn: sqlite3.Connection) -> None:
+    """Three PRs merged in the same ISO week collapse to one row."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    for i in (1, 2, 3):
+        seed_conversation(conn, f"c{i}")
+        seed_human_input(
+            conn,
+            conversation_id=f"c{i}",
+            initial_prompt_words=10 * i,
+            initial_prompt_source="human",
+            followup_word_count=5,
+            followup_message_count=1,
+        )
+        pr_id = seed_pr(
+            conn,
+            repo_id=repo_id,
+            pr_number=i,
+            merged_at="2024-03-05T12:00:00Z",
+            lines_added=100 * i,
+            lines_removed=10 * i,
+        )
+        seed_contribution(conn, conversation_id=f"c{i}", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week == "2024-W10"
+    assert row.prs_merged == 3
+    assert row.lines_added == 600  # 100+200+300
+    assert row.lines_removed == 60
+    assert row.total_loc == 660
+    # words per conv: 10+5=15, 20+5=25, 30+5=35 → 75
+    assert row.human_words == 75
+    # msgs per conv: 1+1=2 each → 6
+    assert row.human_messages == 6
+
+
+def test_prs_span_multiple_weeks(conn: sqlite3.Connection) -> None:
+    """PRs across 3 weeks → 3 rows in ascending week order."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    for i, merged in enumerate(
+        ["2024-03-05T12:00:00Z", "2024-03-12T12:00:00Z", "2024-03-19T12:00:00Z"]
+    ):
+        seed_conversation(conn, f"c{i}")
+        seed_human_input(
+            conn,
+            conversation_id=f"c{i}",
+            initial_prompt_words=10,
+            initial_prompt_source="human",
+        )
+        pr_id = seed_pr(conn, repo_id=repo_id, pr_number=i + 1, merged_at=merged)
+        seed_contribution(conn, conversation_id=f"c{i}", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    weeks = [r.week for r in report.rows]
+    assert weeks == ["2024-W10", "2024-W11", "2024-W12"]
+
+
+def test_iso_week_boundary_2024_12_30(conn: sqlite3.Connection) -> None:
+    """2024-12-30 is in ISO week 2025-W01, NOT 2024-W53.
+
+    This is the canonical SQLite ``%W`` vs ISO regression test. The
+    comment in issue #81 calls this exact date out.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    pr_id = seed_pr(
+        conn, repo_id=repo_id, pr_number=1, merged_at="2024-12-30T12:00:00Z"
+    )
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=5)
+
+    report = aggregate_velocity(conn=conn)
+    assert len(report.rows) == 1
+    assert report.rows[0].week == "2025-W01"
+
+
+def test_iso_week_boundary_sunday_to_monday(conn: sqlite3.Connection) -> None:
+    """A PR merged 23:59 UTC Sunday and one at 00:00 UTC Monday land in different weeks."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_conversation(conn, "c2")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=1)
+    seed_human_input(conn, conversation_id="c2", initial_prompt_words=1)
+    # 2024-03-10 is a Sunday (ISO week 10 of 2024).
+    pr1 = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-10T23:59:59Z")
+    # 2024-03-11 is the following Monday (ISO week 11).
+    pr2 = seed_pr(conn, repo_id=repo_id, pr_number=2, merged_at="2024-03-11T00:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr1)
+    seed_contribution(conn, conversation_id="c2", change_ref_id=pr2)
+
+    report = aggregate_velocity(conn=conn)
+    weeks = [r.week for r in report.rows]
+    assert weeks == ["2024-W10", "2024-W11"]
+
+
+def test_non_merged_prs_excluded(conn: sqlite3.Connection) -> None:
+    """Only ``status='merged'`` PRs are counted; pending/open/closed are dropped."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=10)
+    merged_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        status="merged",
+    )
+    seed_pr(conn, repo_id=repo_id, pr_number=2, merged_at=None, status="pending")
+    seed_pr(conn, repo_id=repo_id, pr_number=3, merged_at=None, status="open")
+    seed_pr(conn, repo_id=repo_id, pr_number=4, merged_at=None, status="closed")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=merged_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert len(report.rows) == 1
+    assert report.rows[0].prs_merged == 1
+
+
+def test_distinct_contributor_no_double_count(conn: sqlite3.Connection) -> None:
+    """One conversation contributing as created+pushed+merged counts once per PR.
+
+    Without the DISTINCT (change_ref_id, conversation_id) sub-select,
+    this conversation's words would be triple-counted.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(
+        conn,
+        conversation_id="c1",
+        initial_prompt_words=20,
+        initial_prompt_source="human",
+        followup_word_count=10,
+        followup_message_count=2,
+    )
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+    )
+    for ctype in ("created", "pushed", "merged"):
+        seed_contribution(
+            conn, conversation_id="c1", change_ref_id=pr_id, contribution_type=ctype
+        )
+
+    report = aggregate_velocity(conn=conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    # Human words = 20 (initial) + 10 (followups) = 30, NOT 90.
+    assert row.human_words == 30
+    # Msgs = 1 + 2 = 3, NOT 9.
+    assert row.human_messages == 3
+
+
+def test_initial_prompt_source_automation(conn: sqlite3.Connection) -> None:
+    """``initial_prompt_source='automation'`` excludes the initial prompt + 1 msg."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(
+        conn,
+        conversation_id="c1",
+        initial_prompt_words=1000,  # should be IGNORED
+        initial_prompt_source="automation",
+        followup_word_count=15,
+        followup_message_count=3,
+    )
+    pr_id = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert report.rows[0].human_words == 15
+    assert report.rows[0].human_messages == 3
+
+
+def test_initial_prompt_source_unknown_counts_as_human(conn: sqlite3.Connection) -> None:
+    """``'unknown'`` is treated identically to ``'human'`` until issue #83."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(
+        conn,
+        conversation_id="c1",
+        initial_prompt_words=12,
+        initial_prompt_source="unknown",
+        followup_word_count=8,
+        followup_message_count=2,
+    )
+    pr_id = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert report.rows[0].human_words == 20  # 12 + 8
+    assert report.rows[0].human_messages == 3  # 1 + 2
+
+
+def test_words_per_loc_zero_denominator(conn: sqlite3.Connection) -> None:
+    """All LOC NULL → words_per_loc is None (no divide-by-zero crash)."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(
+        conn, conversation_id="c1", initial_prompt_words=40, initial_prompt_source="human"
+    )
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=None,
+        lines_removed=None,
+    )
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    row = report.rows[0]
+    assert row.lines_added is None
+    assert row.lines_removed is None
+    assert row.total_loc is None
+    assert row.words_per_loc is None
+    assert row.partial_loc is False  # not partial — fully unknown
+    # CSV renders these as empty strings.
+    buf = io.StringIO()
+    format_csv([row], buf)
+    line = buf.getvalue().splitlines()[1]
+    assert line == "2024-W10,1,,,,40,1,"
+
+
+def test_partial_loc_summed_with_flag(conn: sqlite3.Connection) -> None:
+    """Mixed (some fetched, some NULL) → sum knowns and set ``partial_loc=True``."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    for i in (1, 2, 3):
+        seed_conversation(conn, f"c{i}")
+        seed_human_input(conn, conversation_id=f"c{i}", initial_prompt_words=10)
+    # 2 with LOC, 1 NULL.
+    fetched_a = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=100,
+        lines_removed=10,
+    )
+    fetched_b = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=2,
+        merged_at="2024-03-06T12:00:00Z",
+        lines_added=200,
+        lines_removed=20,
+    )
+    missing = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=3,
+        merged_at="2024-03-07T12:00:00Z",
+        lines_added=None,
+        lines_removed=None,
+    )
+    seed_contribution(conn, conversation_id="c1", change_ref_id=fetched_a)
+    seed_contribution(conn, conversation_id="c2", change_ref_id=fetched_b)
+    seed_contribution(conn, conversation_id="c3", change_ref_id=missing)
+
+    report = aggregate_velocity(conn=conn)
+    row = report.rows[0]
+    assert row.prs_merged == 3
+    # Summed knowns only (100+200=300, 10+20=30, total 330).
+    assert row.lines_added == 300
+    assert row.lines_removed == 30
+    assert row.total_loc == 330
+    assert row.partial_loc is True
+    assert row.missing_loc_count == 1
+
+
+def test_include_empty_fills_gaps(conn: sqlite3.Connection) -> None:
+    """``include_empty=True`` fills weeks with no merged changes as zero-rows."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_conversation(conn, "c2")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=1)
+    seed_human_input(conn, conversation_id="c2", initial_prompt_words=1)
+    pr1 = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    pr2 = seed_pr(conn, repo_id=repo_id, pr_number=2, merged_at="2024-03-19T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr1)
+    seed_contribution(conn, conversation_id="c2", change_ref_id=pr2)
+
+    report = aggregate_velocity(conn=conn, include_empty=True)
+    weeks = [r.week for r in report.rows]
+    assert weeks == ["2024-W10", "2024-W11", "2024-W12"]
+    # The middle week is empty.
+    empty = _row(report.rows, "2024-W11")
+    assert empty.prs_merged == 0
+    assert empty.lines_added is None
+    assert empty.human_words == 0
+
+
+def test_include_empty_respects_since_until(conn: sqlite3.Connection) -> None:
+    """Iteration range honours ``since`` / ``until`` when ``include_empty`` is set."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=1)
+    pr_id = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-12T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    since = datetime(2024, 2, 26, tzinfo=timezone.utc)  # ISO week 9
+    until = datetime(2024, 3, 25, tzinfo=timezone.utc)  # ISO week 13 boundary
+    report = aggregate_velocity(
+        conn=conn, since=since, until=until, include_empty=True
+    )
+    weeks = [r.week for r in report.rows]
+    # Weeks 9, 10, 11, 12 should all appear; the actual PR is in W11.
+    assert "2024-W09" in weeks
+    assert "2024-W11" in weeks
+    productive = [r for r in report.rows if r.prs_merged > 0]
+    assert len(productive) == 1
+    assert productive[0].week == "2024-W11"
+
+
+def test_repo_filter_excludes_other_repos(conn: sqlite3.Connection) -> None:
+    """Filtering by repo drops PRs from other repos."""
+    repo_a = seed_repo(conn, canonical_url="https://github.com/team/proj-a")
+    repo_b = seed_repo(conn, canonical_url="https://github.com/team/proj-b")
+    seed_conversation(conn, "c1")
+    seed_conversation(conn, "c2")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=10)
+    seed_human_input(conn, conversation_id="c2", initial_prompt_words=20)
+    pr_a = seed_pr(conn, repo_id=repo_a, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    pr_b = seed_pr(conn, repo_id=repo_b, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_a)
+    seed_contribution(conn, conversation_id="c2", change_ref_id=pr_b)
+
+    report = aggregate_velocity(conn=conn, repo="proj-a")
+    assert len(report.rows) == 1
+    assert report.rows[0].prs_merged == 1
+    assert report.rows[0].human_words == 10  # only c1
+
+
+def test_repo_filter_unknown_raises_lookup(conn: sqlite3.Connection) -> None:
+    """An unrecognised --repo value raises ``LookupError`` for the CLI to catch."""
+    seed_repo(conn, canonical_url="https://github.com/team/proj-a")
+    with pytest.raises(LookupError):
+        aggregate_velocity(conn=conn, repo="nonexistent-repo")
+
+
+def test_since_until_filters(conn: sqlite3.Connection) -> None:
+    """Date range filters drop rows outside [since, until)."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    for i, when in enumerate(
+        ["2024-02-15T12:00:00Z", "2024-03-05T12:00:00Z", "2024-04-15T12:00:00Z"]
+    ):
+        seed_conversation(conn, f"c{i}")
+        seed_human_input(conn, conversation_id=f"c{i}", initial_prompt_words=5)
+        pr_id = seed_pr(conn, repo_id=repo_id, pr_number=i + 1, merged_at=when)
+        seed_contribution(conn, conversation_id=f"c{i}", change_ref_id=pr_id)
+
+    since = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    until = datetime(2024, 4, 1, tzinfo=timezone.utc)
+    report = aggregate_velocity(conn=conn, since=since, until=until)
+    assert len(report.rows) == 1
+    assert report.rows[0].week == "2024-W10"
+
+
+def test_direct_push_counted(conn: sqlite3.Connection) -> None:
+    """``change_type='direct_push'`` rows are also aggregated."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=10)
+    push_id = seed_direct_push(
+        conn,
+        repo_id=repo_id,
+        commit_range="abc123..def456",
+        merged_at="2024-03-05T12:00:00Z",
+    )
+    seed_contribution(conn, conversation_id="c1", change_ref_id=push_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert len(report.rows) == 1
+    assert report.rows[0].prs_merged == 1
+    assert report.rows[0].lines_added == 50
+
+
+def test_empty_db_returns_no_rows(conn: sqlite3.Connection) -> None:
+    """No change_refs rows → empty report; aggregate function does not crash."""
+    report = aggregate_velocity(conn=conn)
+    assert report.rows == []
+    assert report.totals is not None
+    assert report.totals.prs_merged == 0
+
+
+def test_compute_totals_uses_global_ratio() -> None:
+    """The totals row uses ``sum(words) / sum(total_loc)``, NOT the mean."""
+    rows = [
+        VelocityRow(
+            week="2024-W10",
+            prs_merged=1,
+            lines_added=10,
+            lines_removed=0,
+            total_loc=10,
+            human_words=10,
+            human_messages=1,
+            words_per_loc=1.00,
+        ),
+        VelocityRow(
+            week="2024-W11",
+            prs_merged=1,
+            lines_added=1000,
+            lines_removed=0,
+            total_loc=1000,
+            human_words=10,
+            human_messages=1,
+            words_per_loc=0.01,
+        ),
+    ]
+    totals = compute_totals(rows)
+    # Mean of ratios = (1.00 + 0.01) / 2 = 0.505 — wrong.
+    # Global ratio = 20 / 1010 = 0.0198 → rounds to 0.02.
+    assert totals.words_per_loc == 0.02
+    assert totals.prs_merged == 2
+    assert totals.lines_added == 1010
+    assert totals.total_loc == 1010
+
+
+def test_compute_totals_handles_all_none_loc() -> None:
+    """Totals row keeps ``None`` LOC when no week has populated LOC."""
+    rows = [
+        VelocityRow(
+            week="2024-W10",
+            prs_merged=2,
+            lines_added=None,
+            lines_removed=None,
+            total_loc=None,
+            human_words=30,
+            human_messages=2,
+            words_per_loc=None,
+        ),
+    ]
+    totals = compute_totals(rows)
+    assert totals.lines_added is None
+    assert totals.total_loc is None
+    assert totals.words_per_loc is None
+    assert totals.human_words == 30
+
+
+def test_fetch_raw_rows_uses_distinct_subselect(conn: sqlite3.Connection) -> None:
+    """Direct test of :func:`fetch_raw_rows` — DISTINCT applied per PR."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_conversation(conn, "c2")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=10)
+    seed_human_input(conn, conversation_id="c2", initial_prompt_words=20)
+    pr_id = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    # c1 contributes 3 ways; c2 contributes once.
+    for ctype in ("created", "pushed", "merged"):
+        seed_contribution(
+            conn, conversation_id="c1", change_ref_id=pr_id, contribution_type=ctype
+        )
+    seed_contribution(conn, conversation_id="c2", change_ref_id=pr_id)
+
+    raw = fetch_raw_rows(conn)
+    assert len(raw) == 1
+    # Words: c1 (10+0) + c2 (20+0) = 30. Without DISTINCT it would be 50.
+    assert raw[0]["human_words"] == 30
+    assert raw[0]["human_messages"] == 2  # one msg per conv
+
+
+def test_bucket_by_iso_week_ignores_unparseable_merged_at(conn: sqlite3.Connection) -> None:
+    """A bogus ``merged_at`` value is skipped, not crashed on."""
+
+    # Build a fake row payload that mimics sqlite3.Row dict access.
+    class _R(dict):
+        def __getitem__(self, k):
+            return super().__getitem__(k)
+
+    bad = _R(
+        change_ref_id=99,
+        merged_at="not-a-date",
+        lines_added=1,
+        lines_removed=0,
+        repo_id=1,
+        repo_fqn="x/y",
+        human_words=0,
+        human_messages=0,
+    )
+    rows = bucket_by_iso_week([bad])
+    assert rows == []
+
+
+def test_aggregate_velocity_requires_conn_or_path() -> None:
+    with pytest.raises(ValueError):
+        aggregate_velocity()
+
+
+def test_format_csv_empty_writes_header_only() -> None:
+    """Empty input still emits the header line (RFC-4180 friendly)."""
+    buf = io.StringIO()
+    format_csv([], buf)
+    assert (
+        buf.getvalue().strip()
+        == "week,prs_merged,lines_added,lines_removed,total_loc,human_words,human_messages,words_per_loc"
+    )
+
+
+def test_format_csv_row_shape(conn: sqlite3.Connection) -> None:
+    """Round-trip: one PR through aggregate_velocity → format_csv."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=50)
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=100,
+        lines_removed=20,
+    )
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    buf = io.StringIO()
+    format_csv(report.rows, buf)
+    lines = buf.getvalue().splitlines()
+    assert len(lines) == 2
+    assert lines[0].startswith("week,")
+    assert lines[1] == "2024-W10,1,100,20,120,50,1,0.42"
+
+
+def test_aggregate_velocity_report_metadata(conn: sqlite3.Connection) -> None:
+    """``VelocityReport.metadata`` carries SQL + counts for --verbose."""
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(conn, conversation_id="c1", initial_prompt_words=10)
+    pr_id = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert isinstance(report, VelocityReport)
+    assert "SELECT" in report.metadata["sql"].upper()
+    assert report.metadata["raw_row_count"] == 1
+    assert report.metadata["bucket_count"] == 1
+    assert report.metadata["missing_loc_total"] == 0


### PR DESCRIPTION
Closes #81

Adds a new `ohtv report` Click command group with its first sub-command `velocity`, which aggregates merged PRs / direct pushes by ISO week. Plus a new `src/ohtv/reports/` package — pure Python, no Click — so issue #82 (charting) can import the row-shaping function directly.

Plugin: load `github:jpshackelford/.openhands/plugins/ohtv-workflow@feat/ohtv-workflow-plugin`

## What landed

| File | Purpose |
|---|---|
| `src/ohtv/reports/__init__.py` | Package marker. |
| `src/ohtv/reports/velocity.py` | `VelocityRow`, `VelocityReport`, `fetch_raw_rows`, `bucket_by_iso_week`, `compute_totals`, `aggregate_velocity`, `format_table`, `format_csv`. |
| `src/ohtv/cli.py` | New `@main.group() report` + `@report.command("velocity")` (~200 lines, thin wrapper). |
| `tests/unit/reports/test_velocity.py` | 26 unit tests against real in-memory SQLite (no mocks). |
| `tests/unit/reports/test_cli_report.py` | 14 CliRunner smoke tests covering every flag + the two graceful empty states. |
| `README.md`, `AGENTS.md` | Quickstart example + §28 design note. |

## Evidence

Seeded an in-memory DB with 16 merged PRs across ISO weeks 10/11/12 of 2024 and ran the command:

### `ohtv report velocity`

```
┏━━━━━━━━━━┳━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━┳━━━━━━━━━━━┓
┃ Week     ┃ PRs ┃ +Lines ┃ -Lines ┃ Total ┃ Words ┃ Msgs ┃ Words/LOC ┃
┡━━━━━━━━━━╇━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━╇━━━━━━━━━━━┩
│ 2024-W10 │   3 │    450 │    120 │   570 │   340 │   11 │      0.60 │
│ 2024-W11 │   5 │    890 │    230 │  1120 │   125 │    8 │      0.11 │
│ 2024-W12 │   8 │   1280 │    176 │  1456 │    45 │   10 │      0.03 │
├──────────┼─────┼────────┼────────┼───────┼───────┼──────┼───────────┤
│ Total    │  16 │   2620 │    526 │  3146 │   510 │   29 │      0.16 │
└──────────┴─────┴────────┴────────┴───────┴───────┴──────┴───────────┘
```

### `ohtv report velocity --format csv`

```
week,prs_merged,lines_added,lines_removed,total_loc,human_words,human_messages,words_per_loc
2024-W10,3,450,120,570,340,11,0.60
2024-W11,5,890,230,1120,125,8,0.11
2024-W12,8,1280,176,1456,45,10,0.03
```

(Header row, no totals row, no separators, empty string for unknown cells — matches the spec verbatim.)

### Empty-DB hint

```
$ OHTV_DIR=/tmp/empty ohtv report velocity
No index database found. Run `ohtv db scan && ohtv db process all` first.
$ echo $?
0
```

### Tests

- **Pre-existing**: 1577 passing (last green build).
- **New**: 40 (26 unit + 14 CLI).
- **Total**: 1617 passing in 9.95 s.

```
$ uv run pytest -q
... 1617 passed, 24 warnings in 9.95s
```

Ruff: clean on the new files (`src/ohtv/reports`, `tests/unit/reports`). `src/ohtv/cli.py` has the same 78 pre-existing warnings as `main` — no new warnings added.

## Design choices worth flagging

1. **ISO week in Python, not SQL.** `strftime('%W', ...)` is GNU/POSIX, not ISO 8601. We pin this with `test_iso_week_boundary_2024_12_30` (2024-12-30 → `2025-W01`, not `2024-W53`).
2. **DISTINCT `(change_ref_id, conversation_id)` sub-select** prevents triple-counting human words when one conversation contributes as `created` + `pushed` + `merged` to the same PR. Pinned by `test_distinct_contributor_no_double_count`.
3. **`initial_prompt_source` policy** matches the issue: `human` and `unknown` include the initial prompt + followups; `automation` excludes the initial prompt. `unknown` is the optimistic default until issue #83 lands.
4. **LOC NULL handling**: all-NULL bucket renders `-`/empty; mixed bucket sums knowns + sets `partial_loc=True` (surfaced by `--verbose`); Words/LOC division-by-zero returns `None` (no crash).
5. **Totals row** uses `sum(words) / sum(total_loc)`, NOT the mean of per-week ratios. Pinned by `test_compute_totals_uses_global_ratio`.
6. **Reuses existing helpers**: `ohtv.filters.parse_date_filter` for `--since` / `--until`, `RepoStore` for the `--repo` FQN/URL/short-name lookup. No duplication.
7. **Reusable surface for issue #82**: `ohtv.reports.velocity.aggregate_velocity(conn=..., since=..., until=..., repo=..., include_empty=...) → VelocityReport(rows, totals, metadata)` is fully importable from non-CLI code. The CLI is just a thin shell.

## Verified — Acceptance Criteria

- [x] `ohtv report --help` lists `velocity` as a sub-command.
- [x] Reads from `~/.ohtv/index.db` (no new DB path).
- [x] Aggregates only `status='merged' AND change_type IN ('pr','direct_push')`.
- [x] Week column shows ISO `YYYY-Www`, computed via `datetime.isocalendar()`.
- [x] Table columns: `Week, PRs, +Lines, -Lines, Total, Words, Msgs, Words/LOC`.
- [x] CSV columns: `week, prs_merged, lines_added, lines_removed, total_loc, human_words, human_messages, words_per_loc`.
- [x] `+Lines / -Lines / Total` render `-` (table) / empty (CSV) when all rows in the bucket have NULL LOC; mixed sums knowns and flags partial in `--verbose`.
- [x] `Words / Msgs` are summed over DISTINCT contributing conversations per change_ref.
- [x] `initial_prompt_source` policy implemented; `'unknown'` treated as `'human'` (documented).
- [x] `Words/LOC` formatted to 2 decimals; `-`/empty when denominator is zero/NULL.
- [x] Totals row uses `sum(words) / sum(total_loc)`, not mean of ratios.
- [x] CSV emits no totals row, no separators, no Rich codes — pure stdlib `csv.writer`.
- [x] Empty weeks omitted by default; `--include-empty` zeros them (respects `--since`/`--until`).
- [x] `--since` accepts YYYY-MM-DD + Nd/Nw/Nm via `parse_date_filter`; `--until` accepts YYYY-MM-DD.
- [x] `--repo` resolves via the same path as `list --repo` / `refs --repo` (RepoStore).
- [x] Empty-state: prints `No merged PRs in range.` or CSV-header-only, exit 0.
- [x] Missing-deps: prints hint pointing at `ohtv db process all` + `ohtv fetch-loc`, exit 0.
- [x] No new migration; uses existing 016/017 schema.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/450921e9-0f8f-457f-a0a2-31421a65202f)