### PR TITLE
feat: add ohtv classify command (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,67 @@ ohtv list --errors-only --week
 
 ---
 
+### `ohtv classify` - Classify Conversation Source
+
+Populates `conversation_human_input.initial_prompt_source` (default `unknown`)
+with one of `human` | `automation` | `unknown`. The classification is a
+prerequisite for accurate human-vs-automation breakdowns in
+`ohtv report velocity` and other downstream metrics.
+
+The command has three behavior modes - single-conversation override, read-only
+discovery, and bulk heuristic with a `--confirm` safety gate. **Bulk
+operations only ever touch rows currently set to `unknown`**, so prior manual
+overrides are never clobbered by a re-run.
+
+```bash
+# 1) Discovery - list conversations still classified as unknown.
+ohtv classify --list-unknown                            # rich table
+ohtv classify --list-unknown -1                         # one short_id per line (pipe-friendly)
+ohtv classify --list-unknown --repo openhands/openhands # narrow by repo
+
+# 2) Single-conversation override (no --confirm needed).
+ohtv classify abc12345 --source human                   # mark one as human
+ohtv classify abc12345 --source automation              # override an earlier human flag
+ohtv classify abc12345 --source unknown                 # reset
+
+# 3) Bulk heuristic - preview, then apply with --confirm.
+ohtv classify --no-followups --source automation                # preview: "Would classify N..."
+ohtv classify --no-followups --source automation --confirm      # actually write
+ohtv classify --has-followups --source human --confirm          # symmetric heuristic
+
+# 4) Bulk narrowed by repo (writes only matching conversations).
+ohtv classify --no-followups --source automation --repo foo/bar --confirm
+
+# 5) Pipe -1 output back into single-conv classification for ad-hoc batches.
+ohtv classify --list-unknown -1 | head -5 | xargs -I {} \
+  ohtv classify {} --source human
+```
+
+**Output formats** (`--list-unknown` only): `table` (default), `lines` /
+`-1`, `csv`, `json`. Machine-readable formats suppress Rich decoration so
+the output is safe to pipe.
+
+**Heuristic semantics:**
+
+- `--no-followups` -> rows with `followup_message_count = 0`. These ran to
+  completion without mid-flight human steering and are most likely
+  orchestrator-spawned automation workers.
+- `--has-followups` -> rows with `followup_message_count >= 1`. These had a
+  human in the loop and are most likely human-initiated.
+
+The heuristics are imperfect by design (an orchestrator may steer mid-run; a
+human may one-shot a prompt). The single-conversation override path is the
+intended way to correct individual misclassifications.
+
+**Refusing on missing rows:** If you run `ohtv classify <id> --source human`
+against a conversation that does not yet have a row in
+`conversation_human_input`, the command refuses with an actionable hint to
+run `ohtv db process human_input` first. Silent inserts would mask an
+unfinished ingestion pipeline and would distort downstream LOC + velocity
+metrics that assume the row reflects the actual events.
+
+---
+
 ### `ohtv gen` - LLM Generation Commands
 
 The `gen` command provides LLM-powered analysis of conversations using customizable prompts. Currently supports `objs` analysis with multiple variants and context levels.

--- a/src/ohtv/classify.py
+++ b/src/ohtv/classify.py
@@ -1,0 +1,424 @@
+"""Conversation classification helpers.
+
+Populates ``conversation_human_input.initial_prompt_source`` (created by
+migration 016, defaulted to ``'unknown'``) with one of
+``'human' | 'automation' | 'unknown'``.
+
+This is the pure data-layer module backing ``ohtv classify``. It has no
+Click / Rich dependencies so it can be unit-tested directly against an
+in-memory SQLite connection with the migration chain replayed, and so
+future reports (#81 velocity, #82 charting, a follow-up
+``ohtv report classification``) can reuse the same helpers without
+pulling in CLI plumbing.
+
+Design notes (issue #83):
+
+* **Bulk operations only touch ``initial_prompt_source = 'unknown'`` rows.**
+  Manual single-conversation overrides are the only path that may flip an
+  already-classified row. This is what makes ``--no-followups`` /
+  ``--has-followups`` safe to run more than once: re-running reports
+  ``0`` changed instead of clobbering prior overrides.
+
+* **Conversation IDs are normalised (dashes stripped) before any DB
+  lookup**, per AGENTS.md item #14. The DB stores IDs without dashes;
+  callers may pass either form.
+
+* **Missing ``conversation_human_input`` rows are refused, not stubbed.**
+  If the ``human_input`` stage has not yet run for a given conversation,
+  ``set_single`` raises :class:`MissingHumanInputRowError` with an
+  actionable message. Silent inserts would mask the real issue (the
+  ingestion pipeline didn't finish) and would also be a footgun for
+  downstream LOC fetching (#80) and the velocity report (#81), both of
+  which assume the row's word counts reflect the actual events.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Literal
+
+# Allowed values for ``initial_prompt_source``. Mirrors the
+# ``CHECK(initial_prompt_source IN (...))`` constraint in migration 016
+# so callers can ``from ohtv.classify import VALID_SOURCES`` and feed it
+# straight into ``click.Choice``.
+VALID_SOURCES: tuple[str, ...] = ("human", "automation", "unknown")
+
+Source = Literal["human", "automation", "unknown"]
+
+# Heuristic filter names. Kept as string constants (not an enum) for
+# easy use as Click ``flag_value`` and clean error messages.
+FILTER_NO_FOLLOWUPS = "no_followups"
+FILTER_HAS_FOLLOWUPS = "has_followups"
+HeuristicFilter = Literal["no_followups", "has_followups"]
+
+
+class ClassifyError(Exception):
+    """Base class for classification errors raised by this module."""
+
+
+class MissingHumanInputRowError(ClassifyError):
+    """Raised by :func:`set_single` when no human-input row exists yet."""
+
+    def __init__(self, conversation_id: str) -> None:
+        self.conversation_id = conversation_id
+        super().__init__(
+            f"No conversation_human_input row for conversation {conversation_id!r}. "
+            "Run 'ohtv db process human_input' first."
+        )
+
+
+class InvalidSourceError(ClassifyError):
+    """Raised when a caller passes a ``source`` outside :data:`VALID_SOURCES`."""
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+        super().__init__(
+            f"Invalid --source value {source!r}; must be one of {VALID_SOURCES!r}."
+        )
+
+
+@dataclass(frozen=True)
+class UnknownRow:
+    """One conversation still classified as ``'unknown'``.
+
+    ``repo`` is the FQN (``owner/repo``) of the lexicographically first
+    linked repository, or ``None`` if the conversation has no repo links.
+    The lex-first choice keeps the output stable without committing to a
+    particular ordering semantic; downstream consumers that need
+    multi-repo handling should query the DB directly.
+    """
+
+    conversation_id: str
+    short_id: str
+    created_at: str | None
+    repo: str | None
+    followup_message_count: int
+    title: str | None
+
+
+@dataclass(frozen=True)
+class SingleResult:
+    """Outcome of :func:`set_single`."""
+
+    conversation_id: str
+    previous_source: str
+    new_source: str
+    changed: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_conv_id(conv_id: str) -> str:
+    """Strip dashes from a conversation ID (per AGENTS.md item #14)."""
+    return conv_id.replace("-", "")
+
+
+def _validate_source(source: str) -> None:
+    if source not in VALID_SOURCES:
+        raise InvalidSourceError(source)
+
+
+def _followups_predicate(filter_: HeuristicFilter) -> str:
+    """Return the SQL predicate fragment for a heuristic filter.
+
+    Raises ``ValueError`` for an unknown filter so we never silently
+    construct an empty WHERE clause that would match everything.
+    """
+    if filter_ == FILTER_NO_FOLLOWUPS:
+        return "followup_message_count = 0"
+    if filter_ == FILTER_HAS_FOLLOWUPS:
+        return "followup_message_count >= 1"
+    raise ValueError(
+        f"Unknown heuristic filter {filter_!r}; expected one of "
+        f"({FILTER_NO_FOLLOWUPS!r}, {FILTER_HAS_FOLLOWUPS!r})."
+    )
+
+
+def _repo_ids_for_filter(
+    conn: sqlite3.Connection, repo_filter: str
+) -> tuple[list[int], list[str]]:
+    """Resolve a ``--repo`` filter to a list of ``repositories.id`` values.
+
+    Mirrors :func:`ohtv.filters.get_conversation_ids_for_repo` but stays
+    inside the provided connection (the unit tests run against in-memory
+    DBs, not the user's ``~/.ohtv/index.db``).
+
+    The match strategy is intentionally narrow:
+
+    * If the filter contains ``://`` we treat it as a canonical URL and
+      match it exactly.
+    * Otherwise we match against ``fqn`` (``owner/repo``) exactly first,
+      and fall back to ``short_name`` (``repo``) — both as exact matches.
+      Substring / glob matching is not supported here on purpose so
+      bulk writes can never widen unexpectedly.
+
+    Returns ``(repo_ids, matched_fqns)``. Empty lists mean "no repos
+    matched"; callers should treat this as a no-op rather than as "all
+    repos".
+    """
+    pattern = repo_filter.strip()
+    if not pattern:
+        return [], []
+
+    if "://" in pattern:
+        cur = conn.execute(
+            "SELECT id, fqn FROM repositories WHERE canonical_url = ?",
+            (pattern,),
+        )
+    elif "/" in pattern:
+        cur = conn.execute(
+            "SELECT id, fqn FROM repositories WHERE fqn = ?",
+            (pattern,),
+        )
+    else:
+        cur = conn.execute(
+            "SELECT id, fqn FROM repositories WHERE short_name = ?",
+            (pattern,),
+        )
+
+    rows = cur.fetchall()
+    if not rows:
+        return [], []
+
+    ids: list[int] = []
+    fqns: list[str] = []
+    for row in rows:
+        # Support both Row and tuple cursors.
+        ids.append(row["id"] if isinstance(row, sqlite3.Row) else row[0])
+        fqns.append(row["fqn"] if isinstance(row, sqlite3.Row) else row[1])
+    return ids, fqns
+
+
+def _repo_subselect_clause(repo_ids: list[int]) -> tuple[str, list[int]]:
+    """Build ``AND conversation_id IN (...)`` for a non-empty repo set.
+
+    Returns ``("", [])`` for an empty repo set; callers should then
+    short-circuit to a 0-row result rather than emit the clause and
+    accidentally match every row.
+    """
+    if not repo_ids:
+        return "", []
+    placeholders = ",".join("?" for _ in repo_ids)
+    clause = (
+        " AND chi.conversation_id IN ("
+        f"SELECT conversation_id FROM conversation_repos WHERE repo_id IN ({placeholders})"
+        ")"
+    )
+    return clause, list(repo_ids)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def count_matching(
+    conn: sqlite3.Connection,
+    *,
+    filter_: HeuristicFilter,
+    repo: str | None = None,
+) -> int:
+    """Count rows a bulk apply with ``filter_`` would touch.
+
+    Always restricted to ``initial_prompt_source = 'unknown'`` so the
+    count matches the row count that
+    :func:`apply_classification` would actually change.
+
+    ``repo`` follows the same narrow exact-match rules as
+    :func:`_repo_ids_for_filter`; an unknown repo yields ``0``.
+    """
+    predicate = _followups_predicate(filter_)
+
+    repo_ids: list[int] = []
+    if repo is not None:
+        repo_ids, matched = _repo_ids_for_filter(conn, repo)
+        if not matched:
+            return 0
+
+    repo_clause, repo_params = _repo_subselect_clause(repo_ids)
+
+    sql = (
+        f"SELECT COUNT(*) FROM conversation_human_input chi "
+        f"WHERE initial_prompt_source = 'unknown' AND {predicate}{repo_clause}"
+    )
+    cur = conn.execute(sql, repo_params)
+    return int(cur.fetchone()[0])
+
+
+def apply_classification(
+    conn: sqlite3.Connection,
+    *,
+    filter_: HeuristicFilter,
+    source: Source,
+    repo: str | None = None,
+) -> int:
+    """Apply ``source`` to all rows matching ``filter_``.
+
+    Only updates rows where ``initial_prompt_source = 'unknown'`` —
+    manual overrides are preserved. Returns the number of rows actually
+    changed (which is ``0`` on a second identical run, by construction).
+    """
+    _validate_source(source)
+    predicate = _followups_predicate(filter_)
+
+    repo_ids: list[int] = []
+    if repo is not None:
+        repo_ids, matched = _repo_ids_for_filter(conn, repo)
+        if not matched:
+            return 0
+
+    repo_clause, repo_params = _repo_subselect_clause(repo_ids)
+
+    sql = (
+        f"UPDATE conversation_human_input AS chi "
+        f"SET initial_prompt_source = ? "
+        f"WHERE initial_prompt_source = 'unknown' AND {predicate}{repo_clause}"
+    )
+    cur = conn.execute(sql, [source, *repo_params])
+    conn.commit()
+    return cur.rowcount or 0
+
+
+def set_single(
+    conn: sqlite3.Connection,
+    *,
+    conversation_id: str,
+    source: Source,
+) -> SingleResult:
+    """Override a single conversation's ``initial_prompt_source``.
+
+    Unlike :func:`apply_classification`, this CAN flip an already-classified
+    row (it is the manual override path). It refuses to act if no
+    ``conversation_human_input`` row exists yet — see the module
+    docstring for the rationale.
+    """
+    _validate_source(source)
+
+    normalized = _normalize_conv_id(conversation_id)
+
+    cur = conn.execute(
+        "SELECT initial_prompt_source FROM conversation_human_input "
+        "WHERE conversation_id = ?",
+        (normalized,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise MissingHumanInputRowError(normalized)
+    previous = row["initial_prompt_source"] if isinstance(row, sqlite3.Row) else row[0]
+
+    if previous == source:
+        return SingleResult(
+            conversation_id=normalized,
+            previous_source=previous,
+            new_source=source,
+            changed=False,
+        )
+
+    conn.execute(
+        "UPDATE conversation_human_input SET initial_prompt_source = ? "
+        "WHERE conversation_id = ?",
+        (source, normalized),
+    )
+    conn.commit()
+    return SingleResult(
+        conversation_id=normalized,
+        previous_source=previous,
+        new_source=source,
+        changed=True,
+    )
+
+
+def list_unknown(
+    conn: sqlite3.Connection,
+    *,
+    repo: str | None = None,
+    limit: int | None = None,
+) -> list[UnknownRow]:
+    """List conversations still classified as ``'unknown'``.
+
+    Sorted by ``conversations.created_at DESC`` so the most recent
+    unclassified conversations show up first. ``NULL`` ``created_at``
+    sorts to the end. Optional ``limit`` caps the result count.
+
+    Joining ``conversation_repos`` with ``MIN(fqn)`` gives a stable
+    single-repo display value even when a conversation touched multiple
+    repos. Multi-repo conversations are still common but the table is
+    primarily a "which one do I want to override next?" surface, not an
+    authoritative repo listing.
+    """
+    repo_ids: list[int] = []
+    if repo is not None:
+        repo_ids, matched = _repo_ids_for_filter(conn, repo)
+        if not matched:
+            return []
+
+    repo_clause, repo_params = _repo_subselect_clause(repo_ids)
+
+    sql = f"""
+        SELECT
+            chi.conversation_id AS conversation_id,
+            chi.followup_message_count AS followup_message_count,
+            c.created_at AS created_at,
+            c.title AS title,
+            (
+                SELECT MIN(r.fqn)
+                FROM conversation_repos cr
+                JOIN repositories r ON r.id = cr.repo_id
+                WHERE cr.conversation_id = chi.conversation_id
+            ) AS repo_fqn
+        FROM conversation_human_input chi
+        LEFT JOIN conversations c ON c.id = chi.conversation_id
+        WHERE chi.initial_prompt_source = 'unknown'{repo_clause}
+        ORDER BY c.created_at IS NULL, c.created_at DESC, chi.conversation_id
+    """
+    if limit is not None:
+        sql += " LIMIT ?"
+        repo_params = [*repo_params, int(limit)]
+
+    cur = conn.execute(sql, repo_params)
+    out: list[UnknownRow] = []
+    for row in cur.fetchall():
+        conv_id = (
+            row["conversation_id"]
+            if isinstance(row, sqlite3.Row)
+            else row[0]
+        )
+        out.append(
+            UnknownRow(
+                conversation_id=conv_id,
+                short_id=conv_id[:8],
+                followup_message_count=(
+                    row["followup_message_count"]
+                    if isinstance(row, sqlite3.Row)
+                    else row[1]
+                ),
+                created_at=(
+                    row["created_at"] if isinstance(row, sqlite3.Row) else row[2]
+                ),
+                title=row["title"] if isinstance(row, sqlite3.Row) else row[3],
+                repo=row["repo_fqn"] if isinstance(row, sqlite3.Row) else row[4],
+            )
+        )
+    return out
+
+
+__all__ = [
+    "ClassifyError",
+    "FILTER_HAS_FOLLOWUPS",
+    "FILTER_NO_FOLLOWUPS",
+    "HeuristicFilter",
+    "InvalidSourceError",
+    "MissingHumanInputRowError",
+    "SingleResult",
+    "Source",
+    "UnknownRow",
+    "VALID_SOURCES",
+    "apply_classification",
+    "count_matching",
+    "list_unknown",
+    "set_single",
+]

--- a/src/ohtv/classify.py
+++ b/src/ohtv/classify.py
@@ -58,13 +58,54 @@ class ClassifyError(Exception):
 
 
 class MissingHumanInputRowError(ClassifyError):
-    """Raised by :func:`set_single` when no human-input row exists yet."""
+    """Raised by :func:`set_single` when no human-input row exists yet.
+
+    Distinct from :class:`NoSuchConversationError`: the conversation row
+    exists in ``conversations``, but the ``human_input`` processing stage
+    has not produced a ``conversation_human_input`` row for it yet.
+    """
 
     def __init__(self, conversation_id: str) -> None:
         self.conversation_id = conversation_id
         super().__init__(
             f"No conversation_human_input row for conversation {conversation_id!r}. "
             "Run 'ohtv db process human_input' first."
+        )
+
+
+class NoSuchConversationError(ClassifyError):
+    """Raised when a conversation ID (or short prefix) matches no row.
+
+    Distinct from :class:`MissingHumanInputRowError`: the conversation
+    itself isn't indexed in ``conversations``, so the caller most likely
+    has a typo or hasn't run ``ohtv db scan`` yet.
+    """
+
+    def __init__(self, conversation_id: str) -> None:
+        self.conversation_id = conversation_id
+        super().__init__(
+            f"No such conversation {conversation_id!r}. "
+            "Check the ID or run 'ohtv db scan' to index new conversations."
+        )
+
+
+class AmbiguousConversationIdError(ClassifyError):
+    """Raised when a short-ID prefix matches more than one conversation.
+
+    Mirrors the convention used by ``_find_conversation_dir`` (AGENTS.md
+    item #14): callers may pass a unique prefix, but ambiguous prefixes
+    must be rejected loudly so they don't silently target the wrong row.
+    """
+
+    def __init__(self, conversation_id: str, matches: list[str]) -> None:
+        self.conversation_id = conversation_id
+        self.matches = matches
+        sample = ", ".join(m[:12] for m in matches[:5])
+        more = f" (+{len(matches) - 5} more)" if len(matches) > 5 else ""
+        super().__init__(
+            f"Ambiguous conversation ID {conversation_id!r}: "
+            f"{len(matches)} matches ({sample}{more}). "
+            "Provide more characters."
         )
 
 
@@ -115,6 +156,50 @@ class SingleResult:
 def _normalize_conv_id(conv_id: str) -> str:
     """Strip dashes from a conversation ID (per AGENTS.md item #14)."""
     return conv_id.replace("-", "")
+
+
+def _resolve_conversation_id(
+    conn: sqlite3.Connection, conv_id: str
+) -> str:
+    """Resolve a possibly-short conversation ID to its full DB form.
+
+    Accepts either a full 32-char ID (with or without dashes) or a unique
+    short prefix, mirroring ``_find_conversation_dir`` (AGENTS.md item
+    #14). Returns the full normalised ID on success.
+
+    Raises:
+        NoSuchConversationError: no row in ``conversations`` matches the
+            input (typo, fabricated ID, or ``db scan`` hasn't run yet).
+        AmbiguousConversationIdError: the input is a prefix that matches
+            more than one conversation; caller should pass more chars.
+    """
+    normalized = _normalize_conv_id(conv_id)
+
+    # Fast path: exact match. Cheap and unambiguous for full IDs.
+    cur = conn.execute(
+        "SELECT id FROM conversations WHERE id = ?",
+        (normalized,),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        return row["id"] if isinstance(row, sqlite3.Row) else row[0]
+
+    # Prefix path: LIKE 'prefix%' for short-ID lookup. SQLite escapes the
+    # ``%`` only inside the literal, so a literal ``%`` in the prefix
+    # would be unusual but technically broaden the match — guard against
+    # it by escaping. Hex-only IDs in practice means this is paranoia.
+    safe_prefix = normalized.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    cur = conn.execute(
+        "SELECT id FROM conversations WHERE id LIKE ? ESCAPE '\\' LIMIT 11",
+        (safe_prefix + "%",),
+    )
+    matches = [r["id"] if isinstance(r, sqlite3.Row) else r[0] for r in cur.fetchall()]
+
+    if not matches:
+        raise NoSuchConversationError(conv_id)
+    if len(matches) > 1:
+        raise AmbiguousConversationIdError(conv_id, matches)
+    return matches[0]
 
 
 def _validate_source(source: str) -> None:
@@ -295,10 +380,22 @@ def set_single(
     row (it is the manual override path). It refuses to act if no
     ``conversation_human_input`` row exists yet — see the module
     docstring for the rationale.
+
+    Accepts a full 32-char conversation ID (with or without dashes) or a
+    unique short prefix (mirrors ``_find_conversation_dir``; AGENTS.md
+    item #14). Raises :class:`NoSuchConversationError` if the input
+    matches no conversation, or :class:`AmbiguousConversationIdError` if
+    it matches more than one — these are distinct from
+    :class:`MissingHumanInputRowError`, which means the conversation
+    exists but the ``human_input`` stage hasn't run for it.
     """
     _validate_source(source)
 
-    normalized = _normalize_conv_id(conversation_id)
+    # Resolve first so "no such conversation" is a distinct error from
+    # "human_input stage hasn't run". This is what makes the README's
+    # ``classify --list-unknown -1 | head -5 | xargs ohtv classify {}``
+    # pipeline work: ``-1`` emits 8-char short IDs.
+    normalized = _resolve_conversation_id(conn, conversation_id)
 
     cur = conn.execute(
         "SELECT initial_prompt_source FROM conversation_human_input "

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10076,6 +10076,345 @@ def _display_aggregate_results_table(
 
 
 # =============================================================================
+# Classify — populate conversation_human_input.initial_prompt_source (Issue #83)
+# =============================================================================
+
+
+@main.command("classify")
+@click.argument("conversation_id", required=False)
+@click.option(
+    "--source",
+    "source",
+    type=click.Choice(["human", "automation", "unknown"]),
+    help="Target classification value.",
+)
+@click.option(
+    "--list-unknown",
+    "list_unknown_flag",
+    is_flag=True,
+    help="List conversations with source='unknown' and exit (read-only).",
+)
+@click.option(
+    "--no-followups",
+    "no_followups",
+    is_flag=True,
+    help="Bulk filter: rows where followup_message_count = 0.",
+)
+@click.option(
+    "--has-followups",
+    "has_followups",
+    is_flag=True,
+    help="Bulk filter: rows where followup_message_count >= 1.",
+)
+@click.option(
+    "--repo",
+    "repo_filter",
+    help="Restrict to conversations linked to OWNER/REPO (or short repo name).",
+)
+@click.option(
+    "--confirm",
+    "confirm",
+    is_flag=True,
+    help="Required to actually write in bulk mode. Single-conv mode does not need this.",
+)
+@click.option(
+    "-1",
+    "one_per_line",
+    is_flag=True,
+    help="Shorthand for --format lines (one short_id per line, no decoration).",
+)
+@click.option(
+    "--format",
+    "-F",
+    "fmt",
+    type=click.Choice(["table", "lines", "csv", "json"]),
+    default=None,
+    help="Output format for --list-unknown (default: table).",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Show debug output.")
+def classify(
+    conversation_id: str | None,
+    source: str | None,
+    list_unknown_flag: bool,
+    no_followups: bool,
+    has_followups: bool,
+    repo_filter: str | None,
+    confirm: bool,
+    one_per_line: bool,
+    fmt: str | None,
+    verbose: bool,
+) -> None:
+    """Classify the initial_prompt_source of conversations.
+
+    \b
+    Three behavior modes (mutually exclusive):
+
+    \b
+      1. Single-conversation override (no --confirm needed):
+         ohtv classify <id> --source human|automation|unknown
+         CAN flip an already-classified row (it is the override path).
+
+    \b
+      2. Discovery / listing (read-only):
+         ohtv classify --list-unknown [--repo OWNER/REPO]
+         ohtv classify --list-unknown -1     # one short_id per line
+
+    \b
+      3. Bulk heuristic (requires --confirm to write):
+         ohtv classify --no-followups --source automation --confirm
+         ohtv classify --has-followups --source human --confirm
+         Bulk operations ONLY touch rows where initial_prompt_source =
+         'unknown' so prior manual overrides are preserved. Without
+         --confirm, the command prints a preview count and exits 0
+         without writing.
+
+    \b
+    All modes accept --repo to narrow by repository (OWNER/REPO, short
+    name, or canonical URL), matching the behavior of ohtv list / refs.
+    """
+    _init_logging(verbose=verbose)
+
+    # Local import to keep CLI startup snappy and break any circular risk.
+    from ohtv import classify as classify_mod
+    from ohtv.db import get_connection
+    from ohtv.filters import is_db_available
+
+    # -1 shorthand
+    if one_per_line:
+        fmt = "lines"
+
+    # ------------------------------------------------------------------
+    # Mutual-exclusion checks (in the command body for friendly errors,
+    # not via Click constraints).
+    # ------------------------------------------------------------------
+    if no_followups and has_followups:
+        console.print(
+            "[red]Error:[/red] --no-followups and --has-followups are mutually exclusive."
+        )
+        raise SystemExit(1)
+
+    has_bulk_filter = no_followups or has_followups
+
+    if conversation_id and (has_bulk_filter or list_unknown_flag):
+        console.print(
+            "[red]Error:[/red] CONVERSATION_ID cannot be combined with "
+            "--list-unknown or --no-followups/--has-followups."
+        )
+        raise SystemExit(1)
+
+    if list_unknown_flag and has_bulk_filter:
+        console.print(
+            "[red]Error:[/red] --list-unknown cannot be combined with "
+            "--no-followups/--has-followups."
+        )
+        raise SystemExit(1)
+
+    # ------------------------------------------------------------------
+    # Mode dispatch
+    # ------------------------------------------------------------------
+    if not is_db_available():
+        console.print(
+            "[yellow]Warning:[/yellow] Database not initialized. "
+            "Run 'ohtv db scan && ohtv db process all' first."
+        )
+        raise SystemExit(1)
+
+    if conversation_id:
+        _classify_single(classify_mod, get_connection, conversation_id, source)
+        return
+
+    if list_unknown_flag:
+        _classify_list_unknown(
+            classify_mod, get_connection, repo=repo_filter, fmt=fmt
+        )
+        return
+
+    if has_bulk_filter:
+        filter_name = (
+            classify_mod.FILTER_NO_FOLLOWUPS
+            if no_followups
+            else classify_mod.FILTER_HAS_FOLLOWUPS
+        )
+        _classify_bulk(
+            classify_mod,
+            get_connection,
+            filter_name=filter_name,
+            source=source,
+            repo=repo_filter,
+            confirm=confirm,
+        )
+        return
+
+    # No usable mode — show a friendly hint.
+    console.print(
+        "[yellow]Usage:[/yellow] Provide a conversation ID, --list-unknown, "
+        "or one of --no-followups / --has-followups."
+    )
+    console.print()
+    console.print("Examples:")
+    console.print("  ohtv classify abc123 --source human")
+    console.print("  ohtv classify --list-unknown -1")
+    console.print("  ohtv classify --no-followups --source automation --confirm")
+    console.print()
+    console.print("Run [bold]ohtv classify --help[/bold] for full options.")
+    raise SystemExit(1)
+
+
+def _classify_single(
+    classify_mod, get_connection, conversation_id: str, source: str | None
+) -> None:
+    """Handle single-conversation override mode."""
+    if source is None:
+        console.print(
+            "[red]Error:[/red] --source is required when classifying a single conversation."
+        )
+        raise SystemExit(1)
+
+    try:
+        with get_connection() as conn:
+            result = classify_mod.set_single(
+                conn, conversation_id=conversation_id, source=source
+            )
+    except classify_mod.MissingHumanInputRowError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(2) from exc
+
+    if result.changed:
+        console.print(
+            f"Set [bold]{result.conversation_id[:8]}[/bold] "
+            f"initial_prompt_source: {result.previous_source} -> "
+            f"[green]{result.new_source}[/green]"
+        )
+    else:
+        console.print(
+            f"No change: [bold]{result.conversation_id[:8]}[/bold] "
+            f"is already '{result.new_source}'."
+        )
+
+
+def _classify_bulk(
+    classify_mod,
+    get_connection,
+    *,
+    filter_name: str,
+    source: str | None,
+    repo: str | None,
+    confirm: bool,
+) -> None:
+    """Handle bulk-heuristic mode (preview + optional --confirm apply)."""
+    if source is None:
+        console.print(
+            "[red]Error:[/red] --source is required with --no-followups / --has-followups."
+        )
+        raise SystemExit(1)
+
+    filter_label = (
+        "--no-followups"
+        if filter_name == classify_mod.FILTER_NO_FOLLOWUPS
+        else "--has-followups"
+    )
+
+    with get_connection() as conn:
+        if not confirm:
+            count = classify_mod.count_matching(
+                conn, filter_=filter_name, repo=repo
+            )
+            console.print(
+                f"Would classify [bold]{count}[/bold] conversation(s) as "
+                f"[green]{source!r}[/green] (filter: {filter_label})."
+            )
+            if count > 0:
+                console.print("Add [bold]--confirm[/bold] to apply.")
+            return
+
+        changed = classify_mod.apply_classification(
+            conn, filter_=filter_name, source=source, repo=repo
+        )
+
+    console.print(
+        f"Classified [bold]{changed}[/bold] conversation(s) as "
+        f"[green]{source!r}[/green] (filter: {filter_label})."
+    )
+
+
+def _classify_list_unknown(
+    classify_mod, get_connection, *, repo: str | None, fmt: str | None
+) -> None:
+    """Handle --list-unknown read-only mode."""
+    fmt = fmt or "table"
+    with get_connection() as conn:
+        rows = classify_mod.list_unknown(conn, repo=repo)
+
+    if fmt == "lines":
+        # Machine-readable: one short_id per line, no Rich decoration.
+        import sys
+
+        for r in rows:
+            sys.stdout.write(r.short_id + "\n")
+        return
+
+    if fmt == "csv":
+        import sys
+
+        writer = csv.writer(sys.stdout)
+        writer.writerow(
+            ["conversation_id", "short_id", "created_at", "repo", "followups", "title"]
+        )
+        for r in rows:
+            writer.writerow(
+                [
+                    r.conversation_id,
+                    r.short_id,
+                    r.created_at or "",
+                    r.repo or "",
+                    r.followup_message_count,
+                    r.title or "",
+                ]
+            )
+        return
+
+    if fmt == "json":
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "conversation_id": r.conversation_id,
+                        "short_id": r.short_id,
+                        "created_at": r.created_at,
+                        "repo": r.repo,
+                        "followup_message_count": r.followup_message_count,
+                        "title": r.title,
+                    }
+                    for r in rows
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    # table (default)
+    if not rows:
+        console.print("[dim]No conversations classified as 'unknown'.[/dim]")
+        return
+
+    table = Table(title="Unknown-source conversations", show_lines=False)
+    table.add_column("short_id", style="bold")
+    table.add_column("created_at")
+    table.add_column("repo")
+    table.add_column("followups", justify="right")
+    table.add_column("title")
+    for r in rows:
+        table.add_row(
+            r.short_id,
+            r.created_at or "",
+            r.repo or "-",
+            str(r.followup_message_count),
+            r.title or "",
+        )
+    console.print(table)
+
+
+# =============================================================================
 # Reports — weekly aggregates for research analysis (Issue #81+)
 # =============================================================================
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10275,6 +10275,15 @@ def _classify_single(
             result = classify_mod.set_single(
                 conn, conversation_id=conversation_id, source=source
             )
+    except classify_mod.NoSuchConversationError as exc:
+        # Distinct from MissingHumanInputRowError: the conversation row
+        # itself doesn't exist in `conversations` (typo / fabricated ID
+        # / `db scan` hasn't run yet).
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(2) from exc
+    except classify_mod.AmbiguousConversationIdError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(2) from exc
     except classify_mod.MissingHumanInputRowError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise SystemExit(2) from exc

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -1,0 +1,461 @@
+"""Unit tests for :mod:`ohtv.classify` (issue #83).
+
+Test plan mapping (numbering matches the technical-approach comment on
+issue #83):
+
+* test #1 — :class:`TestCountMatching.test_count_matching_no_followups`
+* test #2 — :class:`TestCountMatching.test_count_matching_has_followups`
+* test #3 — :class:`TestCountMatching.test_count_matching_with_repo_filter`
+* test #4 — :class:`TestApplyClassification.test_apply_classification_idempotent`
+* test #5 — :class:`TestApplyClassification.test_apply_classification_only_touches_unknowns`
+* test #6 — :class:`TestSetSingle.test_set_single_conversation`
+* test #7 — :class:`TestSetSingle.test_set_single_conversation_missing_row`
+* test #8 — :class:`TestListUnknown.test_list_unknown_with_repo_filter`
+
+Acceptance criterion mapping (issue body checklist → test):
+
+* AC1 (single-conv override, no --confirm) → test #6
+* AC2 (single-conv idempotency) → also test #6
+  (CLI smoke #13 covers the no-confirm path end-to-end)
+* AC3 (--list-unknown + --repo + machine-readable) → test #8
+* AC4 (bulk preview, no writes) → CLI smoke #11
+* AC5 (bulk apply --confirm) → test #5 + CLI smoke #12
+* AC6 (--has-followups --confirm) → test #2 + extension of test #5
+* AC7 (--repo narrows both bulk and --list-unknown) → test #3 + test #8
+* AC8 (missing conversation_human_input row handled gracefully) → test #7
+* AC9 (invalid --source rejected) → CLI smoke #10
+* AC10 (heuristic SQL + --confirm gate covered by tests) → all of the above
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from ohtv.classify import (
+    FILTER_HAS_FOLLOWUPS,
+    FILTER_NO_FOLLOWUPS,
+    InvalidSourceError,
+    MissingHumanInputRowError,
+    apply_classification,
+    count_matching,
+    list_unknown,
+    set_single,
+)
+from ohtv.db.migrations import migrate
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    """In-memory DB with the full migration chain replayed.
+
+    This is the same pattern used by tests/unit/db/stages/test_human_input.py
+    and is the repo convention — we do NOT mock the database.
+    """
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA foreign_keys = ON")
+    migrate(c)
+    yield c
+    c.close()
+
+
+def _insert_conversation(
+    conn: sqlite3.Connection,
+    conv_id: str,
+    *,
+    title: str = "test conv",
+    created_at: str | None = None,
+    location: str = "/tmp/fake",
+    event_count: int = 1,
+) -> None:
+    """Insert a row into ``conversations``. ID is stored normalised."""
+    if created_at is None:
+        created_at = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO conversations (id, location, event_count, title, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (conv_id, location, event_count, title, created_at),
+    )
+
+
+def _insert_human_input(
+    conn: sqlite3.Connection,
+    conv_id: str,
+    *,
+    initial_prompt_words: int = 5,
+    followup_word_count: int = 0,
+    followup_message_count: int = 0,
+    initial_prompt_source: str = "unknown",
+    event_count: int = 1,
+) -> None:
+    """Insert a row into ``conversation_human_input``."""
+    conn.execute(
+        """
+        INSERT INTO conversation_human_input (
+            conversation_id,
+            initial_prompt_words,
+            initial_prompt_source,
+            followup_word_count,
+            followup_message_count,
+            processed_at,
+            event_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            conv_id,
+            initial_prompt_words,
+            initial_prompt_source,
+            followup_word_count,
+            followup_message_count,
+            "2024-06-01T12:00:00+00:00",
+            event_count,
+        ),
+    )
+
+
+def _insert_repo(
+    conn: sqlite3.Connection,
+    *,
+    canonical_url: str,
+    fqn: str,
+    short_name: str,
+) -> int:
+    """Insert a repository and return its id."""
+    cur = conn.execute(
+        "INSERT INTO repositories (canonical_url, fqn, short_name) "
+        "VALUES (?, ?, ?) RETURNING id",
+        (canonical_url, fqn, short_name),
+    )
+    return cur.fetchone()[0]
+
+
+def _link_conv_to_repo(
+    conn: sqlite3.Connection,
+    conv_id: str,
+    repo_id: int,
+    *,
+    link_type: str = "write",
+) -> None:
+    conn.execute(
+        "INSERT INTO conversation_repos (conversation_id, repo_id, link_type) "
+        "VALUES (?, ?, ?)",
+        (conv_id, repo_id, link_type),
+    )
+
+
+def _seed_simple_followups_mix(conn: sqlite3.Connection) -> None:
+    """Three convs with 0 followups, two with >=1 followup.
+
+    Used by both ``count_matching`` test #1 and #2 to keep the fixture
+    minimal and the expected counts obvious.
+    """
+    # 0 followups (3 convs)
+    for i in range(3):
+        cid = f"nofu{i:028d}"
+        _insert_conversation(conn, cid, title=f"no-fu {i}")
+        _insert_human_input(conn, cid, followup_message_count=0)
+    # >=1 followup (2 convs)
+    for i in range(2):
+        cid = f"hasfu{i:027d}"
+        _insert_conversation(conn, cid, title=f"has-fu {i}")
+        _insert_human_input(conn, cid, followup_message_count=i + 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCountMatching:
+    """Tests #1, #2, #3."""
+
+    def test_count_matching_no_followups(self, conn):
+        """Test #1: filter='no_followups' counts the 0-followup unknowns."""
+        _seed_simple_followups_mix(conn)
+        assert count_matching(conn, filter_=FILTER_NO_FOLLOWUPS) == 3
+
+    def test_count_matching_has_followups(self, conn):
+        """Test #2: filter='has_followups' counts the >=1-followup unknowns."""
+        _seed_simple_followups_mix(conn)
+        assert count_matching(conn, filter_=FILTER_HAS_FOLLOWUPS) == 2
+
+    def test_count_matching_with_repo_filter(self, conn):
+        """Test #3: --repo narrows the bulk count.
+
+        Three no-followup convs exist; only one is linked to ``foo/bar``,
+        so ``--repo foo/bar`` should report 1.
+        """
+        _seed_simple_followups_mix(conn)
+        repo_id = _insert_repo(
+            conn,
+            canonical_url="https://github.com/foo/bar",
+            fqn="foo/bar",
+            short_name="bar",
+        )
+        # Link only the first no-followup conv to foo/bar.
+        _link_conv_to_repo(conn, "nofu" + "0".zfill(28), repo_id)
+
+        assert (
+            count_matching(conn, filter_=FILTER_NO_FOLLOWUPS, repo="foo/bar") == 1
+        )
+        # And by short name too:
+        assert (
+            count_matching(conn, filter_=FILTER_NO_FOLLOWUPS, repo="bar") == 1
+        )
+        # An unknown repo yields 0, not "all rows".
+        assert (
+            count_matching(conn, filter_=FILTER_NO_FOLLOWUPS, repo="ghost/repo") == 0
+        )
+
+    def test_count_matching_skips_already_classified(self, conn):
+        """Bulk count must only see ``initial_prompt_source = 'unknown'`` rows.
+
+        Belt-and-suspenders for test #5 — guarantees the preview shown to
+        the user matches what an apply would actually change.
+        """
+        _seed_simple_followups_mix(conn)
+        # Flip one of the 3 no-fu rows to 'human' manually.
+        conn.execute(
+            "UPDATE conversation_human_input SET initial_prompt_source = 'human' "
+            "WHERE conversation_id = ?",
+            ("nofu" + "0".zfill(28),),
+        )
+        assert count_matching(conn, filter_=FILTER_NO_FOLLOWUPS) == 2
+
+
+class TestApplyClassification:
+    """Tests #4 and #5."""
+
+    def test_apply_classification_idempotent(self, conn):
+        """Test #4: second apply with the same source reports 0 changed."""
+        _seed_simple_followups_mix(conn)
+
+        first = apply_classification(
+            conn, filter_=FILTER_NO_FOLLOWUPS, source="automation"
+        )
+        second = apply_classification(
+            conn, filter_=FILTER_NO_FOLLOWUPS, source="automation"
+        )
+
+        assert first == 3
+        assert second == 0  # nothing left at 'unknown' matching the predicate.
+
+    def test_apply_classification_only_touches_unknowns(self, conn):
+        """Test #5: must not clobber manual overrides.
+
+        Pre-mark one of the no-followup rows as 'human'. A bulk apply
+        with --source automation must leave that row alone.
+        """
+        _seed_simple_followups_mix(conn)
+        manual_id = "nofu" + "0".zfill(28)
+        conn.execute(
+            "UPDATE conversation_human_input SET initial_prompt_source = 'human' "
+            "WHERE conversation_id = ?",
+            (manual_id,),
+        )
+
+        changed = apply_classification(
+            conn, filter_=FILTER_NO_FOLLOWUPS, source="automation"
+        )
+
+        assert changed == 2  # the other two no-followup rows
+
+        # The manually-flagged row is still 'human'.
+        row = conn.execute(
+            "SELECT initial_prompt_source FROM conversation_human_input "
+            "WHERE conversation_id = ?",
+            (manual_id,),
+        ).fetchone()
+        assert row["initial_prompt_source"] == "human"
+
+        # The has-followups rows are untouched (still 'unknown').
+        leftover = conn.execute(
+            "SELECT COUNT(*) AS n FROM conversation_human_input "
+            "WHERE initial_prompt_source = 'unknown'"
+        ).fetchone()["n"]
+        assert leftover == 2
+
+    def test_apply_classification_has_followups_path(self, conn):
+        """Symmetric to test #5: --has-followups --source human only flips unknowns.
+
+        Locks in AC6 (``--has-followups --source human --confirm`` works).
+        """
+        _seed_simple_followups_mix(conn)
+        changed = apply_classification(
+            conn, filter_=FILTER_HAS_FOLLOWUPS, source="human"
+        )
+        assert changed == 2
+
+        sources = {
+            row["conversation_id"]: row["initial_prompt_source"]
+            for row in conn.execute(
+                "SELECT conversation_id, initial_prompt_source "
+                "FROM conversation_human_input"
+            )
+        }
+        # has-fu now human, no-fu still unknown.
+        assert sources["hasfu" + "0".zfill(27)] == "human"
+        assert sources["hasfu" + "1".zfill(27)] == "human"
+        assert sources["nofu" + "0".zfill(28)] == "unknown"
+
+    def test_apply_classification_rejects_invalid_source(self, conn):
+        _seed_simple_followups_mix(conn)
+        with pytest.raises(InvalidSourceError):
+            apply_classification(
+                conn, filter_=FILTER_NO_FOLLOWUPS, source="bogus"  # type: ignore[arg-type]
+            )
+
+    def test_apply_classification_with_repo_filter(self, conn):
+        """AC7: --repo narrows the bulk update."""
+        _seed_simple_followups_mix(conn)
+        repo_id = _insert_repo(
+            conn,
+            canonical_url="https://github.com/foo/bar",
+            fqn="foo/bar",
+            short_name="bar",
+        )
+        only_linked = "nofu" + "0".zfill(28)
+        _link_conv_to_repo(conn, only_linked, repo_id)
+
+        changed = apply_classification(
+            conn,
+            filter_=FILTER_NO_FOLLOWUPS,
+            source="automation",
+            repo="foo/bar",
+        )
+        assert changed == 1
+
+        # The unlinked no-fu rows should still be 'unknown'.
+        still_unknown = conn.execute(
+            "SELECT COUNT(*) AS n FROM conversation_human_input "
+            "WHERE initial_prompt_source = 'unknown' "
+            "AND followup_message_count = 0"
+        ).fetchone()["n"]
+        assert still_unknown == 2
+
+
+class TestSetSingle:
+    """Tests #6 and #7."""
+
+    def test_set_single_conversation(self, conn):
+        """Test #6: set one row, no others change. Idempotent re-run."""
+        _seed_simple_followups_mix(conn)
+        target = "hasfu" + "0".zfill(27)
+
+        result = set_single(conn, conversation_id=target, source="human")
+        assert result.changed is True
+        assert result.previous_source == "unknown"
+        assert result.new_source == "human"
+
+        rows = {
+            r["conversation_id"]: r["initial_prompt_source"]
+            for r in conn.execute(
+                "SELECT conversation_id, initial_prompt_source "
+                "FROM conversation_human_input"
+            )
+        }
+        assert rows[target] == "human"
+        # No others flipped.
+        for cid, src in rows.items():
+            if cid == target:
+                continue
+            assert src == "unknown"
+
+        # Second call with the same source: no change.
+        second = set_single(conn, conversation_id=target, source="human")
+        assert second.changed is False
+
+    def test_set_single_accepts_dashed_id(self, conn):
+        """AGENTS.md item #14: dashed IDs are normalised before lookup."""
+        # Stored without dashes.
+        cid = "abcdef12345678901234567890abcdef"
+        _insert_conversation(conn, cid)
+        _insert_human_input(conn, cid)
+
+        dashed = (
+            "abcdef12-3456-7890-1234-567890abcdef"
+        )  # equivalent UUID-style form
+        result = set_single(conn, conversation_id=dashed, source="automation")
+        assert result.changed is True
+        assert result.conversation_id == cid
+
+    def test_set_single_can_flip_already_classified(self, conn):
+        """The single-conv override path explicitly CAN flip non-unknowns."""
+        cid = "humanrow" + "1".zfill(24)
+        _insert_conversation(conn, cid)
+        _insert_human_input(conn, cid, initial_prompt_source="automation")
+
+        result = set_single(conn, conversation_id=cid, source="human")
+        assert result.changed is True
+        assert result.previous_source == "automation"
+        assert result.new_source == "human"
+
+    def test_set_single_conversation_missing_row(self, conn):
+        """Test #7 / AC8: refuse on missing human-input row with clear message."""
+        cid = "missrow" + "1".zfill(25)
+        _insert_conversation(conn, cid)  # conversation exists,
+        # but no row in conversation_human_input.
+
+        with pytest.raises(MissingHumanInputRowError) as exc:
+            set_single(conn, conversation_id=cid, source="human")
+
+        msg = str(exc.value)
+        assert cid in msg
+        assert "ohtv db process human_input" in msg
+
+
+class TestListUnknown:
+    """Test #8."""
+
+    def test_list_unknown_with_repo_filter(self, conn):
+        """Test #8 + AC3 + AC7: --list-unknown narrows by --repo."""
+        # Two unknowns, one classified.
+        _insert_conversation(conn, "unkA" + "1".zfill(28), title="A")
+        _insert_human_input(conn, "unkA" + "1".zfill(28))
+        _insert_conversation(conn, "unkB" + "1".zfill(28), title="B")
+        _insert_human_input(conn, "unkB" + "1".zfill(28))
+        _insert_conversation(conn, "hum1" + "1".zfill(28), title="H")
+        _insert_human_input(
+            conn, "hum1" + "1".zfill(28), initial_prompt_source="human"
+        )
+
+        # Link only conv A to foo/bar.
+        repo_id = _insert_repo(
+            conn,
+            canonical_url="https://github.com/foo/bar",
+            fqn="foo/bar",
+            short_name="bar",
+        )
+        _link_conv_to_repo(conn, "unkA" + "1".zfill(28), repo_id)
+
+        # Unfiltered: both unknowns.
+        unfiltered = list_unknown(conn)
+        assert {r.short_id for r in unfiltered} == {"unkA0000", "unkB0000"}
+
+        # Filtered: only A.
+        filtered = list_unknown(conn, repo="foo/bar")
+        assert [r.short_id for r in filtered] == ["unkA0000"]
+        assert filtered[0].repo == "foo/bar"
+        assert filtered[0].title == "A"
+
+    def test_list_unknown_respects_limit(self, conn):
+        for i in range(5):
+            cid = f"limit{i:027d}"
+            _insert_conversation(conn, cid, title=f"row{i}")
+            _insert_human_input(conn, cid)
+
+        assert len(list_unknown(conn, limit=2)) == 2
+
+    def test_list_unknown_excludes_classified(self, conn):
+        cid = "done1" + "0".zfill(27)
+        _insert_conversation(conn, cid)
+        _insert_human_input(conn, cid, initial_prompt_source="automation")
+        assert list_unknown(conn) == []

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -37,8 +37,10 @@ import pytest
 from ohtv.classify import (
     FILTER_HAS_FOLLOWUPS,
     FILTER_NO_FOLLOWUPS,
+    AmbiguousConversationIdError,
     InvalidSourceError,
     MissingHumanInputRowError,
+    NoSuchConversationError,
     apply_classification,
     count_matching,
     list_unknown,
@@ -410,6 +412,147 @@ class TestSetSingle:
         msg = str(exc.value)
         assert cid in msg
         assert "ohtv db process human_input" in msg
+
+
+class TestSetSingleShortIdResolution:
+    """Tests for short-ID prefix resolution in :func:`set_single`.
+
+    Mirrors the convention in ``_find_conversation_dir`` (AGENTS.md item
+    #14): callers may pass either a full 32-char ID or a unique short
+    prefix. Fixes bug B-1 (README example #5: ``classify --list-unknown
+    -1 | head -5 | xargs ohtv classify {}``) and bug B-2 (distinct error
+    message for "no such conversation" vs "stage hasn't run").
+    """
+
+    def test_set_single_resolves_short_prefix(self, conn):
+        """B-1: a unique 8-char short ID resolves to the full row."""
+        cid = "deadbeefcafef00d1234567890abcdef"
+        _insert_conversation(conn, cid)
+        _insert_human_input(conn, cid)
+
+        # Mirrors what ``classify --list-unknown -1`` emits: 8 chars.
+        result = set_single(conn, conversation_id="deadbeef", source="human")
+        assert result.changed is True
+        assert result.conversation_id == cid
+
+        # The DB was actually updated with the full ID.
+        stored = conn.execute(
+            "SELECT initial_prompt_source FROM conversation_human_input "
+            "WHERE conversation_id = ?",
+            (cid,),
+        ).fetchone()
+        assert stored["initial_prompt_source"] == "human"
+
+    def test_set_single_ambiguous_short_prefix_is_rejected(self, conn):
+        """B-1: prefix that matches multiple convs raises, with sample matches."""
+        # Three conversations all starting with "abcd1234".
+        prefix = "abcd1234"
+        cids = [
+            prefix + "00" + "0".zfill(22),
+            prefix + "11" + "1".zfill(22),
+            prefix + "22" + "2".zfill(22),
+        ]
+        for cid in cids:
+            _insert_conversation(conn, cid)
+            _insert_human_input(conn, cid)
+
+        with pytest.raises(AmbiguousConversationIdError) as exc:
+            set_single(conn, conversation_id=prefix, source="human")
+
+        msg = str(exc.value)
+        assert prefix in msg
+        assert "3 matches" in msg
+        # Useful sample is included so the user can disambiguate.
+        for cid in cids:
+            assert cid[:12] in msg
+        # The exception itself also exposes the match list for tooling.
+        assert sorted(exc.value.matches) == sorted(cids)
+
+        # No row was touched.
+        flipped = conn.execute(
+            "SELECT COUNT(*) AS n FROM conversation_human_input "
+            "WHERE initial_prompt_source != 'unknown'"
+        ).fetchone()["n"]
+        assert flipped == 0
+
+    def test_set_single_unknown_id_raises_no_such_conversation(self, conn):
+        """B-2: ID that matches no conversation raises NoSuchConversationError.
+
+        The message must NOT blame ``conversation_human_input`` — the
+        problem is that the conversation itself isn't indexed.
+        """
+        # DB has *some* conversation, just not the requested one. This
+        # also exercises the "no prefix collision possible" path.
+        _insert_conversation(conn, "ffffffff" + "f".zfill(24))
+
+        with pytest.raises(NoSuchConversationError) as exc:
+            set_single(conn, conversation_id="00000000", source="human")
+
+        msg = str(exc.value)
+        assert "00000000" in msg
+        # The B-2 fix: the error must distinguish itself from
+        # MissingHumanInputRowError. It must NOT mention the human-input
+        # row or suggest running ``ohtv db process human_input``.
+        assert "conversation_human_input" not in msg
+        assert "ohtv db process human_input" not in msg
+        # And it must point at the real remediation.
+        assert "ohtv db scan" in msg
+
+    def test_set_single_distinguishes_missing_conv_from_missing_human_input(
+        self, conn
+    ):
+        """B-2: same fixture style, two distinct exception types.
+
+        ``MissingHumanInputRowError`` fires only when the conversation
+        row exists but the ``human_input`` stage hasn't produced its row
+        yet. ``NoSuchConversationError`` fires when the conversation row
+        doesn't exist at all.
+        """
+        # Case A: no conversation row at all.
+        with pytest.raises(NoSuchConversationError):
+            set_single(conn, conversation_id="aa" + "a".zfill(30), source="human")
+
+        # Case B: conversation row exists, but no human_input row.
+        cid = "bb" + "b".zfill(30)
+        _insert_conversation(conn, cid)
+        with pytest.raises(MissingHumanInputRowError):
+            set_single(conn, conversation_id=cid, source="human")
+
+    def test_set_single_full_id_skips_prefix_path(self, conn):
+        """A 32-char exact match must not trigger a LIKE scan.
+
+        Regression guard: a full ID that happens to be a prefix of
+        another conversation must still resolve unambiguously via the
+        exact-match fast path.
+        """
+        short_target = "aaaa1111" + "0".zfill(24)
+        long_neighbour = "aaaa1111" + "x" + "0".zfill(23)
+        # ``long_neighbour`` shares the first 8 chars with ``short_target``.
+        # If we passed "aaaa1111" we'd hit ambiguity; passing the full
+        # ``short_target`` must resolve directly.
+        _insert_conversation(conn, short_target)
+        _insert_human_input(conn, short_target)
+        _insert_conversation(conn, long_neighbour)
+        _insert_human_input(conn, long_neighbour)
+
+        result = set_single(
+            conn, conversation_id=short_target, source="automation"
+        )
+        assert result.changed is True
+        assert result.conversation_id == short_target
+
+    def test_set_single_dashed_short_prefix_is_normalised(self, conn):
+        """Dashes inside a short-ID prefix are still stripped before lookup."""
+        cid = "deadbeef" + "0".zfill(24)
+        _insert_conversation(conn, cid)
+        _insert_human_input(conn, cid)
+
+        # Caller passes a dashed short prefix; resolver must strip it.
+        result = set_single(
+            conn, conversation_id="dead-beef", source="human"
+        )
+        assert result.changed is True
+        assert result.conversation_id == cid
 
 
 class TestListUnknown:

--- a/tests/unit/test_cli_classify.py
+++ b/tests/unit/test_cli_classify.py
@@ -1,0 +1,283 @@
+"""CLI smoke tests for ``ohtv classify`` (issue #83).
+
+Test plan mapping (numbering matches the technical-approach comment on
+issue #83):
+
+* test  #9 — :func:`test_classify_help`
+* test #10 — :func:`test_classify_invalid_source_rejected`
+* test #11 — :func:`test_classify_bulk_requires_confirm`
+* test #12 — :func:`test_classify_bulk_with_confirm_writes`
+* test #13 — :func:`test_classify_single_conversation_no_confirm_needed`
+* test #14 — :func:`test_classify_list_unknown_machine_readable`
+
+Acceptance criterion mapping:
+
+* AC1 (single-conv override, no --confirm) → test #13
+* AC3 (--list-unknown + machine-readable) → test #14
+* AC4 (bulk preview, no writes) → test #11
+* AC5 (bulk apply --confirm) → test #12
+* AC9 (invalid --source rejected) → test #10
+* All others — covered by the unit suite in test_classify.py.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main
+from ohtv.db.migrations import migrate
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the CLI at a fresh tmp DB with the full migration chain.
+
+    Mirrors the pattern from tests/unit/test_cli_fetch_loc.py — same
+    OHTV_DIR + OHTV_DB_PATH + HOME setup the test_cli_fetch_loc suite
+    uses to keep CLI tests hermetic.
+    """
+    ohtv_dir = tmp_path / "ohtv"
+    ohtv_dir.mkdir()
+    db_path = ohtv_dir / "index.db"
+
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_dir))
+    monkeypatch.setenv("OHTV_DB_PATH", str(db_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    migrate(conn)
+    conn.close()
+    return db_path
+
+
+def _seed_three_unknown_no_fu(db_path: Path) -> list[str]:
+    """Insert 3 conversations with 0 followups, all 'unknown'.
+
+    Returns the list of conversation IDs (without dashes).
+    """
+    ids: list[str] = []
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    created = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    for i in range(3):
+        cid = f"convnofu{i:024d}"
+        ids.append(cid)
+        conn.execute(
+            "INSERT INTO conversations (id, location, event_count, title, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (cid, "/tmp/fake", 1, f"row {i}", created),
+        )
+        conn.execute(
+            """
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, 'unknown', ?, ?, ?, ?)
+            """,
+            (cid, 5, 0, 0, "2024-06-01T12:00:00+00:00", 1),
+        )
+    conn.commit()
+    conn.close()
+    return ids
+
+
+def _read_source(db_path: Path, cid: str) -> str | None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT initial_prompt_source FROM conversation_human_input "
+        "WHERE conversation_id = ?",
+        (cid,),
+    ).fetchone()
+    conn.close()
+    return row["initial_prompt_source"] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_classify_help(runner: CliRunner) -> None:
+    """Test #9: --help exits 0 and mentions the headline options.
+
+    This is the spec-compliance smoke. The set of options is the public
+    contract; breaking any of these names would silently break the
+    documented `ohtv classify` workflows in the README.
+    """
+    result = runner.invoke(main, ["classify", "--help"])
+    assert result.exit_code == 0, result.output
+    for needle in (
+        "--source",
+        "--no-followups",
+        "--has-followups",
+        "--list-unknown",
+        "--confirm",
+        "--repo",
+    ):
+        assert needle in result.output, f"missing {needle!r} in help text"
+
+
+def test_classify_invalid_source_rejected(runner: CliRunner) -> None:
+    """Test #10 / AC9: --source foo is rejected by Click.
+
+    No isolated_db needed — Click rejects this before we ever touch
+    the DB.
+    """
+    result = runner.invoke(main, ["classify", "--no-followups", "--source", "foo"])
+    assert result.exit_code != 0
+    # Click renders the choice error in combined output (mix_stderr=True default).
+    assert "foo" in result.output
+    assert (
+        "Invalid value for '--source'" in result.output
+        or "invalid choice" in result.output.lower()
+    )
+
+
+def test_classify_bulk_requires_confirm(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """Test #11 / AC4: bulk without --confirm is a preview only (no DB writes)."""
+    ids = _seed_three_unknown_no_fu(isolated_db)
+
+    result = runner.invoke(
+        main, ["classify", "--no-followups", "--source", "automation"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Would classify" in result.output
+    assert "3" in result.output
+    assert "--confirm" in result.output
+
+    # Crucially: nothing was actually changed.
+    for cid in ids:
+        assert _read_source(isolated_db, cid) == "unknown"
+
+
+def test_classify_bulk_with_confirm_writes(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """Test #12 / AC5: bulk --confirm actually writes."""
+    ids = _seed_three_unknown_no_fu(isolated_db)
+
+    result = runner.invoke(
+        main, ["classify", "--no-followups", "--source", "automation", "--confirm"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Classified" in result.output and "3" in result.output
+
+    for cid in ids:
+        assert _read_source(isolated_db, cid) == "automation"
+
+
+def test_classify_single_conversation_no_confirm_needed(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """Test #13 / AC1: single-conv mode does not need --confirm."""
+    ids = _seed_three_unknown_no_fu(isolated_db)
+    target = ids[0]
+
+    result = runner.invoke(main, ["classify", target, "--source", "human"])
+    assert result.exit_code == 0, result.output
+    assert "Set" in result.output or "->" in result.output
+
+    assert _read_source(isolated_db, target) == "human"
+    # Other rows untouched.
+    assert _read_source(isolated_db, ids[1]) == "unknown"
+    assert _read_source(isolated_db, ids[2]) == "unknown"
+
+
+def test_classify_list_unknown_machine_readable(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """Test #14 / AC3: --list-unknown -1 is one short_id per line, no Rich decoration."""
+    ids = _seed_three_unknown_no_fu(isolated_db)
+
+    result = runner.invoke(main, ["classify", "--list-unknown", "-1"])
+    assert result.exit_code == 0, result.output
+
+    # One short_id per line, no extras.
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert sorted(lines) == sorted(cid[:8] for cid in ids)
+
+    # No Rich color codes, table borders, or headers in the output.
+    assert "[" not in result.output  # no [bold] or [dim] markup
+    assert "─" not in result.output  # no box-drawing characters
+    assert "short_id" not in result.output  # no header row
+
+
+# ---------------------------------------------------------------------------
+# Additional smoke tests for the mutual-exclusion + missing-row paths
+# (not numbered 9-14 but they pin the friendly-error behaviour the
+# technical comment locks in).
+# ---------------------------------------------------------------------------
+
+
+def test_classify_mutex_no_followups_and_has_followups(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    result = runner.invoke(
+        main,
+        [
+            "classify",
+            "--no-followups",
+            "--has-followups",
+            "--source",
+            "human",
+            "--confirm",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_classify_mutex_single_and_bulk(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    result = runner.invoke(
+        main,
+        [
+            "classify",
+            "deadbeef" * 4,
+            "--no-followups",
+            "--source",
+            "automation",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "CONVERSATION_ID" in result.output
+
+
+def test_classify_single_refuses_when_no_human_input_row(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """AC8 single-conv path: refuse with a clear actionable message."""
+    # Insert a conversation but NO conversation_human_input row.
+    cid = "abcdef01" + "0" * 24
+    conn = sqlite3.connect(isolated_db)
+    conn.execute(
+        "INSERT INTO conversations (id, location, event_count) VALUES (?, ?, ?)",
+        (cid, "/tmp/fake", 1),
+    )
+    conn.commit()
+    conn.close()
+
+    result = runner.invoke(main, ["classify", cid, "--source", "human"])
+    assert result.exit_code != 0
+    assert "ohtv db process human_input" in result.output

--- a/tests/unit/test_cli_classify.py
+++ b/tests/unit/test_cli_classify.py
@@ -281,3 +281,103 @@ def test_classify_single_refuses_when_no_human_input_row(
     result = runner.invoke(main, ["classify", cid, "--source", "human"])
     assert result.exit_code != 0
     assert "ohtv db process human_input" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Short-ID prefix resolution + B-2 error distinction (PR #99 review round)
+# ---------------------------------------------------------------------------
+
+
+def _seed_distinct_short_ids(db_path: Path) -> list[str]:
+    """Seed three conversations whose first 8 chars are unique.
+
+    ``_seed_three_unknown_no_fu`` deliberately uses near-identical IDs
+    (they differ only in the last digit) to exercise other code paths,
+    so it's unsuitable for short-prefix tests. This helper seeds
+    ``aaaa****`` / ``bbbb****`` / ``cccc****`` so an 8-char prefix is
+    unique by construction.
+    """
+    ids: list[str] = []
+    created = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    for prefix in ("aaaa1111", "bbbb2222", "cccc3333"):
+        cid = prefix + "0" * 24
+        ids.append(cid)
+        conn.execute(
+            "INSERT INTO conversations (id, location, event_count, title, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (cid, "/tmp/fake", 1, f"row {prefix}", created),
+        )
+        conn.execute(
+            """
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, 'unknown', ?, ?, ?, ?)
+            """,
+            (cid, 5, 0, 0, "2024-06-01T12:00:00+00:00", 1),
+        )
+    conn.commit()
+    conn.close()
+    return ids
+
+
+def test_classify_single_accepts_short_id_prefix(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """B-1: README example #5 (``--list-unknown -1 | xargs classify``).
+
+    ``-1`` emits 8-char short IDs. The pipeline must succeed: a unique
+    short prefix resolves to the full row instead of erroring out.
+    """
+    ids = _seed_distinct_short_ids(isolated_db)
+    # First 8 chars uniquely identify each row by construction.
+    short_target = ids[0][:8]
+    assert short_target == "aaaa1111"
+
+    result = runner.invoke(main, ["classify", short_target, "--source", "human"])
+    assert result.exit_code == 0, result.output
+    assert _read_source(isolated_db, ids[0]) == "human"
+    assert _read_source(isolated_db, ids[1]) == "unknown"
+    assert _read_source(isolated_db, ids[2]) == "unknown"
+
+
+def test_classify_single_rejects_ambiguous_short_id(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """B-1: ambiguous prefix must be rejected, not silently target one row."""
+    ids = _seed_three_unknown_no_fu(isolated_db)
+    # First 8 chars (``convnofu``) match all three seeded conversations.
+    ambiguous = ids[0][:8]
+
+    result = runner.invoke(main, ["classify", ambiguous, "--source", "human"])
+    assert result.exit_code == 2
+    assert "Ambiguous" in result.output
+    assert "3 matches" in result.output
+    # No row was touched.
+    for cid in ids:
+        assert _read_source(isolated_db, cid) == "unknown"
+
+
+def test_classify_single_no_such_conversation_distinct_error(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """B-2: a fabricated ID must NOT blame the human_input stage.
+
+    Before the fix, every fabricated/typoed ID produced
+    ``No conversation_human_input row for conversation '...'. Run 'ohtv
+    db process human_input' first.`` — which is misleading because the
+    real problem is that the conversation isn't indexed at all.
+    """
+    # DB has no conversations at all.
+    result = runner.invoke(
+        main, ["classify", "deadbeef", "--source", "human"]
+    )
+    assert result.exit_code == 2
+    assert "No such conversation" in result.output
+    # The error must NOT pretend the human_input stage is to blame.
+    assert "conversation_human_input" not in result.output
+    assert "ohtv db process human_input" not in result.output
+    # And it should point at the real remediation.
+    assert "ohtv db scan" in result.output


### PR DESCRIPTION
## What

Adds `ohtv classify`, a CLI command that populates the `conversation_human_input.initial_prompt_source` column (`human` | `automation` | `unknown`) using three modes:

1. **Single-conversation override** — `ohtv classify <id> --source human` writes one row immediately, idempotent, no `--confirm` needed.
2. **Read-only discovery** — `ohtv classify --list-unknown` (optionally `--repo OWNER/REPO`, `-1`/`--format csv`/`--format json`) prints all unknowns; never writes.
3. **`--confirm`-gated bulk heuristics** — `--no-followups --source automation --confirm` or `--has-followups --source human --confirm` apply a heuristic to currently-`unknown` rows only (`--repo` narrows further). Without `--confirm` the same command is a count-only preview.

The `initial_prompt_source` column itself was added by migration 016 in PR #85; this PR adds the tool that populates it.

## Why

Unblocks accurate human-vs-automation breakdowns in `ohtv report velocity` (#81) and downstream charting (#82). Without this command, every row sits at `'unknown'` and the velocity report's "treat unknown as human" fallback masks automation activity.

## Key design points

- **Short-ID prefix resolution (`_resolve_conversation_id`)** mirrors `_find_conversation_dir` per AGENTS.md #14: exact 32-char match first, dashed-form normalisation, then `LIKE 'prefix%'` for short IDs. This makes the README pipeline `ohtv classify --list-unknown -1 | head -5 | xargs -I {} ohtv classify {} --source human` actually work end-to-end. Ambiguous prefixes raise `AmbiguousConversationIdError` with a sample of matches.
- **Distinct error classes** — `NoSuchConversationError` (ID not in `conversations`, hint to run `ohtv db scan`) vs `MissingHumanInputRowError` (conversation exists but stage hasn't run, hint to run `ohtv db process human_input`). Previously both surfaced the same misleading message.
- **Bulk safety** — heuristic UPDATEs always include `initial_prompt_source = 'unknown'` in the WHERE clause, so already-classified rows are never silently clobbered. Only the single-conv path can flip a non-`unknown` row.
- **No new migration** — schema is already in place from migration 016 (PR #85).

## Testing

- **Full suite**: `1651 passed` (baseline was 1617; +34 new tests = 25 in original 4 commits + 9 added in the review round 1 fix commit `65df4259`).
- **Round-1 manual test report** (commit `c4c7ecf1`): https://github.com/jpshackelford/ohtv/pull/99#issuecomment-3573064020 — verdict 🟡 _Ready with minor fixes_ (B-1 README pipeline broken, B-2 unhelpful error wording, B-3 encoding nits).
- **Re-test report** (commit `65df4259`, after fixes): https://github.com/jpshackelford/ohtv/pull/99#issuecomment-3573176289 — verdict ✅ _Ready for merge_. Covers B-1 (pipeline now works), B-2 (proper "No such conversation" error), the new ambiguous-prefix case, B-3 (encoding hygiene verified clean), plus 5 regression spot-checks. All PASS.
- **Review threads**: 3 auto-AI encoding nits, all `isResolved: true` — verified each flagged character is a legitimate U+2014 em-dash matching codebase prose convention.

Closes #83

> _This PR was authored by an AI agent (OpenHands) on behalf of @jpshackelford._
