### PR TITLE
feat(embeddings): support EMBEDDING_API_KEY / EMBEDDING_BASE_URL overrides

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,6 +20,8 @@ Environment variables, data directories, and logging.
 | `LLM_BASE_URL` | Custom LLM base URL | Provider default |
 | `LLM_TIMEOUT` | LLM request timeout in seconds | `300` |
 | `EMBEDDING_MODEL` | Model for embeddings (`db embed`, `search`) | `openai/text-embedding-3-small` |
+| `EMBEDDING_API_KEY` | API key for embedding calls (overrides `LLM_API_KEY` for embeddings only) | Falls back to `LLM_API_KEY` |
+| `EMBEDDING_BASE_URL` | Base URL for embedding calls (overrides `LLM_BASE_URL` for embeddings only) | Falls back to `LLM_BASE_URL` |
 | `GITHUB_TOKEN` | GitHub PAT (read-only is fine) or `gh auth token` output | Required for `fetch-loc` (non-dry-run) |
 
 ### Precedence

--- a/src/ohtv/analysis/embeddings/client.py
+++ b/src/ohtv/analysis/embeddings/client.py
@@ -3,7 +3,9 @@
 Handles configuration, API interaction, and result types.
 
 Supports two modes:
-- LiteLLM: Uses LLM_API_KEY and LLM_BASE_URL for cloud embeddings
+- LiteLLM: Uses EMBEDDING_API_KEY / EMBEDDING_BASE_URL (preferred when
+  embeddings target a different proxy than chat models), falling back to
+  LLM_API_KEY / LLM_BASE_URL.
 - Ollama: Uses local Ollama server (set EMBEDDING_MODEL=ollama/nomic-embed-text)
 
 Includes a global rate limiter that coordinates backoff across all threads
@@ -18,7 +20,11 @@ from dataclasses import dataclass
 
 import litellm
 
-from ohtv.analysis.embeddings.config import get_effective_embedding_model
+from ohtv.analysis.embeddings.config import (
+    get_effective_embedding_api_key,
+    get_effective_embedding_base_url,
+    get_effective_embedding_model,
+)
 
 # Suppress LiteLLM info messages that spam output during batch operations
 litellm.suppress_debug_info = True
@@ -355,15 +361,18 @@ def get_embedding(text: str, model: str | None = None) -> EmbeddingResult:
     if model.startswith("ollama/"):
         return _get_ollama_embedding(text, model)
 
-    # Use LiteLLM for cloud models
-    api_key = os.environ.get("LLM_API_KEY")
-    api_base = os.environ.get("LLM_BASE_URL")
+    # Use LiteLLM for cloud models. Embeddings can target a different
+    # proxy/provider than chat models via EMBEDDING_API_KEY / EMBEDDING_BASE_URL;
+    # both fall back to LLM_API_KEY / LLM_BASE_URL when unset.
+    api_key = get_effective_embedding_api_key()
+    api_base = get_effective_embedding_base_url()
 
     if not api_key:
         raise RuntimeError(
-            "LLM_API_KEY environment variable not set. "
-            "This is required for embedding generation. "
-            "Or use EMBEDDING_MODEL=ollama/nomic-embed-text for local embeddings."
+            "No API key configured for embeddings. "
+            "Set EMBEDDING_API_KEY (preferred when embeddings use a different "
+            "proxy than chat) or LLM_API_KEY. "
+            "Alternatively use EMBEDDING_MODEL=ollama/nomic-embed-text for local embeddings."
         )
 
     log.debug("Getting embedding with model %s", model)

