### PR TITLE
fix(cache): alias auto-promoted context_level so re-runs hit the cache (#129)

### DIFF
--- a/src/ohtv/analysis/cache.py
+++ b/src/ohtv/analysis/cache.py
@@ -370,8 +370,27 @@ class AnalysisCacheManager:
             log.warning("Failed to parse cached analysis for key '%s': %s", cache_key, e)
             return None
 
-        # Validate content hash (specific to this analysis's context level)
-        if analysis.content_hash != content_hash:
+        # Detect alias hits (issue #129): the stored analysis carries its true
+        # effective ``context_level`` (the level the LLM actually saw). When
+        # that differs from the requested level encoded in the cache_key, we
+        # are reading the analysis through its alias entry — the caller asked
+        # for ``minimal`` but the writer auto-promoted to ``default``/``full``
+        # and stored a key alias pointing at the promoted content.
+        requested_context = validation_kwargs.get("context_level")
+        is_alias_hit = (
+            requested_context is not None
+            and getattr(analysis, "context_level", requested_context)
+            != requested_context
+        )
+
+        # Validate content hash (specific to this analysis's context level).
+        # On an alias hit we skip this check: the cached analysis's
+        # ``content_hash`` was computed from the *promoted* transcript while
+        # ``content_hash`` here is computed from the *requested* (typically
+        # narrower) transcript — they will always differ. The event-count
+        # check above already guards against the conversation actually
+        # changing under us.
+        if not is_alias_hit and analysis.content_hash != content_hash:
             log.debug("Cache invalidated for key '%s': content hash mismatch", cache_key)
             return None
 
@@ -386,8 +405,20 @@ class AnalysisCacheManager:
                 )
                 return None
 
-        # Validate that stored parameters match requested parameters
+        # Validate that stored parameters match requested parameters.
+        # NOTE (issue #129): we deliberately skip ``context_level`` here.
+        # The cache_key already encodes context_level (it's a kwarg in
+        # ``_make_cache_key``), so a key match is sufficient. We need the
+        # tolerance for "alias" entries written by ``save(requested_key_kwargs=...)``
+        # — when ``analyze_objectives`` auto-promotes a worker conversation
+        # from ``minimal`` to ``default``/``full``, the LLM result is stored
+        # under BOTH cache keys (effective and requested) but the analysis
+        # content retains its true ``context_level`` (the level the LLM saw).
+        # Re-validating equality on context_level would reject the alias hit
+        # and re-trigger an LLM call on every run.
         for key, expected_value in validation_kwargs.items():
