### PR TITLE
feat: add ohtv report weekly-counts command (#92)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,14 @@ These decisions explain WHY the code is structured as it is. See `README.md` for
     - **LOC NULL handling**: All-NULL bucket → `-` (table) / empty (CSV). Mixed → sum knowns + `partial_loc=True` (surfaced by `--verbose`). Words/LOC denominator zero → `-` / empty.
     - **Reusable surface**: `ohtv.reports.velocity.aggregate_velocity(conn=..., since=..., until=..., repo=..., include_empty=...)` returns a `VelocityReport(rows, totals, metadata)` and is the entry point that issue #82 should consume.
 
+29. **Weekly counts report (`ohtv.reports.weekly_counts`, Issue #92)**: CSV-only export of new-conversation counts bucketed by ISO 8601 week, split by source. Built on top of the #81 scaffolding (`reports/` package + `report` Click group).
+    - **CLI**: `ohtv report weekly-counts` emits stdout CSV with header `week,cloud,cli,total`. Flags: `--since`/`--until`, `--source [cloud|cli|all]`, `--include-empty`, `--exclude-current-week`, `--out PATH`.
+    - **`cli` (CSV) vs `local` (DB) naming**: The CSV column header is `cli` because that is what the issue title says and what reads naturally in a report. The DB stores `source='local'` for CLI conversations (see `src/ohtv/sources/base.py`). The translation happens in exactly one place: `weekly_counts.aggregate_weekly_counts` (DB→CSV) and the CLI `--source` flag mapping (`cli` → `'local'` bind value). Every other layer keeps the existing `local` vocabulary.
+    - **UTC-bin caveat**: Cloud `created_at` is UTC, CLI `created_at` is often naive (see item 5 above). Naive timestamps are treated as UTC for ISO-week bucketing — best-effort consistent with the rest of the codebase. This can mis-bucket conversations created within a few hours of a Monday boundary on machines in non-UTC time zones. Documented in the module docstring and in the test `test_naive_timestamp_treated_as_utc` (T-11).
+    - **Bucket-by `created_at`** (NOT `updated_at`) — "new conversations per week" is the report's semantics.
+    - **No SQLite `strftime` for ISO week**: Same regression rule as #81 (test T-4: 2024-12-30 → `2025-W01`).
+    - **Reusable surface**: `ohtv.reports.weekly_counts.fetch_rows(conn, ...)` + `aggregate_weekly_counts(rows, ...)` returns a `WeeklyCountsReport(rows, metadata)` and is the entry point that issue #82 should consume.
+
 ## Troubleshooting
 
 ### Terminal shows `^M^M^M` when typing input

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ GITHUB_TOKEN=$(gh auth token) ohtv fetch-loc
 ohtv report velocity
 ohtv report velocity --format csv > velocity.csv
 
+# Weekly new-conversation counts CSV (cloud, cli, total) by ISO week
+ohtv report weekly-counts > counts.csv
+ohtv report weekly-counts --since 4w --exclude-current-week
+
 # Search conversations semantically
 ohtv search "fix authentication bugs"
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10622,5 +10622,143 @@ def report_velocity(
         )
 
 
+@report.command("weekly-counts")
+@click.option(
+    "--since",
+    "since_str",
+    help="Lower bound on created_at; YYYY-MM-DD or relative (7d, 2w, 1m)",
+)
+@click.option(
+    "--until",
+    "until_str",
+    help="Upper bound on created_at; YYYY-MM-DD or relative",
+)
+@click.option(
+    "--source",
+    type=click.Choice(["cloud", "cli", "all"]),
+    default="all",
+    show_default=True,
+    help="Restrict to one source. 'cli' maps to DB source='local'.",
+)
+@click.option(
+    "--include-empty",
+    is_flag=True,
+    help="Emit weeks with zero conversations as zero rows (default: omit)",
+)
+@click.option(
+    "--exclude-current-week",
+    is_flag=True,
+    help="Omit the in-progress (current) ISO week from output",
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(dir_okay=False, writable=True),
+    help="Write CSV to PATH instead of stdout",
+)
+def report_weekly_counts(
+    since_str: str | None,
+    until_str: str | None,
+    source: str,
+    include_empty: bool,
+    exclude_current_week: bool,
+    out_path: str | None,
+) -> None:
+    """Emit weekly new-conversation counts as CSV (cloud, cli, total).
+
+    Buckets ``conversations.created_at`` by ISO 8601 week
+    (``YYYY-Www``, Monday-start). The ``cli`` column is the count of
+    CLI / local conversations (stored as ``source='local'`` in the
+    DB — the CSV header uses ``cli`` because it reads naturally in a
+    report).
+
+    Output is always CSV with header ``week,cloud,cli,total``. By
+    default it streams to stdout; pass ``--out PATH`` to write to a
+    file. Weeks with zero conversations are omitted unless
+    ``--include-empty`` is passed.
+
+    \b
+    Examples:
+      ohtv report weekly-counts > counts.csv
+      ohtv report weekly-counts --since 4w
+      ohtv report weekly-counts --since 2024-01-01 --include-empty
+      ohtv report weekly-counts --source cli --exclude-current-week
+    """
+    import sys
+
+    from ohtv.db import ensure_db_ready, get_connection, get_db_path
+    from ohtv.filters import parse_date_filter
+    from ohtv.reports.weekly_counts import (
+        aggregate_weekly_counts,
+        fetch_rows,
+        format_csv,
+    )
+
+    since_dt = None
+    if since_str:
+        since_dt = parse_date_filter(since_str)
+        if since_dt is None:
+            console.print(
+                f"[red]Error:[/red] could not parse --since {since_str!r}. "
+                "Use YYYY-MM-DD or relative (e.g., 7d, 2w, 1m)."
+            )
+            raise SystemExit(2)
+
+    until_dt = None
+    if until_str:
+        until_dt = parse_date_filter(until_str)
+        if until_dt is None:
+            console.print(
+                f"[red]Error:[/red] could not parse --until {until_str!r}. "
+                "Use YYYY-MM-DD or relative (e.g., 7d, 2w, 1m)."
+            )
+            raise SystemExit(2)
+
+    # User-facing 'cli' → DB 'local'. Sole place this translation happens.
+    db_source: str | None
+    if source == "cli":
+        db_source = "local"
+    elif source == "cloud":
+        db_source = "cloud"
+    else:
+        db_source = None
+
+    def _emit(report_rows: list, stream) -> None:
+        format_csv(report_rows, stream)
+
+    db_path = get_db_path()
+    if not db_path.exists():
+        # Friendly empty state: write header-only CSV.
+        if out_path:
+            with open(out_path, "w", newline="") as fh:
+                _emit([], fh)
+        else:
+            _emit([], sys.stdout)
+        return
+
+    with get_connection(db_path) as conn:
+        ensure_db_ready(conn, show_progress=False)
+        raw_rows = fetch_rows(
+            conn,
+            since=since_dt,
+            until=until_dt,
+            source=db_source,
+        )
+
+    report_data = aggregate_weekly_counts(
+        raw_rows,
+        include_empty=include_empty,
+        exclude_current_week=exclude_current_week,
+        since=since_dt,
+        until=until_dt,
+    )
+
+    if out_path:
+        with open(out_path, "w", newline="") as fh:
+            _emit(report_data.rows, fh)
+    else:
+        _emit(report_data.rows, sys.stdout)
+
+
 if __name__ == "__main__":
     main()

--- a/src/ohtv/reports/weekly_counts.py
+++ b/src/ohtv/reports/weekly_counts.py
@@ -1,0 +1,317 @@
+"""Weekly conversation count report (issue #92).
+
+CSV export of new-conversation counts bucketed by ISO 8601 week
+(``YYYY-Www``, Monday-start), split by source: ``cloud`` and ``cli``.
+
+Pure data layer — no Click imports, no Rich, no filesystem state.
+:func:`aggregate_weekly_counts` is the importable surface that
+charting (issue #82) is expected to reuse.
+
+Design notes
+------------
+
+* The ISO week label is computed in Python via
+  :func:`ohtv.analysis.periods.make_week_period`. SQLite's
+  ``strftime('%W', ...)`` is GNU/POSIX, not ISO 8601, and
+  ``strftime('%V', ...)`` is unreliable across SQLite builds; both
+  mis-bucket the 2024-12-30 / 2025-W01 boundary. The companion
+  regression test (T-4) locks this in.
+
+* Bucketing is by ``conversations.created_at`` (NOT ``updated_at``),
+  matching the "new conversations per week" semantics in the issue
+  title. ``updated_at`` would double-count long-running conversations
+  whose touch dates cross week boundaries.
+
+* Naming gotcha: the DB stores ``source = 'local'`` for CLI
+  conversations (see :mod:`ohtv.sources.base`). The CSV header uses
+  ``cli`` instead because that is what the issue title says and what
+  reads naturally in a report. The translation happens here, at the
+  report layer — every other layer keeps the existing ``local``
+  vocabulary.
+
+* Timezone caveat: cloud ``created_at`` is UTC; CLI ``created_at`` is
+  whatever the producer wrote, often naive. We assume naive
+  timestamps are UTC for bucketing (consistent with the rest of the
+  codebase — see AGENTS.md item 5). This is best-effort and can mis-
+  bucket conversations created within a few hours of a week boundary
+  on machines in non-UTC time zones.
+"""
+
+from __future__ import annotations
+
+import csv
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import IO, Iterable, Sequence
+
+from ohtv.analysis.periods import get_week_start, iterate_periods, make_week_period
+
+
+# CSV column order. ``cli`` comes before ``total`` to match the
+# issue body exactly.
+CSV_HEADER = ("week", "cloud", "cli", "total")
+
+# DB-side source value for CLI / local conversations.
+_DB_SOURCE_LOCAL = "local"
+_DB_SOURCE_CLOUD = "cloud"
+
+
+# Pure SQL — bucketing happens in Python (see module docstring).
+_WEEKLY_COUNTS_SQL = """
+SELECT created_at, source
+FROM conversations
+WHERE created_at IS NOT NULL
+  AND (:since   IS NULL OR created_at >= :since)
+  AND (:until   IS NULL OR created_at <  :until)
+  AND (:source  IS NULL OR source = :source)
+ORDER BY created_at
+"""
+
+
+@dataclass
+class WeeklyCountsRow:
+    """One ISO-week bucket of conversation counts.
+
+    ``week_iso`` is the ISO 8601 label ``YYYY-Www`` (zero-padded,
+    Monday-start). ``cloud`` and ``cli`` are mutually exclusive
+    counts; ``total = cloud + cli``.
+    """
+
+    week_iso: str
+    cloud: int
+    cli: int
+    total: int
+
+
+@dataclass
+class WeeklyCountsReport:
+    """Container returned by :func:`aggregate_weekly_counts`.
+
+    ``rows`` is in ascending ISO-week order. ``metadata`` is the
+    bag the CLI ``--verbose`` path (if any) and downstream charting
+    (#82) might consume; today it holds the rendered SQL, the bind
+    parameters, and the raw input row count.
+    """
+
+    rows: list[WeeklyCountsRow]
+    metadata: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Data fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_rows(
+    conn: sqlite3.Connection,
+    *,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    source: str | None = None,
+) -> list[sqlite3.Row]:
+    """Fetch ``(created_at, source)`` for conversations in range.
+
+    Args:
+        conn: SQLite connection (row_factory will be coerced to
+            :class:`sqlite3.Row` if unset).
+        since: Inclusive lower bound on ``created_at`` (UTC datetime).
+        until: Exclusive upper bound on ``created_at`` (UTC datetime).
+        source: Optional DB source filter; values are ``'cloud'`` /
+            ``'local'``. ``None`` includes both.
+
+    Returns:
+        List of rows ordered by ``created_at`` ascending. Rows whose
+        ``created_at`` is NULL are filtered out at the SQL layer.
+    """
+    if conn.row_factory is None:
+        conn.row_factory = sqlite3.Row
+    cursor = conn.execute(
+        _WEEKLY_COUNTS_SQL,
+        {
+            "since": _to_iso_z(since),
+            "until": _to_iso_z(until),
+            "source": source,
+        },
+    )
+    return list(cursor.fetchall())
+
+
+# ---------------------------------------------------------------------------
+# Bucketing
+# ---------------------------------------------------------------------------
+
+
+def _parse_created_at(value: str | None) -> datetime | None:
+    """Parse a ``conversations.created_at`` ISO timestamp to UTC.
+
+    Naive timestamps are assumed UTC — see the module-level
+    timezone caveat. Returns ``None`` for unparseable / empty input
+    so callers can skip defensively.
+    """
+    if value is None:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _to_iso_z(dt: datetime | None) -> str | None:
+    """Format a UTC datetime as ``YYYY-MM-DDTHH:MM:SSZ`` for SQL bind."""
+    if dt is None:
+        return None
+    dt_utc = dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    return dt_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _iso_label(d: date) -> str:
+    """ISO-week label ``YYYY-Www`` for any date in that week."""
+    return make_week_period(get_week_start(d)).iso
+
+
+def aggregate_weekly_counts(
+    rows: Iterable[sqlite3.Row],
+    *,
+    include_empty: bool = False,
+    exclude_current_week: bool = False,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    today: date | None = None,
+) -> WeeklyCountsReport:
+    """Fold ``(created_at, source)`` rows into ISO-week buckets.
+
+    Args:
+        rows: Iterable of rows produced by :func:`fetch_rows`. Each
+            row must expose ``["created_at"]`` and ``["source"]``.
+        include_empty: When True, emit zero-rows for every ISO week
+            in the range that has no conversations. Range is bounded
+            by ``since`` / ``until`` if given; otherwise by the
+            earliest / latest seen row.
+        exclude_current_week: When True, drop the row whose
+            ``week_iso`` matches today's ISO week (best-effort UTC).
+        since: Iteration lower bound (UTC). Used to anchor
+            ``include_empty`` zero-fill.
+        until: Iteration upper bound (UTC, exclusive). Used to anchor
+            ``include_empty`` zero-fill.
+        today: Override "today" for ``exclude_current_week``;
+            primarily for tests.
+
+    Returns:
+        :class:`WeeklyCountsReport` with per-week rows in ascending
+        order. Rows with unparseable ``created_at`` are silently
+        skipped.
+    """
+    buckets: dict[str, dict[str, int]] = {}
+    earliest: date | None = None
+    latest: date | None = None
+    raw_count = 0
+    skipped = 0
+
+    for row in rows:
+        raw_count += 1
+        created_at = _parse_created_at(row["created_at"])
+        if created_at is None:
+            skipped += 1
+            continue
+        bucket_date = created_at.date()
+        if earliest is None or bucket_date < earliest:
+            earliest = bucket_date
+        if latest is None or bucket_date > latest:
+            latest = bucket_date
+        label = _iso_label(bucket_date)
+        bucket = buckets.setdefault(label, {"cloud": 0, "cli": 0})
+        src = row["source"]
+        if src == _DB_SOURCE_CLOUD:
+            bucket["cloud"] += 1
+        elif src == _DB_SOURCE_LOCAL:
+            bucket["cli"] += 1
+        # Any other source value is silently ignored — keeps the
+        # report stable if a new source kind is added later.
+
+    if include_empty:
+        # Determine zero-fill range. Honour explicit bounds first;
+        # otherwise span the actual data.
+        if since is not None:
+            range_start = since.astimezone(timezone.utc).date()
+        elif earliest is not None:
+            range_start = earliest
+        else:
+            range_start = date.today()
+        if until is not None:
+            # ``until`` is exclusive; use it directly as the iteration
+            # end (iterate_periods will include the week containing
+            # range_end). If until is week-aligned, this still
+            # includes that week's bucket — that's the intuitive
+            # behaviour for a date range.
+            range_end = until.astimezone(timezone.utc).date()
+        elif latest is not None:
+            range_end = latest
+        else:
+            range_end = date.today()
+        if range_end < range_start:
+            range_end = range_start
+        for period in iterate_periods(range_start, range_end, "week"):
+            buckets.setdefault(period.iso, {"cloud": 0, "cli": 0})
+
+    if exclude_current_week:
+        ref_today = today if today is not None else datetime.now(timezone.utc).date()
+        current_label = _iso_label(ref_today)
+        buckets.pop(current_label, None)
+
+    out: list[WeeklyCountsRow] = []
+    for label in sorted(buckets):
+        b = buckets[label]
+        out.append(
+            WeeklyCountsRow(
+                week_iso=label,
+                cloud=b["cloud"],
+                cli=b["cli"],
+                total=b["cloud"] + b["cli"],
+            )
+        )
+
+    metadata = {
+        "sql": _WEEKLY_COUNTS_SQL,
+        "params": {
+            "since": _to_iso_z(since),
+            "until": _to_iso_z(until),
+        },
+        "raw_row_count": raw_count,
+        "skipped_unparseable": skipped,
+        "bucket_count": len(out),
+    }
+    return WeeklyCountsReport(rows=out, metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# CSV emission
+# ---------------------------------------------------------------------------
+
+
+def format_csv(
+    rows: Sequence[WeeklyCountsRow],
+    file: IO[str],
+    *,
+    header: bool = True,
+) -> None:
+    """Write rows as RFC 4180 CSV to ``file``.
+
+    Always uses ``\\r\\n`` line terminators (RFC 4180 default for
+    stdlib :mod:`csv`). The header row is included unless
+    ``header=False`` — but the CLI never disables it; the keyword is
+    there only for callers that want to splice multiple reports.
+    """
+    writer = csv.writer(file)
+    if header:
+        writer.writerow(CSV_HEADER)
+    for row in rows:
+        writer.writerow([row.week_iso, row.cloud, row.cli, row.total])

--- a/tests/unit/reports/test_cli_weekly_counts.py
+++ b/tests/unit/reports/test_cli_weekly_counts.py
@@ -1,0 +1,133 @@
+"""CLI smoke tests for ``ohtv report weekly-counts`` (issue #92).
+
+Exercise the full Click entry point against an isolated ``OHTV_DIR``
+with a fully-migrated SQLite DB. No DB mocks.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main as ohtv_main
+from ohtv.db.migrations import migrate
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Force the CLI to use a temp DB at ``$OHTV_DIR/index.db``.
+
+    Mirrors the pattern in :mod:`tests.unit.reports.test_cli_report`.
+    """
+    ohtv_dir = tmp_path / "ohtv"
+    ohtv_dir.mkdir()
+    db_path = ohtv_dir / "index.db"
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_dir))
+    monkeypatch.setenv("OHTV_DB_PATH", str(db_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    migrate(conn)
+    conn.close()
+    return db_path
+
+
+def _seed_two_weeks(db_path: Path) -> None:
+    """Seed two cloud conversations in adjacent ISO weeks."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO conversations (id, location, created_at, source) "
+        "VALUES (?, ?, ?, ?)",
+        ("c1", "/tmp/c1", "2024-03-05T12:00:00Z", "cloud"),  # W10
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, location, created_at, source) "
+        "VALUES (?, ?, ?, ?)",
+        ("c2", "/tmp/c2", "2024-03-12T12:00:00Z", "local"),  # W11
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# C-1: default stdout CSV
+# ---------------------------------------------------------------------------
+
+
+def test_default_stdout_csv(runner: CliRunner, isolated_db: Path) -> None:
+    """Default invocation prints a parseable CSV with the canonical header."""
+    _seed_two_weeks(isolated_db)
+    result = runner.invoke(ohtv_main, ["report", "weekly-counts"])
+    assert result.exit_code == 0, result.output
+
+    # First line is the header.
+    lines = result.output.splitlines()
+    assert lines[0] == "week,cloud,cli,total", lines[0]
+
+    # Parses cleanly with DictReader.
+    reader = csv.DictReader(io.StringIO(result.output))
+    rows = list(reader)
+    assert reader.fieldnames == ["week", "cloud", "cli", "total"]
+    assert len(rows) == 2
+    by_week = {r["week"]: r for r in rows}
+    assert by_week["2024-W10"]["cloud"] == "1"
+    assert by_week["2024-W10"]["cli"] == "0"
+    assert by_week["2024-W10"]["total"] == "1"
+    assert by_week["2024-W11"]["cloud"] == "0"
+    assert by_week["2024-W11"]["cli"] == "1"
+    assert by_week["2024-W11"]["total"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# C-2: --out writes to file
+# ---------------------------------------------------------------------------
+
+
+def test_out_flag_writes_file(
+    runner: CliRunner, isolated_db: Path, tmp_path: Path
+) -> None:
+    """``--out PATH`` writes the CSV to the file and prints nothing on stdout."""
+    _seed_two_weeks(isolated_db)
+    out_file = tmp_path / "counts.csv"
+    result = runner.invoke(
+        ohtv_main, ["report", "weekly-counts", "--out", str(out_file)]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output == "", f"expected empty stdout, got {result.output!r}"
+    assert out_file.exists()
+
+    contents = out_file.read_text()
+    lines = contents.splitlines()
+    assert lines[0] == "week,cloud,cli,total"
+
+    reader = csv.DictReader(io.StringIO(contents))
+    rows = list(reader)
+    assert len(rows) == 2
+    assert {r["week"] for r in rows} == {"2024-W10", "2024-W11"}
+
+
+# ---------------------------------------------------------------------------
+# C-3: empty DB → header-only
+# ---------------------------------------------------------------------------
+
+
+def test_empty_db_emits_header_only(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """No conversations → exactly the header row, exit 0."""
+    result = runner.invoke(ohtv_main, ["report", "weekly-counts"])
+    assert result.exit_code == 0, result.output
+    non_empty_lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert non_empty_lines == ["week,cloud,cli,total"]

--- a/tests/unit/reports/test_weekly_counts.py
+++ b/tests/unit/reports/test_weekly_counts.py
@@ -1,0 +1,330 @@
+"""Unit tests for :mod:`ohtv.reports.weekly_counts` (issue #92).
+
+Exercises the row-shaping + bucketing logic against an in-memory
+SQLite DB with the real migration history applied. No DB mocks.
+
+The ``conn`` fixture lives in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+from datetime import date, datetime, timezone
+
+from ohtv.reports.weekly_counts import (
+    CSV_HEADER,
+    WeeklyCountsReport,
+    WeeklyCountsRow,
+    aggregate_weekly_counts,
+    fetch_rows,
+    format_csv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_conv(
+    conn: sqlite3.Connection,
+    conv_id: str,
+    *,
+    created_at: str | None,
+    source: str = "cloud",
+) -> None:
+    """Minimal conversations insert covering the columns this report touches."""
+    conn.execute(
+        "INSERT INTO conversations (id, location, created_at, source) "
+        "VALUES (?, ?, ?, ?)",
+        (conv_id, f"/tmp/{conv_id}", created_at, source),
+    )
+    conn.commit()
+
+
+def _aggregate(
+    conn: sqlite3.Connection, **kwargs
+) -> WeeklyCountsReport:
+    """Run fetch_rows + aggregate_weekly_counts in one shot."""
+    rows = fetch_rows(
+        conn,
+        since=kwargs.pop("since", None),
+        until=kwargs.pop("until", None),
+        source=kwargs.pop("source", None),
+    )
+    return aggregate_weekly_counts(rows, **kwargs)
+
+
+def _row(report: WeeklyCountsReport, week: str) -> WeeklyCountsRow:
+    for r in report.rows:
+        if r.week_iso == week:
+            return r
+    raise AssertionError(
+        f"week {week!r} not in {[r.week_iso for r in report.rows]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T-1
+# ---------------------------------------------------------------------------
+
+
+def test_single_conversation_one_week(conn: sqlite3.Connection) -> None:
+    """One cloud conv → one row, cloud=1 cli=0 total=1."""
+    _insert_conv(conn, "c1", created_at="2024-03-05T12:00:00Z", source="cloud")
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week_iso == "2024-W10"
+    assert row.cloud == 1
+    assert row.cli == 0
+    assert row.total == 1
+
+
+# ---------------------------------------------------------------------------
+# T-2
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_sources_same_week(conn: sqlite3.Connection) -> None:
+    """3 cloud + 2 local in the same ISO week → cloud=3 cli=2 total=5."""
+    for i in range(3):
+        _insert_conv(
+            conn, f"cloud{i}", created_at=f"2024-03-05T1{i}:00:00Z", source="cloud"
+        )
+    for i in range(2):
+        _insert_conv(
+            conn, f"cli{i}", created_at=f"2024-03-06T1{i}:00:00Z", source="local"
+        )
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week_iso == "2024-W10"
+    assert row.cloud == 3
+    assert row.cli == 2
+    assert row.total == 5
+
+
+# ---------------------------------------------------------------------------
+# T-3
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_weeks_chronological_order(conn: sqlite3.Connection) -> None:
+    """Three weeks of data → three rows in ascending ISO-week order."""
+    _insert_conv(conn, "c1", created_at="2024-03-05T12:00:00Z", source="cloud")  # W10
+    _insert_conv(conn, "c2", created_at="2024-03-12T12:00:00Z", source="cloud")  # W11
+    _insert_conv(conn, "c3", created_at="2024-03-19T12:00:00Z", source="cloud")  # W12
+    report = _aggregate(conn)
+    assert [r.week_iso for r in report.rows] == ["2024-W10", "2024-W11", "2024-W12"]
+    for r in report.rows:
+        assert r.cloud == 1
+        assert r.cli == 0
+        assert r.total == 1
+
+
+# ---------------------------------------------------------------------------
+# T-4 — Year-boundary regression (mandatory)
+# ---------------------------------------------------------------------------
+
+
+def test_iso_week_boundary_2024_12_30(conn: sqlite3.Connection) -> None:
+    """2024-12-30 (a Monday) belongs to ISO 2025-W01, not 2024-W53.
+
+    SQLite ``strftime('%W', ...)`` reports week 53. This test locks
+    in the Python-side ``isocalendar()`` round-trip used by
+    :func:`make_week_period`.
+    """
+    _insert_conv(conn, "c1", created_at="2024-12-30T12:00:00Z", source="cloud")
+    _insert_conv(conn, "c2", created_at="2024-12-31T23:59:59Z", source="local")
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week_iso == "2025-W01"
+    assert row.cloud == 1
+    assert row.cli == 1
+    assert row.total == 2
+
+
+# ---------------------------------------------------------------------------
+# T-5 — Sunday→Monday crossover
+# ---------------------------------------------------------------------------
+
+
+def test_sunday_to_monday_crossover(conn: sqlite3.Connection) -> None:
+    """A Sunday-night conv and a Monday-morning conv land in different weeks."""
+    # 2025-01-05 is Sunday → 2025-W01. 2025-01-06 is Monday → 2025-W02.
+    _insert_conv(conn, "c_sun", created_at="2025-01-05T23:00:00Z", source="cloud")
+    _insert_conv(conn, "c_mon", created_at="2025-01-06T01:00:00Z", source="cloud")
+    report = _aggregate(conn)
+    assert [r.week_iso for r in report.rows] == ["2025-W01", "2025-W02"]
+    assert _row(report, "2025-W01").total == 1
+    assert _row(report, "2025-W02").total == 1
+
+
+# ---------------------------------------------------------------------------
+# T-6 — include_empty
+# ---------------------------------------------------------------------------
+
+
+def test_include_empty_fills_gaps(conn: sqlite3.Connection) -> None:
+    """W10 + W12 with include_empty=True → 3 rows (W10, W11=zeros, W12)."""
+    _insert_conv(conn, "c1", created_at="2024-03-05T12:00:00Z", source="cloud")  # W10
+    _insert_conv(conn, "c2", created_at="2024-03-19T12:00:00Z", source="cloud")  # W12
+    report = _aggregate(conn, include_empty=True)
+    weeks = [r.week_iso for r in report.rows]
+    assert weeks == ["2024-W10", "2024-W11", "2024-W12"]
+    filler = _row(report, "2024-W11")
+    assert filler.cloud == 0
+    assert filler.cli == 0
+    assert filler.total == 0
+
+
+# ---------------------------------------------------------------------------
+# T-7 — exclude_current_week
+# ---------------------------------------------------------------------------
+
+
+def test_exclude_current_week_drops_today(conn: sqlite3.Connection) -> None:
+    """A conv last week + a conv this week, --exclude-current-week → 1 row."""
+    # Anchor "today" deterministically. Pick a Wednesday so "last week"
+    # is unambiguous.
+    today = date(2025, 3, 19)  # Wed of 2025-W12
+    last_week_day = date(2025, 3, 10)  # Mon of 2025-W11
+    _insert_conv(conn, "c_last", created_at=f"{last_week_day}T12:00:00Z", source="cloud")
+    _insert_conv(conn, "c_today", created_at=f"{today}T12:00:00Z", source="cloud")
+    rows = fetch_rows(conn)
+    report = aggregate_weekly_counts(rows, exclude_current_week=True, today=today)
+    assert [r.week_iso for r in report.rows] == ["2025-W11"]
+    assert _row(report, "2025-W11").cloud == 1
+
+
+# ---------------------------------------------------------------------------
+# T-8 — source filter
+# ---------------------------------------------------------------------------
+
+
+def test_source_filter_cli(conn: sqlite3.Connection) -> None:
+    """source='local' filter → cloud column is 0 for every row."""
+    for i in range(3):
+        _insert_conv(
+            conn, f"cloud{i}", created_at=f"2024-03-05T1{i}:00:00Z", source="cloud"
+        )
+    for i in range(2):
+        _insert_conv(
+            conn, f"cli{i}", created_at=f"2024-03-05T2{i}:00:00Z", source="local"
+        )
+    report = _aggregate(conn, source="local")
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.cloud == 0
+    assert row.cli == 2
+    assert row.total == 2
+
+
+# ---------------------------------------------------------------------------
+# T-9 — since/until bounds
+# ---------------------------------------------------------------------------
+
+
+def test_since_until_bounds(conn: sqlite3.Connection) -> None:
+    """``since`` is inclusive, ``until`` is exclusive.
+
+    Boundary-on-since lands inside; boundary-on-until lands outside.
+    """
+    _insert_conv(conn, "c_before", created_at="2024-03-04T12:00:00Z", source="cloud")
+    _insert_conv(conn, "c_on_since", created_at="2024-03-05T00:00:00Z", source="cloud")
+    _insert_conv(conn, "c_inside", created_at="2024-03-06T12:00:00Z", source="cloud")
+    _insert_conv(conn, "c_on_until", created_at="2024-03-12T00:00:00Z", source="cloud")
+    _insert_conv(conn, "c_after", created_at="2024-03-13T00:00:00Z", source="cloud")
+
+    since_dt = datetime(2024, 3, 5, tzinfo=timezone.utc)
+    until_dt = datetime(2024, 3, 12, tzinfo=timezone.utc)
+    report = _aggregate(conn, since=since_dt, until=until_dt)
+
+    # c_on_since + c_inside are in W10; nothing else falls inside.
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week_iso == "2024-W10"
+    assert row.cloud == 2
+    assert row.cli == 0
+    assert row.total == 2
+
+
+# ---------------------------------------------------------------------------
+# T-10 — NULL created_at silently skipped
+# ---------------------------------------------------------------------------
+
+
+def test_null_created_at_skipped(conn: sqlite3.Connection) -> None:
+    """``created_at IS NULL`` rows are filtered at the SQL layer.
+
+    No crash, no row, no count contribution.
+    """
+    _insert_conv(conn, "c_null", created_at=None, source="cloud")
+    _insert_conv(conn, "c_ok", created_at="2024-03-05T12:00:00Z", source="cloud")
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    assert report.rows[0].cloud == 1
+    assert report.rows[0].total == 1
+    # And the SQL-layer skip is the reason — the bucket loop in
+    # Python never sees the row at all.
+    assert report.metadata["raw_row_count"] == 1
+    assert report.metadata["skipped_unparseable"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T-11 — naive timestamp treated as UTC
+# ---------------------------------------------------------------------------
+
+
+def test_naive_timestamp_treated_as_utc(conn: sqlite3.Connection) -> None:
+    """A local-source conv with a naive ISO timestamp is bucketed as if UTC.
+
+    This is the documented behaviour from the module docstring and
+    matches the codebase's treatment of naive local timestamps
+    (AGENTS.md item 5).
+    """
+    _insert_conv(conn, "c_naive", created_at="2024-03-05T12:00:00", source="local")
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    assert row.week_iso == "2024-W10"
+    assert row.cli == 1
+    assert row.cloud == 0
+
+
+# ---------------------------------------------------------------------------
+# T-12 — CSV header uses `cli` not `local`
+# ---------------------------------------------------------------------------
+
+
+def test_csv_header_uses_cli_not_local() -> None:
+    """The CSV header must be exactly ``week,cloud,cli,total``.
+
+    Regression for the naming translation between the DB column
+    value (``local``) and the user-facing CSV column (``cli``).
+    """
+    buf = io.StringIO()
+    rows = [WeeklyCountsRow(week_iso="2024-W10", cloud=3, cli=2, total=5)]
+    format_csv(rows, buf)
+    output = buf.getvalue()
+    first_line = output.splitlines()[0]
+    assert first_line == "week,cloud,cli,total"
+    # And the constant agrees.
+    assert CSV_HEADER == ("week", "cloud", "cli", "total")
+    # Sanity: the data row uses the same column order.
+    assert output.splitlines()[1] == "2024-W10,3,2,5"
+
+
+# ---------------------------------------------------------------------------
+# Extra: format_csv on empty rows still emits header
+# ---------------------------------------------------------------------------
+
+
+def test_format_csv_empty_rows_emits_header_only() -> None:
+    """An empty rows list still produces the header line."""
+    buf = io.StringIO()
+    format_csv([], buf)
+    assert buf.getvalue().splitlines() == ["week,cloud,cli,total"]


### PR DESCRIPTION
## What

Adds a new CSV-only report — `ohtv report weekly-counts` — that emits new-conversation counts bucketed by ISO 8601 week, split into `cloud` / `cli` / `total` columns.

```
$ ohtv report weekly-counts --since 4w
week,cloud,cli,total
2025-W18,12,4,16
2025-W19,8,6,14
2025-W20,15,3,18
2025-W21,11,7,18
```

Flags:
- `--since` / `--until` — accept the same formats as `list`/`refs` (`YYYY-MM-DD`, `7d`, `2w`, `1m`, `today`, `yesterday`)
- `--source [cloud|cli|all]` — restrict to one source (default `all`); `cli` maps to DB `source='local'`
- `--include-empty` — zero-fill weeks with no conversations
- `--exclude-current-week` — drop the in-progress (current) ISO week
- `--out PATH` — write CSV to file instead of stdout

## Why

Closes #92. The issue expansion comment (`gh issue view 92 --comments`) is the canonical spec — this PR implements its narrow-scope plan (counts only, no token/cost columns). The token/cost expansion proposed in the earlier comment is intentionally deferred to a companion issue per the expansion's rationale table.

## Key design points

- **Built on #81's `reports/` scaffolding.** Mirrors `velocity.py`'s pure-data + thin-CLI split so issue #82 (charting) can `from ohtv.reports.weekly_counts import aggregate_weekly_counts` directly.
- **ISO bucketing in Python**, not SQL. SQLite's `strftime('%W', ...)` is GNU/POSIX, not ISO 8601 — it would mis-bucket 2024-12-30 as `2024-W53` instead of `2025-W01`. We use `ohtv.analysis.periods.make_week_period(get_week_start(...)).iso` (same regression rule #81 documents). Test `test_iso_week_boundary_2024_12_30` locks it in.
- **`cli` (CSV) ↔ `local` (DB) naming translation.** The CSV column header is `cli` because that's what the issue title says and what reads naturally in a report; the DB stores `source='local'`. Translation happens in exactly one place: the report module + the `--source` flag mapping. Documented in the module docstring and in AGENTS.md #29.
- **Bucket by `created_at`**, not `updated_at` — matches "new conversations per week" semantics.
- **Timezone caveat documented.** Naive CLI timestamps are treated as UTC for bucketing (consistent with the rest of the codebase per AGENTS.md item 5). Test T-11 locks this in.
- **CSV-only, no `--format table` flag.** Deliberate design — the issue title says CSV, and stdout-CSV-by-default matches the unix-idiomatic shape `velocity --format csv > foo.csv`.

## Testing

- **16 new tests, all green.** Full suite: 1667 passing (1651 baseline + 16 new).
- **13 unit tests** in `tests/unit/reports/test_weekly_counts.py` — T-1 through T-12 per the issue expansion plus an extra empty-rows header test. Fresh `:memory:` SQLite with full migration history applied; raw `conn.execute` seeding, no DB mocks.
- **3 CliRunner smoke tests** in `tests/unit/reports/test_cli_weekly_counts.py` — C-1 stdout, C-2 `--out` file, C-3 empty-DB header-only.
- **Manual smoke** against the sandbox `~/.ohtv/index.db` — command runs end-to-end and emits a parseable CSV.
- **Ruff clean** on every new file. `src/ohtv/cli.py` has pre-existing lint errors (78 baseline) that this PR neither introduces nor fixes.

## Files changed

| File | Change |
|---|---|
| `src/ohtv/reports/weekly_counts.py` | NEW. ~290 LOC: `WeeklyCountsRow` + `WeeklyCountsReport` dataclasses, `fetch_rows`, `aggregate_weekly_counts`, `format_csv`. |
| `src/ohtv/cli.py` | +130 LOC: new `@report.command("weekly-counts")`. |
| `tests/unit/reports/test_weekly_counts.py` | NEW, ~300 LOC, 13 tests. |
| `tests/unit/reports/test_cli_weekly_counts.py` | NEW, ~125 LOC, 3 CliRunner tests. |
| `README.md` | +3 lines: copy-pasteable usage examples under Manual testing. |
| `AGENTS.md` | +7 lines: new point #29 documenting the naming gotcha + UTC caveat. |

Closes #92.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/14ac006e-6138-4661-ac02-b63d857c2adc)