--- a/src/ohtv/analysis/embeddings/config.py
+++ b/src/ohtv/analysis/embeddings/config.py
@@ -193,11 +193,14 @@ def test_litellm_embedding(model: str) -> tuple[bool, str | None]:
     Returns:
         Tuple of (success, error_message)
     """
-    api_key = os.environ.get("LLM_API_KEY")
-    api_base = os.environ.get("LLM_BASE_URL")
-    
+    api_key = get_effective_embedding_api_key()
+    api_base = get_effective_embedding_base_url()
+
     if not api_key:
-        return False, "LLM_API_KEY environment variable not set"
+        return False, (
+            "No API key configured for embeddings. "
+            "Set EMBEDDING_API_KEY (preferred) or LLM_API_KEY."
+        )
     
     try:
         import litellm
@@ -264,8 +267,8 @@ def get_current_config() -> EmbeddingConfig:
                 source="file",
             )
     
-    # Check if LLM_API_KEY is set (implies cloud embedding might work)
-    if os.environ.get("LLM_API_KEY"):
+    # Check if an embedding/LLM API key is set (implies cloud embedding might work)
+    if get_effective_embedding_api_key():
         return EmbeddingConfig(
             provider=EmbeddingProvider.LITELLM,
             model="openai/text-embedding-3-small",  # Default
@@ -342,6 +345,28 @@ def get_effective_embedding_model() -> str | None:
     return _load_config().get("embedding_model")
 
 
+def get_effective_embedding_api_key() -> str | None:
+    """Get the API key to use for embedding API calls.
+
+    Embeddings often need to be routed to a different LiteLLM proxy /
+    OpenAI-compatible endpoint than chat models (e.g. an evaluation proxy
+    that exposes embedding models, while the main proxy only exposes
+    chat models). Prefer ``EMBEDDING_API_KEY`` when set, otherwise fall
+    back to ``LLM_API_KEY`` to preserve existing behavior.
+    """
+    return os.environ.get("EMBEDDING_API_KEY") or os.environ.get("LLM_API_KEY")
+
+
+def get_effective_embedding_base_url() -> str | None:
+    """Get the base URL to use for embedding API calls.
+
+    Prefer ``EMBEDDING_BASE_URL`` when set, otherwise fall back to
+    ``LLM_BASE_URL``. See :func:`get_effective_embedding_api_key` for
+    motivation.
+    """
+    return os.environ.get("EMBEDDING_BASE_URL") or os.environ.get("LLM_BASE_URL")
+
+
 def is_embedding_configured() -> bool:
     """Check if embedding is configured (either via env or config file).
     
@@ -351,8 +376,8 @@ def is_embedding_configured() -> bool:
     if os.environ.get("EMBEDDING_MODEL"):
         return True
     
-    # Check LLM_API_KEY (implies default model can be used)
-    if os.environ.get("LLM_API_KEY"):
+    # Check whether an embedding/LLM API key is set (implies default model can be used)
+    if get_effective_embedding_api_key():
         return True
     
     # Check config file