+            if key == "context_level":
+                continue
             cached_value = getattr(analysis, key, None)
             if cached_value != expected_value:
                 log.debug(
@@ -407,6 +438,7 @@ class AnalysisCacheManager:
         conv_dir: Path,
         analysis: T,
         update_embeddings: bool = False,
+        requested_key_kwargs: dict[str, Any] | None = None,
         **key_kwargs,
     ) -> None:
         """Save analysis to cache.
@@ -417,6 +449,15 @@ class AnalysisCacheManager:
             update_embeddings: Whether to update the analysis embedding in the
                 database. This triggers an API call to generate embeddings.
                 Default is False to avoid hidden side effects.
+            requested_key_kwargs: Optional alternative key parameters
+                representing what the caller originally asked for, when that
+                differs from the *effective* parameters reflected on the
+                analysis itself (see issue #129). When the resulting alias key
+                differs from the primary key, this method writes a SECOND
+                cache entry under the alias key pointing at the SAME analysis
+                content. Use this when the analysis pipeline auto-promotes
+                context level for worker conversations so that a subsequent
+                lookup at the originally-requested level still hits the cache.
             **key_kwargs: Parameters that identify the analysis type.
                 If not provided, extracts from analysis object attributes
                 matching common parameter names.
@@ -438,21 +479,43 @@ class AnalysisCacheManager:
 
         cache_key = _make_cache_key(**key_kwargs)
 
-        # Store analysis under its key
         if "analyses" not in cache_data:
             cache_data["analyses"] = {}
 
-        cache_data["analyses"][cache_key] = analysis.model_dump(mode="json")
+        # Build the set of keys this analysis should be discoverable under.
+        # Always includes the primary (effective) key; optionally includes an
+        # alias key derived from the originally-requested parameters (see
+        # issue #129).
+        keys_to_write = [cache_key]
+        if requested_key_kwargs:
+            alias_key = _make_cache_key(**requested_key_kwargs)
+            if alias_key != cache_key:
+                keys_to_write.append(alias_key)
+
+        # Store analysis under each key. The stored content is the SAME for
+        # primary and alias (per issue #129 AC: "only the cache_key mapping is
+        # duplicated, not the stored analysis content"). The dumped dict
+        # retains the analysis's true effective ``context_level`` regardless
+        # of which key it's stored under.
+        analysis_dump = analysis.model_dump(mode="json")
+        for write_key in keys_to_write:
+            cache_data["analyses"][write_key] = analysis_dump
 
         # Clear any skip marker since we successfully analyzed
         cache_data.pop("skipped", None)
 
         self._save_cache_data(cache_file, cache_data)
-        log.debug("Analysis cached to %s (key: %s)", cache_file, cache_key)
-        
-        # Sync to database if available
-        self._sync_cache_to_db(conv_dir.name, cache_key, analysis)
-        
+        log.debug(
+            "Analysis cached to %s (keys: %s)",
+            cache_file,
+            ", ".join(keys_to_write),
+        )
+
+        # Sync to database if available — one row per key, all pointing at
+        # the same content_hash / event_count.
+        for write_key in keys_to_write:
+            self._sync_cache_to_db(conv_dir.name, write_key, analysis)
+
         # Update analysis embedding only if explicitly requested
         if update_embeddings:
             self._update_analysis_embedding(conv_dir, analysis, cache_key)

--- a/src/ohtv/analysis/objectives.py
+++ b/src/ohtv/analysis/objectives.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -650,9 +650,22 @@ def analyze_objectives(
             secondary_outcomes=result.get("secondary_outcomes", []),
         )
 
-    # Cache the result
+    # Cache the result. When the effective context level differs from what
+    # the caller originally requested (auto-promotion above for worker
+    # conversations, or assess-driven upgrade), also write a cache-key alias
+    # under the requested level so subsequent lookups at that level hit the
+    # cache instead of re-invoking the LLM (issue #129).
+    requested_key_kwargs: dict[str, Any] | None = None
+    if effective_context != context:
+        requested_key_kwargs = {
+            "assess": assess,
+            "context_level": context,
+            "detail_level": detail,
+        }
     with _timer("save_cache"):
-        _cache_manager.save(conv_dir, analysis)
+        _cache_manager.save(
+            conv_dir, analysis, requested_key_kwargs=requested_key_kwargs
+        )
 
     total_elapsed = (time.perf_counter() - total_start) * 1000
     log.debug(

--- a/tests/unit/analysis/test_cache_alias_promoted_context.py
+++ b/tests/unit/analysis/test_cache_alias_promoted_context.py
@@ -1,0 +1,251 @@
+"""Regression tests for issue #129.
+
+`ohtv gen objs` (multi-conversation mode) was re-reporting the same worker
+conversations as "needs analysis" on every run because the write path stored
+results under the *auto-promoted* ``context_level`` key while the read path
+looked them up under the originally-*requested* level. The fix writes an
+alias cache_key entry under the requested level pointing at the same
+analysis content, so subsequent lookups at the requested level hit the cache.
+
+These tests pin the two behaviors called out in the issue's Acceptance
+Criteria:
+
+* A second ``analyze_objectives(..., context="minimal")`` call against a
+  worker-style fixture (no user messages, finish action present) hits the
+  cache (``from_cache=True``) and does NOT invoke the LLM.
+* ``_count_uncached_conversations_fast`` reports 0 uncached conversations
+  after a single analyze run on the same fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ohtv_dir(monkeypatch, tmp_path):
+    """Redirect all ohtv-generated state (cache, DB, logs) into ``tmp_path``."""
+
+    ohtv_root = tmp_path / "ohtv_home"
+    ohtv_root.mkdir()
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_root))
+    return ohtv_root
+
+
+@pytest.fixture
+def worker_conv_dir(tmp_path):
+    """Build a worker-style conversation fixture on disk.
+
+    Worker conversations (orchestrator-spawned) have NO user MessageEvent but
+    DO have at least one agent ActionEvent. This is the exact shape that
+    triggers the ``minimal`` -> ``default`` auto-promotion inside
+    ``analyze_objectives``: the legacy transcript builder emits zero items at
+    ``minimal`` (user messages only) but emits the ``finish`` action at
+    ``default``/``full``, so the loop in objectives.py promotes the context.
+    """
+
+    # Use a hex name (no dashes) so the database normalization is a no-op.
+    conv_dir = tmp_path / "conversations" / "abcdef0123456789abcdef0123456789"
+    events_dir = conv_dir / "events"
+    events_dir.mkdir(parents=True)
+
+    # Single ActionEvent: agent finish call. Only included at default+ levels.
+    finish_event = {
+        "id": "evt-0001",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "source": "agent",
+        "kind": "ActionEvent",
+        "tool_name": "finish",
+        "tool_call_id": "call-0001",
+        "action": {
+            "message": "Done.",
+        },
+    }
+    (events_dir / "event-00001-finish.json").write_text(json.dumps(finish_event))
+    return conv_dir
+
+
+@pytest.fixture
+def mock_llm():
+    """Patch the OpenHands SDK LLM with a recording mock.
+
+    Returns the ``completion`` MagicMock so tests can assert call counts.
+    """
+
+    completion_mock = MagicMock()
+
+    # Build a stable JSON response that satisfies the brief/no-assess prompt.
+    response_text = MagicMock()
+    response_text.text = json.dumps({"goal": "Test worker objective"})
+
+    response = MagicMock()
+    response.message.content = [response_text]
+    response.metrics.accumulated_cost = 0.0012
+    completion_mock.return_value = response
+
+    llm_instance = MagicMock()
+    llm_instance.model = "test-model"
+    llm_instance.api_key = "test-key"
+    llm_instance.base_url = None
+    llm_instance.timeout = 60
+    llm_instance.completion = completion_mock
+
+    # ``openhands.sdk.LLM`` is imported lazily INSIDE
+    # ``analyze_objectives``; patching at ``openhands.sdk.LLM`` therefore
+    # covers both ``LLM.load_from_env()`` and the ``LLM(...)`` re-init branch.
+    with patch("openhands.sdk.LLM") as llm_class:
+        llm_class.load_from_env.return_value = llm_instance
+        # If model arg is passed, the code does ``LLM(model=model, ...)``;
+        # route that to the same instance so the recording stays accurate.
+        llm_class.return_value = llm_instance
+        yield completion_mock
+
+
+# ---------------------------------------------------------------------------
+# Test A — cache hit after auto-promotion
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_request_hits_cache_after_auto_promotion(
+    ohtv_dir, worker_conv_dir, mock_llm
+):
+    """AC4: a worker conversation analyzed at ``context="minimal"`` once must
+    hit the cache on the second call with the same args (no second LLM call).
+
+    The internal promotion takes the effective level to ``default`` (or
+    higher). Before the fix, the second call would compute a ``minimal``
+    cache key, miss the (``default``-keyed) stored entry, and re-invoke the
+    LLM.
+    """
+
+    from ohtv.analysis.objectives import analyze_objectives
+
+    # First call — promotes minimal -> default, calls LLM once, caches result.
+    result1 = analyze_objectives(
+        worker_conv_dir,
+        model="test-model",
+        context="minimal",
+        detail="brief",
+        assess=False,
+    )
+
+    assert result1.from_cache is False, "first call should be a cache miss"
+    assert mock_llm.call_count == 1, (
+        "first analyze should invoke the LLM exactly once"
+    )
+    # Sanity: auto-promotion happened (effective context is not 'minimal').
+    assert result1.analysis.context_level != "minimal", (
+        "fixture is expected to trigger auto-promotion; effective level must "
+        "differ from the requested 'minimal' to exercise the alias write"
+    )
+
+    # Second call — must hit the cache via the alias key, NOT invoke the LLM.
+    result2 = analyze_objectives(
+        worker_conv_dir,
+        model="test-model",
+        context="minimal",
+        detail="brief",
+        assess=False,
+    )
+
+    assert result2.from_cache is True, (
+        "second call at the same requested context must hit the cache "
+        "(the alias write under the requested level enables this; see #129)"
+    )
+    assert mock_llm.call_count == 1, (
+        "LLM must not be invoked a second time when the alias cache hit fires"
+    )
+
+    # The returned analysis should carry the TRUE effective context (not the
+    # requested one) — per AC: "stored analysis must retain its true
+    # effective_context — only the cache_key mapping is duplicated".
+    assert result2.analysis.context_level == result1.analysis.context_level
+
+
+# ---------------------------------------------------------------------------
+# Test B — _count_uncached_conversations_fast returns 0 post-analyze
+# ---------------------------------------------------------------------------
+
+
+def test_count_uncached_conversations_fast_zero_after_analyze(
+    ohtv_dir, worker_conv_dir, mock_llm
+):
+    """AC5: ``_count_uncached_conversations_fast`` must report 0 uncached
+    after a single ``analyze_objectives(..., context="minimal")`` run.
+
+    This is the user-visible symptom from the issue: ``ohtv gen objs -D``
+    reporting the same N conversations as needing analysis on every run.
+    """
+
+    from ohtv.analysis.objectives import analyze_objectives
+    from ohtv.cli import _count_uncached_conversations_fast
+    from ohtv.config import Config
+    from ohtv.db import get_connection, migrate
+    from ohtv.db.models import Conversation
+    from ohtv.db.stores import ConversationStore
+    from ohtv.sources.base import ConversationInfo
+
+    # 1. Pre-register the conversation in the DB. We have to do this BEFORE
+    #    invoking analyze_objectives because the analysis_cache table has a
+    #    foreign key on conversations.id (ON DELETE CASCADE). The FK is
+    #    enforced (PRAGMA foreign_keys = ON), so attempting to insert a
+    #    cache row for a non-existent conversation_id would fail silently
+    #    inside ``_sync_cache_to_db``'s broad except handler — and nothing
+    #    would land in the DB. In production this is fine because the
+    #    scanner registers conversations long before ``gen objs`` runs.
+    with get_connection() as conn:
+        migrate(conn)
+        ConversationStore(conn).upsert(
+            Conversation(
+                id=worker_conv_dir.name,
+                location=str(worker_conv_dir),
+                registered_at=datetime.now(timezone.utc),
+                events_mtime=0,
+                event_count=1,  # matches the single ActionEvent fixture
+                source="local",
+            )
+        )
+        conn.commit()
+
+    # 2. Analyze once at the requested ('minimal') level. This auto-promotes
+    #    internally to 'default' and writes the analysis_cache row under the
+    #    promoted key PLUS the alias row under 'minimal' (the fix for #129).
+    analyze_objectives(
+        worker_conv_dir,
+        model="test-model",
+        context="minimal",
+        detail="brief",
+        assess=False,
+    )
+
+    # 3. Build the ConversationInfo the CLI would pass in.
+    info = ConversationInfo(
+        id=worker_conv_dir.name,
+        title=None,
+        created_at=None,
+        updated_at=None,
+        event_count=1,
+        source="local",
+    )
+
+    # 4. Fast-path count at the originally-requested minimal level. Before
+    # the fix, this returned 1; after the fix, the alias cache row at the
+    # 'minimal' key resolves to a hit.
+    uncached = _count_uncached_conversations_fast(
+        [info], Config.from_env(), context="minimal", detail="brief", assess=False
+    )
+
+    assert uncached == 0, (
+        "post-analyze, the conversation must register as cached at the "
+        "originally-requested context level (issue #129); got "
+        f"{uncached} uncached"
+    )


