### PR TITLE
chore(charts): wrap ValueError as click.UsageError for unsupported --chart extension

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10681,6 +10681,8 @@ def report_velocity(
                 "Charting requires the [charts] extra. "
                 "Install with: pip install ohtv[charts]"
             ) from exc
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
         return
 
     if fmt == "csv":

--- a/tests/unit/reports/test_cli_chart.py
+++ b/tests/unit/reports/test_cli_chart.py
@@ -173,6 +173,18 @@ def test_cli_chart_missing_matplotlib(
     assert "pip install ohtv[charts]" in result.output
 
 
+def test_cli_chart_unsupported_extension(
+    runner: CliRunner, isolated_db: Path, tmp_path: Path
+) -> None:
+    """Unsupported --chart extension → click.UsageError, exit 2, no traceback."""
+    _seed_one_repo(isolated_db)
+    out = tmp_path / "v.txt"
+    result = runner.invoke(ohtv_main, ["report", "velocity", "--chart", str(out)])
+    assert result.exit_code == 2
+    assert "unsupported output extension" in result.output
+    assert "Traceback" not in result.output
+
+
 # ---------------------------------------------------------------------------
 # C-4: --chart respects --repo filter (data routed through aggregate_velocity).
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #102

## Problem

When `ohtv report velocity --chart <path>` is given a path with an unsupported extension (e.g. `.txt`) or no extension at all, the CLI surfaced the raw Python `ValueError` traceback from `src/ohtv/reports/charts.py:128` instead of a clean Click usage error. Exit code was 1 with a 20-line traceback.

This is inconsistent with the missing-matplotlib path (T-8 in PR #101's manual test report), which correctly raises `click.UsageError` and produces a single-line `Error: …` / `Usage: …` message with exit code 2.

## Fix

Extend the existing `try`/`except` block around the `plot_velocity(...)` call in `src/ohtv/cli.py` to also catch `ValueError` and re-raise it as `click.UsageError`, mirroring the adjacent `ImportError → UsageError` translation:

```python
except ValueError as exc:
    raise click.UsageError(str(exc)) from exc
```

The module-level `ValueError` contract in `src/ohtv/reports/charts.py` is **intentionally preserved** — `tests/unit/reports/test_charts.py::test_unknown_extension_raises` still asserts the raw `ValueError`. Only the CLI's reaction to that exception is polished.

## Changes

- **`src/ohtv/cli.py`** — 2 new lines: an `except ValueError` branch next to the existing `except ImportError` handler.
- **`tests/unit/reports/test_cli_chart.py`** — 1 new test `test_cli_chart_unsupported_extension`, modeled on the existing C-3 `test_cli_chart_missing_matplotlib`.

No new files. No changes to `charts.py`. No changes to README.

## Testing

```
$ uv run pytest tests/unit/reports/test_cli_chart.py tests/unit/reports/test_charts.py -v
18 passed
$ uv run pytest -q
1739 passed
```

The full suite went from 1738 → 1739 (one new test added).

## Acceptance criteria

- [x] `uv run ohtv report velocity --chart /tmp/foo.txt` exits with code 2, printing a single-line `Error: unsupported output extension '.txt'; expected one of ['.pdf', '.png', '.svg']` — no Python traceback.
- [x] `uv run ohtv report velocity --chart /tmp/foo` (no extension) behaves identically: single-line usage error, no traceback.
- [x] The existing C-3 missing-matplotlib path still works (regression: `test_cli_chart_missing_matplotlib` still passes).
- [x] `test_charts.py::test_unknown_extension_raises` still passes unchanged (module-level contract preserved).

---

This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford.

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/87d0f992-3216-4bff-b973-f18508d6d60c)