--- a/tests/unit/analysis/test_embedding_env_overrides.py
+++ b/tests/unit/analysis/test_embedding_env_overrides.py
@@ -1,0 +1,133 @@
+"""Tests for embedding-specific env var overrides.
+
+Embeddings can be routed to a different LiteLLM proxy / OpenAI-compatible
+endpoint than chat models by setting EMBEDDING_API_KEY / EMBEDDING_BASE_URL.
+When those are unset, the embedding helpers fall back to LLM_API_KEY /
+LLM_BASE_URL (the historical behavior).
+"""
+
+import pytest
+
+from ohtv.analysis.embeddings.config import (
+    get_effective_embedding_api_key,
+    get_effective_embedding_base_url,
+    is_embedding_configured,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_embedding_env(monkeypatch):
+    """Ensure each test starts with a clean env for the relevant vars."""
+    for k in ("EMBEDDING_API_KEY", "EMBEDDING_BASE_URL", "LLM_API_KEY", "LLM_BASE_URL", "EMBEDDING_MODEL"):
+        monkeypatch.delenv(k, raising=False)
+
+
+class TestEffectiveEmbeddingApiKey:
+    def test_returns_none_when_nothing_set(self):
+        assert get_effective_embedding_api_key() is None
+
+    def test_falls_back_to_llm_api_key(self, monkeypatch):
+        monkeypatch.setenv("LLM_API_KEY", "sk-fallback")
+        assert get_effective_embedding_api_key() == "sk-fallback"
+
+    def test_prefers_embedding_api_key(self, monkeypatch):
+        monkeypatch.setenv("LLM_API_KEY", "sk-fallback")
+        monkeypatch.setenv("EMBEDDING_API_KEY", "sk-embed")
+        assert get_effective_embedding_api_key() == "sk-embed"
+
+    def test_embedding_only_when_no_llm(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_API_KEY", "sk-embed")
+        assert get_effective_embedding_api_key() == "sk-embed"
+
+
+class TestEffectiveEmbeddingBaseUrl:
+    def test_returns_none_when_nothing_set(self):
+        assert get_effective_embedding_base_url() is None
+
+    def test_falls_back_to_llm_base_url(self, monkeypatch):
+        monkeypatch.setenv("LLM_BASE_URL", "https://chat.example.com")
+        assert get_effective_embedding_base_url() == "https://chat.example.com"
+
+    def test_prefers_embedding_base_url(self, monkeypatch):
+        monkeypatch.setenv("LLM_BASE_URL", "https://chat.example.com")
+        monkeypatch.setenv("EMBEDDING_BASE_URL", "https://embed.example.com")
+        assert get_effective_embedding_base_url() == "https://embed.example.com"
+
+
+class TestIsEmbeddingConfigured:
+    def test_false_when_nothing_set(self):
+        assert is_embedding_configured() is False
+
+    def test_true_when_only_embedding_api_key_set(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_API_KEY", "sk-embed")
+        assert is_embedding_configured() is True
+
+    def test_true_when_only_llm_api_key_set(self, monkeypatch):
+        monkeypatch.setenv("LLM_API_KEY", "sk-fallback")
+        assert is_embedding_configured() is True
+
+    def test_true_when_embedding_model_env_set(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_MODEL", "ollama/nomic-embed-text")
+        assert is_embedding_configured() is True
+
+
+class TestClientUsesEffectiveCredentials:
+    """get_embedding() must use EMBEDDING_* env vars when set, else LLM_*."""
+
+    def test_get_embedding_uses_embedding_env_when_set(self, monkeypatch):
+        from ohtv.analysis.embeddings import client as embed_client
+
+        captured: dict = {}
+
+        class _Resp:
+            data = [{"embedding": [0.1, 0.2, 0.3]}]
+            usage = type("U", (), {"total_tokens": 4})()
+
+        def _fake_litellm_embedding(model, input, api_key, api_base):
+            captured["model"] = model
+            captured["api_key"] = api_key
+            captured["api_base"] = api_base
+            return _Resp()
+
+        monkeypatch.setenv("LLM_API_KEY", "sk-chat")
+        monkeypatch.setenv("LLM_BASE_URL", "https://chat.example.com")
+        monkeypatch.setenv("EMBEDDING_API_KEY", "sk-embed")
+        monkeypatch.setenv("EMBEDDING_BASE_URL", "https://embed.example.com")
+
+        monkeypatch.setattr(embed_client.litellm, "embedding", _fake_litellm_embedding)
+
+        result = embed_client.get_embedding("hello", model="openai/text-embedding-3-small")
+
+        assert result.embedding == [0.1, 0.2, 0.3]
+        assert captured["api_key"] == "sk-embed"
+        assert captured["api_base"] == "https://embed.example.com"
+
+    def test_get_embedding_falls_back_to_llm_env(self, monkeypatch):
+        from ohtv.analysis.embeddings import client as embed_client
+
+        captured: dict = {}
+
+        class _Resp:
+            data = [{"embedding": [0.4]}]
+            usage = type("U", (), {"total_tokens": 2})()
+
+        def _fake_litellm_embedding(model, input, api_key, api_base):
+            captured["api_key"] = api_key
+            captured["api_base"] = api_base
+            return _Resp()
+
+        monkeypatch.setenv("LLM_API_KEY", "sk-chat")
+        monkeypatch.setenv("LLM_BASE_URL", "https://chat.example.com")
+
+        monkeypatch.setattr(embed_client.litellm, "embedding", _fake_litellm_embedding)
+
+        embed_client.get_embedding("hello", model="openai/text-embedding-3-small")
+
+        assert captured["api_key"] == "sk-chat"
+        assert captured["api_base"] == "https://chat.example.com"
+
+    def test_get_embedding_raises_when_no_key(self, monkeypatch):
+        from ohtv.analysis.embeddings import client as embed_client
+
+        with pytest.raises(RuntimeError, match="EMBEDDING_API_KEY"):
+            embed_client.get_embedding("hello", model="openai/text-embedding-3-small")


### PR DESCRIPTION
## Why

Some setups route embedding requests to a different LiteLLM proxy / OpenAI-compatible endpoint than chat models. Concrete example that motivated this: the **app** LiteLLM proxy (`llm-proxy.app.all-hands.dev`) is used for chat models in `ohtv` analysis, but only the **eval** proxy (`llm-proxy.eval.all-hands.dev`) exposes embedding models. Today `ohtv` reads `LLM_API_KEY` / `LLM_BASE_URL` for *both* analysis and embeddings, so the only way to switch proxies for the embedding stage is to overwrite the chat config or run analysis and embed in two separate shells.

## What

Add two new env vars that override the chat-model env *for embedding calls only*:

| Env var | Falls back to | Used by |
|---|---|---|
| `EMBEDDING_API_KEY` | `LLM_API_KEY` | `get_embedding()`, `test_litellm_embedding()` |
| `EMBEDDING_BASE_URL` | `LLM_BASE_URL` | `get_embedding()`, `test_litellm_embedding()` |

If `EMBEDDING_*` is unset, the existing behavior is preserved exactly — single-proxy users notice no change.

Two small helpers in `ohtv/analysis/embeddings/config.py` (`get_effective_embedding_api_key`, `get_effective_embedding_base_url`) centralize the precedence logic so every call site stays one line.

## Files changed

- `src/ohtv/analysis/embeddings/config.py` — new helpers; `test_litellm_embedding()`, `get_current_config()`, `is_embedding_configured()` use them.
- `src/ohtv/analysis/embeddings/client.py` — `get_embedding()` uses them; module docstring updated; error message when no key is set mentions both vars.
- `tests/unit/analysis/test_embedding_env_overrides.py` — 14 new unit tests: helper precedence + fallback, `is_embedding_configured()` matrix, and an end-to-end `get_embedding()` test that fakes `litellm.embedding` and asserts the wire credentials match the `EMBEDDING_*` values when both are set (and `LLM_*` when only those are).
- `docs/reference/configuration.md` — two new rows in the env var table.

## Backwards compat

- No call sites that previously worked are removed or renamed.
- Behavior when only `LLM_API_KEY` / `LLM_BASE_URL` are set: identical to today.
- Behavior when only `EMBEDDING_API_KEY` / `EMBEDDING_BASE_URL` are set: now works (was an error before).
- Behavior when both pairs are set: `EMBEDDING_*` wins for embedding calls only.

## Tests

- Targeted unit tests: 14 passed.
- All embedding-adjacent tests (`test_embeddings.py`, `test_sync_embeddings.py`, `test_embedding_progress.py`, `test_embedding_store.py`): 146 passed.
- Full unit suite: **1709 passed**, 0 new failures, 0 new warnings.
- `ruff check` on changed files: introduces 0 new lint errors (the 3 pre-existing F401s in this dir are unchanged).

## Live verification

End-to-end check against a real LiteLLM proxy:

```python
os.environ["LLM_API_KEY"]       = "sk-not-the-right-one"           # intentional wrong proxy
os.environ["LLM_BASE_URL"]      = "https://llm-proxy.app.all-hands.dev/"
os.environ["EMBEDDING_API_KEY"] = "<real eval-proxy virtual key>"
os.environ["EMBEDDING_BASE_URL"]= "https://llm-proxy.eval.all-hands.dev"

from ohtv.analysis.embeddings.client import get_embedding
r = get_embedding("ohtv embedding test", model="litellm_proxy/openai/text-embedding-3-small")
# → OK  dims=1536  tokens=5  model=litellm_proxy/openai/text-embedding-3-small
```

The call was correctly routed to the eval proxy even though `LLM_*` was pointing somewhere else.

## Migration notes

For users who run `ohtv sync` and want a split: drop into the env *only* the new vars; keep `LLM_API_KEY` / `LLM_BASE_URL` exactly as they were.

```bash
export EMBEDDING_API_KEY=sk-...
export EMBEDDING_BASE_URL=https://llm-proxy.eval.all-hands.dev
# LLM_API_KEY / LLM_BASE_URL unchanged → still used for analysis
ohtv sync
```

---

_This PR was prepared by an AI agent (OpenHands) on behalf of @jpshackelford._