### PR DESCRIPTION
Fixes #129.

## Bug

`ohtv gen objs -D` (and any other multi-conversation mode) re-classified the same N worker conversations as "needs analysis" on every run — billing the same LLM calls indefinitely. The issue surfaced for orchestrator-spawned worker conversations (no user messages but with agent actions): the writer auto-promoted `context_level` from `minimal` → `default`/`full` to have something to analyze, while the reader still looked up cache rows under the originally-requested `minimal` key.

## Root cause (from issue body, verbatim file:line evidence)

- **Write path:** `src/ohtv/analysis/objectives.py:467–481` auto-promote `effective_context` from `minimal` → `default` → `full` for empty-transcript worker conversations. The saved `ObjectiveAnalysis` carries `context_level=effective_context` (lines 629 / 644). `AnalysisCacheManager._sync_cache_to_db` writes the `analysis_cache` row with the **promoted** level baked into `cache_key`.
- **Read path:** `src/ohtv/cli.py:_count_uncached_conversations_fast` (~line 8424) builds the lookup key from the **requested** context (`minimal` by default for multi-conv mode). `AnalysisCacheStore.get_cache_status_batch` joins on `ac.cache_key = ?` (exact match), so the writer's rows under `context_level=full` were invisible to a `minimal` lookup.

