### PR TITLE
fix(sync): sort by updated_at DESC in reset_to_n_newest (#107)

### DIFF
--- a/REFERENCE_CLOUD_API.md
+++ b/REFERENCE_CLOUD_API.md
@@ -127,7 +127,7 @@ curl -s "https://app.all-hands.dev/api/v1/app-conversations/search?updated_at__g
   -H "Authorization: Bearer $OH_API_KEY"
 ```
 
-**Note on Sorting:** Results are returned in descending order by `updated_at` (most recently updated first).
+**Note on Sorting:** Results are returned in descending order by `created_at` (most recently created first). The endpoint does not accept a `sort` parameter; callers that need `updated_at` ordering must sort client-side.
 
 ---
 

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -1139,11 +1139,20 @@ class SyncManager:
         try:
             with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
                 # Fetch all conversations from cloud.
-                # Note: API returns conversations sorted by updated_at descending (newest first).
-                # See REFERENCE_CLOUD_API.md for sort order documentation.
+                # The /search endpoint returns items in created_at DESC order and exposes
+                # no `sort` parameter (see REFERENCE_CLOUD_API.md). To honor this method's
+                # documented "N most recently updated" semantic, sort client-side by
+                # updated_at DESC before truncating. Items with a missing/None updated_at
+                # are coerced to "" so they sort to the end under reverse=True — a
+                # conversation with unknown updated_at must not displace a known-recent
+                # one from the keep set (issue #107).
                 conversations = client.search_all_conversations()
                 log.info("Found %d total conversations in cloud", len(conversations))
-                
+                conversations.sort(
+                    key=lambda c: c.get("updated_at") or "",
+                    reverse=True,
+                )
+
                 # Take only first N
                 conversations_to_sync = conversations[:n]
                 

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -2000,3 +2000,119 @@ class TestMetadataDiffDataclass:
         ]:
             diff = MetadataDiff(**{kwarg: True})
             assert diff.any_changed is True, f"any_changed False for {kwarg}"
+
+
+
+class TestResetToNNewest:
+    """Tests for SyncManager.reset_to_n_newest() client-side sort (Issue #107).
+
+    The cloud /search endpoint returns items in created_at DESC order and has no
+    `sort` parameter, so reset_to_n_newest must sort by updated_at DESC
+    client-side to honor its documented "N most recently updated" semantic.
+    """
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        """SyncManager with a tmp manifest and mocked config."""
+        config = MagicMock()
+        config.api_key = "test-key"
+        config.cloud_api_url = "https://example.com"
+        config.synced_conversations_dir = tmp_path / "synced"
+        with patch("ohtv.sync.get_manifest_path", return_value=tmp_path / "manifest.json"):
+            return SyncManager(config)
+
+    def test_returns_n_items_sorted_by_updated_at_desc(self, manager):
+        """The N items kept must be those with the newest updated_at, even when
+        that ordering disagrees with created_at (which is what the API returns)."""
+        # Listing as the API would return it: created_at DESC.
+        # Note: conv "B" has the oldest created_at but the newest updated_at —
+        # the pre-#107 code would have dropped it; the fix must keep it.
+        listing = [
+            {"id": "A", "title": "A", "created_at": "2026-05-20T00:00:00Z", "updated_at": "2026-05-20T00:00:00Z"},
+            {"id": "C", "title": "C", "created_at": "2026-05-15T00:00:00Z", "updated_at": "2026-05-22T00:00:00Z"},
+            {"id": "D", "title": "D", "created_at": "2026-05-10T00:00:00Z", "updated_at": "2026-05-18T00:00:00Z"},
+            {"id": "E", "title": "E", "created_at": "2026-05-05T00:00:00Z", "updated_at": "2026-05-12T00:00:00Z"},
+            {"id": "B", "title": "B", "created_at": "2026-05-01T00:00:00Z", "updated_at": "2026-05-25T00:00:00Z"},
+        ]
+        client = _RecordingCloudClient(listing)
+
+        progress: list[str] = []
+
+        def on_progress(conv_id, title, status):
+            progress.append(conv_id)
+
+        with patch("ohtv.sync.CloudClient", return_value=client):
+            result = manager.reset_to_n_newest(n=3, dry_run=True, on_progress=on_progress)
+
+        # Newest-updated three are B (05-25), C (05-22), A (05-20). E and D drop.
+        assert progress == ["B", "C", "A"]
+        assert result.new == 3
+        assert result.skipped_new == 2
+
+    def test_missing_updated_at_sorts_last(self, manager):
+        """Items with updated_at=None must sort to the END so that an unknown
+        timestamp can never displace a known-recent conversation from the keep
+        set — even when the item has a very recent created_at."""
+        listing = [
+            {"id": "A", "title": "A", "created_at": "2026-05-20T00:00:00Z", "updated_at": "2026-05-20T00:00:00Z"},
+            # X has the newest created_at but updated_at=None. It must NOT
+            # displace A or C, both of which have a known updated_at.
+            {"id": "X", "title": "X", "created_at": "2026-05-25T00:00:00Z", "updated_at": None},
+            {"id": "C", "title": "C", "created_at": "2026-05-15T00:00:00Z", "updated_at": "2026-05-22T00:00:00Z"},
+        ]
+        client = _RecordingCloudClient(listing)
+
+        progress: list[str] = []
+
+        def on_progress(conv_id, title, status):
+            progress.append(conv_id)
+
+        with patch("ohtv.sync.CloudClient", return_value=client):
+            result = manager.reset_to_n_newest(n=2, dry_run=True, on_progress=on_progress)
+
+        # C (updated 05-22) > A (updated 05-20) > X (created 05-25 fallback).
+        # Two highest are C and A. X is dropped despite having the newest
+        # created_at, because updated_at is the primary sort key.
+        assert progress == ["C", "A"]
+        assert result.new == 2
+        assert result.skipped_new == 1
+
+    def test_preserves_all_items_when_n_exceeds_total(self, manager):
+        """When N >= total, every item is kept; skipped_new is 0."""
+        listing = [
+            {"id": "A", "title": "A", "created_at": "2026-05-20T00:00:00Z", "updated_at": "2026-05-20T00:00:00Z"},
+            {"id": "B", "title": "B", "created_at": "2026-05-10T00:00:00Z", "updated_at": "2026-05-22T00:00:00Z"},
+            {"id": "C", "title": "C", "created_at": "2026-05-15T00:00:00Z", "updated_at": "2026-05-18T00:00:00Z"},
+        ]
+        client = _RecordingCloudClient(listing)
+
+        progress: list[str] = []
+
+        def on_progress(conv_id, title, status):
+            progress.append(conv_id)
+
+        with patch("ohtv.sync.CloudClient", return_value=client):
+            result = manager.reset_to_n_newest(n=10, dry_run=True, on_progress=on_progress)
+
+        # All 3 kept, still sorted by updated_at DESC: B (05-22), A (05-20), C (05-18).
+        assert progress == ["B", "A", "C"]
+        assert result.new == 3
+        assert result.skipped_new == 0
+
+    def test_empty_cloud_is_noop(self, manager):
+        """Empty cloud listing must produce a clean no-op SyncResult (no errors,
+        no progress callbacks). Guards against TypeError or IndexError on []."""
+        client = _RecordingCloudClient([])
+
+        progress: list[tuple] = []
+
+        def on_progress(conv_id, title, status):
+            progress.append((conv_id, status))
+
+        with patch("ohtv.sync.CloudClient", return_value=client):
+            result = manager.reset_to_n_newest(n=5, dry_run=True, on_progress=on_progress)
+
+        assert progress == []
+        assert result.new == 0
+        assert result.skipped_new == 0
+


### PR DESCRIPTION
Fixes #107.

## Summary

`ohtv sync --force -n N` documented itself as keeping the N most recently **updated** conversations, but the cloud `/api/v1/app-conversations/search` endpoint actually returns items in `created_at` DESC order and exposes no `sort` parameter. As a result, `--force -n` was keeping the N most recently **created** conversations — silently excluding long-running conversations whose creation date had drifted out of the top N.

Per the expansion comment on the issue (Option A — fix the code, not the docs), this PR adds a client-side sort by `updated_at` DESC inside `SyncManager.reset_to_n_newest` before the `[:n]` slice. ~3 lines of code, plus collateral fixes to the comment/docs that propagated the same false claim about cloud-side ordering.

## Changed locations

1. **`src/ohtv/sync.py` — `reset_to_n_newest` (~L1144)**  
   Added `conversations.sort(key=lambda c: c.get("updated_at") or "", reverse=True)` after the `search_all_conversations()` call. Items with missing/None `updated_at` are coerced to `""` so they sort to the end under `reverse=True` — an unknown timestamp must not displace a known-recent conversation from the keep set.

2. **`src/ohtv/sync.py` — inline comment (~L1142)**  
   The pre-fix comment claimed *"API returns conversations sorted by updated_at descending (newest first). See REFERENCE_CLOUD_API.md for sort order documentation."* That was wrong. Replaced with an accurate description of the actual API behavior + the reason for the client-side sort.

3. **`REFERENCE_CLOUD_API.md` L130**  
   Corrected the same false claim. New text: *"Results are returned in descending order by `created_at` (most recently created first). The endpoint does not accept a `sort` parameter; callers that need `updated_at` ordering must sort client-side."*

## Test plan

Added `TestResetToNNewest` class (`tests/unit/test_sync.py`) reusing the existing `_RecordingCloudClient` fake. Four unit tests:

- `test_returns_n_items_sorted_by_updated_at_desc` — regression for #107. Listing has 5 conversations with deliberately mis-aligned `created_at`/`updated_at`; the conversation with the oldest `created_at` has the newest `updated_at` and must be kept (the pre-fix code would have dropped it).
- `test_missing_updated_at_sorts_last` — documents that `updated_at=None` sorts to the end and cannot displace a known-recent conversation, even when `created_at` is the newest in the listing.
- `test_preserves_all_items_when_n_exceeds_total` — sanity: N ≥ total keeps everything; `skipped_new == 0`.
- `test_empty_cloud_is_noop` — guards against `TypeError`/`IndexError` on an empty listing.

Local results:

```
tests/unit/test_sync.py::TestResetToNNewest::test_returns_n_items_sorted_by_updated_at_desc PASSED
tests/unit/test_sync.py::TestResetToNNewest::test_missing_updated_at_sorts_last PASSED
tests/unit/test_sync.py::TestResetToNNewest::test_preserves_all_items_when_n_exceeds_total PASSED
tests/unit/test_sync.py::TestResetToNNewest::test_empty_cloud_is_noop PASSED
```

Full suite: `1695 passed, 24 warnings in 26.63s`. No new ruff findings (the one pre-existing F841 in `test_sync.py:654` is unrelated to this PR).

## Drift note

The expansion comment proposed a fallback chain `c.get("updated_at") or c.get("created_at") or ""`. That chain has a subtle defect: an item with a brand-new `created_at` but no `updated_at` would rank as if it had been recently updated, which the orchestration prompt explicitly called out as the wrong behavior ("sort `None` to the END, not the beginning, since a missing `updated_at` shouldn't displace a known-recent conversation from the keep set"). I implemented the simpler `c.get("updated_at") or ""` to honor that constraint. Test #2 (`test_missing_updated_at_sorts_last`) locks in this semantic.

The expansion also suggested tightening `src/ohtv/cli.py:329–330`'s `sync` command docstring; the prompt explicitly scoped that out of this PR. Left untouched.

## Out of scope

The broader sync-cursor rewrite is tracked in **#110 / #111 / #112 / #113 / #114** and is intentionally not addressed here. `reset_to_n_newest` continues to behave the same way for sub-conversations (#108) and concurrent invocations (#109).

---

_This pull request was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/705e31a1-d37c-4433-9d16-f3d03808f737)