The `analysis_skips` table already solves the analogous problem via `CacheStatus.needs_analysis_for_context`; the `analysis_cache` lookup had no equivalent.

## Fix

Per the issue's AC, the fix lives in the writer (`AnalysisCacheManager.save` and its caller in `objectives.py`), **not** in `get_cache_status_batch` (rejected as the primary fix in the issue body, alongside `make_cache_key` refactoring which is out of scope).

1. **`analyze_objectives`** now tracks the originally-requested context separately from the effective one. When they diverge (auto-promotion fires), it passes a `requested_key_kwargs` alias down to `_cache_manager.save`.
2. **`AnalysisCacheManager.save`** accepts an optional `requested_key_kwargs`. When the derived alias key differs from the primary one, it writes a SECOND entry — both to the on-disk cache file and via `_sync_cache_to_db` to the `analysis_cache` table — pointing at the same `analysis.model_dump()`. The stored analysis retains its true effective `context_level` (the level the LLM actually saw); only the cache_key mapping is duplicated, exactly as the AC requires.
3. **`AnalysisCacheManager.load_cached`** gets two narrow tolerances to honor alias hits:
   - skip the per-attribute `context_level` equality check (the cache_key already encodes context_level — a key match is sufficient)
   - skip the `content_hash` check when the stored analysis's `context_level` differs from the requested one (the cached hash was computed from the promoted transcript while the lookup recomputes for the requested transcript; the `event_count` check above still guards against the conversation growing).

`detail_level`, `assess`, and `prompt_hash` validation remain strict.

## Regression tests

`tests/unit/analysis/test_cache_alias_promoted_context.py` pins the two AC bullets:

- `test_minimal_request_hits_cache_after_auto_promotion` — fixture worker conv with no user messages and a finish action; `analyze_objectives(..., context="minimal")` is called twice with the LLM mocked at `openhands.sdk.LLM`. After the fix, the second call returns `from_cache=True` and the LLM is invoked exactly **once**.
- `test_count_uncached_conversations_fast_zero_after_analyze` — same fixture, after registering the conversation in the DB and running `analyze_objectives` once, `_count_uncached_conversations_fast` returns **0** uncached.

Verified locally that both tests **fail on `main`** (pre-fix baseline) and **pass with the fix**.

## Verification

- `uv run pytest` — **1795 passed, 3 skipped, 10 xfailed** (full suite green)
- `uv run pytest tests/unit/analysis/ tests/unit/db/ tests/unit/test_objectives.py tests/unit/test_cli_gen.py` — **947 passed** (adjacent surface confirmed clean)
- `uv run ruff check` on the changed files — clean (one pre-existing `CONTEXT_LEVELS` warning in `cache.py` is unrelated and left untouched to keep the diff tight)

## Acceptance Criteria reflection

- [x] An immediate `ohtv gen objs -D` after a successful analyze reports **0 uncached** for the same conversation set — pinned by `test_count_uncached_conversations_fast_zero_after_analyze`.
- [x] Fix lives in `AnalysisCacheManager._sync_cache_to_db`-area (specifically `.save`, which calls it) and its caller in `objectives.py`. The primary read path stays strict-equality; only alias hits relax `context_level` / `content_hash`.
- [x] Stored analysis retains its true `effective_context` — only the cache_key mapping is duplicated. Verified inside Test A's sanity assertion (`result1.analysis.context_level != "minimal"` and `result2.analysis.context_level == result1.analysis.context_level`).
- [x] Regression test: second `analyze_objectives(..., context="minimal")` against the worker fixture hits the cache (`from_cache=True`) and the mocked LLM `completion` is called exactly once total.
- [x] Regression test: `_count_uncached_conversations_fast` returns 0 after a single analyze run.

## Out of scope (per issue)

- No changes to `make_cache_key` (would lose side-by-side `minimal`/`full` caching).
- No "or higher level" tolerance added to `get_cache_status_batch` / `needs_analysis_for_context` — the issue explicitly rejected that as the primary fix.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._


@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dd954a94-87f1-46c4-8be3-fd331765f9fc)