### PR TITLE
feat(sync): recover from cloud/local gap via set-diff engine (#111)

### DIFF
--- a/docs/guides/syncing.md
+++ b/docs/guides/syncing.md
@@ -2,12 +2,23 @@
 
 Mirror cloud conversations to local disk for offline indexing, analysis, and search. Requires `OPENHANDS_API_KEY` (or `OH_API_KEY`).
 
+> **Behavior change (PR #133 / Issue #111): set-diff sync engine.**
+> `ohtv sync` no longer uses a time-cursor (`last_sync_at`) to decide
+> what to download. Every run now enumerates the **full** cloud listing
+> and reconciles it against the local store via a set-diff. The first
+> sync after upgrading from a pre-#111 build will close any historical
+> gap between cloud and local — if your account has accumulated drift
+> (conversations on cloud that never landed locally), expect a one-time
+> catch-up download on the first run. Subsequent runs against a
+> fully-synced cloud do zero downloads. There are no new flags and no
+> new env vars; the change is purely in the engine.
+
 ## `ohtv sync` - Sync Cloud Conversations
 
 Downloads conversations from OpenHands Cloud. Requires `OPENHANDS_API_KEY` or `OH_API_KEY` environment variable.
 
 ```bash
-# Sync incrementally (only downloads changes)
+# Sync (full set-diff against the cloud; downloads only what's missing or stale)
 ohtv sync
 
 # Sync and run all processing stages (recommended)
@@ -16,7 +27,8 @@ ohtv sync --process
 # Force re-download everything
 ohtv sync --force
 
-# Only sync conversations updated after a date
+# Only act on conversations updated after a date (filters the work list,
+# not the cloud listing — see "How --since works" below)
 ohtv sync --since 2024-01-01
 
 # Preview what would sync
@@ -43,7 +55,8 @@ ohtv sync --quiet
 | Flag | Description |
 |------|-------------|
 | `-f, --force` | Re-download all conversations |
-| `--since DATE` | Only sync conversations updated after date |
+| `--since DATE` | Filter the work list to conversations updated after `DATE` (the cloud listing is always full; see below) |
+| `-n, --max-new` | Maximum number of NEW conversations to sync (no limit on updates) |
 | `--dry-run` | Show what would sync without downloading |
 | `-s, --status` | Show sync status |
 | `--repair` | Check and fix sync state (manifest vs disk vs cloud) |
@@ -51,11 +64,77 @@ ohtv sync --quiet
 | `-p, --process` | Run all processing stages after sync |
 | `-q, --quiet` | Minimal output for cron jobs |
 
+## How the set-diff engine works
+
+Every `ohtv sync` runs two phases:
+
+1. **Listing pass.** Paginate the entire cloud listing into the local
+   `cloud_listing` snapshot table under a fresh `snapshot_id`. Pages
+   commit incrementally — if the run is interrupted (Ctrl+C, SIGTERM,
+   network hiccup), the next `ohtv sync` resumes from the last
+   committed page without re-fetching it. On success the snapshot is
+   atomically swapped; on failure the in-flight snapshot is abandoned
+   and the previous one stays usable.
+2. **Set-diff dispatch.** Compare the snapshot against local
+   `conversations` and dispatch:
+   - `missing_locally` → **download** (this is where automatic gap
+     recovery happens; no `--since` workaround needed)
+   - `stale_locally` (`cloud_listing.updated_at != local
+     cloud_updated_at`) → **refetch** (uses `!=`, not `>`, so a
+     backdated `updated_at` on the cloud is still honored)
+   - `removed_from_cloud` → **no-op** (detected but not acted on; the
+     `--repair` UX from a future iteration will own pruning)
+   - present + in-sync → **no-op**
+
+Downloads commit incrementally per item. A re-run against a fully
+synced cloud produces zero downloads.
+
+### Automatic gap recovery
+
+The old cursor-based sync (`updated_since >= last_sync_at`) could
+silently miss conversations that existed before the cursor but were
+never present locally — for example after a one-time `--since`
+invocation or a `reset_to_n_newest` run. Once that gap opened it stayed
+open. The set-diff engine closes it on the next normal `ohtv sync`. The
+historical workaround (`ohtv sync --since <very-old-date>`) is no
+longer needed for this case.
+
+### How `--since` works (post-#111)
+
+`--since` filters the **work list**, not the cloud listing. The
+listing is always full — that's the whole architectural inversion that
+makes gap recovery automatic. Use `--since` when you want a normal,
+already-converged store and just want to confine this run's downloads
+to the last day / week / month of activity. It does NOT make the sync
+"faster by skipping the listing" — the listing pass always runs in
+full.
+
+### Fresh-install behavior
+
+`ohtv sync` runs `ensure_db_ready()` on entry, so on a fresh install
+you can call `ohtv sync` directly without a prior `ohtv db scan`. The
+schema (including the `cloud_listing` snapshot table from migration
+018) and any one-time maintenance tasks land lazily inside the sync.
+
+### Interruption safety
+
+Both the listing pass and the download pipeline commit incrementally.
+A `Ctrl+C` or `SIGTERM` mid-sync drains in-flight work and exits; the
+next `ohtv sync` continues from the last committed snapshot page +
+last committed download, with no manual recovery step.
+
+### Status field: `last_sync_at`
+
+`last_sync_at` (visible via `ohtv sync --status` and the manifest) is
+now **informational only**. It records the timestamp of the last
+successful reconciliation but is never compared against by the sync
+engine. The cursor-based filter that used it as a gate is gone.
+
 ## Metadata refresh (`--update-metadata`)
 
 Cloud-side edits to a conversation's title, labels, or `selected_repository`
 (via the `PATCH /app-conversations/{id}` API or the cloud UI) are not picked
-up by the normal incremental sync because the API may not bump `updated_at`
+up by the normal sync because the API may not bump `updated_at`
 on a metadata-only change. Run `ohtv sync --update-metadata` to refresh
 the cached cloud-derived metadata fields for every already-synced
 conversation without re-downloading any trajectories.
@@ -91,4 +170,3 @@ keeping the steady-state output compact for the common case where only
 title/labels drift.
 
 ---
-

--- a/docs/guides/syncing.md
+++ b/docs/guides/syncing.md
@@ -89,6 +89,30 @@ Every `ohtv sync` runs two phases:
 Downloads commit incrementally per item. A re-run against a fully
 synced cloud produces zero downloads.
 
+### Scalability boundary
+
+Phase 1 always paginates the full cloud listing — the architectural
+inversion that makes gap recovery automatic costs an unconditional
+listing round-trip. Phase 2 then streams `SELECT * FROM cloud_listing`
+row-by-row through the set-diff cursor, so memory tracks one row at a
+time (not the whole result set). The in-memory accumulators (work
+list, "seen in cloud" set, manifest-key normalization map) scale
+linearly with the catalog size and are well under 10 MB at 10k
+conversations. Chunked queries would be the next mitigation if a real
+catalog ever grew an order of magnitude beyond that — deferred to a
+follow-up issue rather than baked in pre-emptively.
+
+### Removed-from-cloud reconciliation
+
+When the listing pass observes that a conversation present in the
+local manifest no longer appears in the cloud listing, the engine
+removes the manifest entry so the work list stays coherent and emits
+a `WARNING`-level log line (`Removed N conversation(s) from manifest
+(no longer visible in cloud listing).`). The full user-facing report
++ prune action is tracked under a follow-up issue (#113); the warning
+is the interim signal so accidental cloud-side data loss or permission
+changes do not silently shrink the manifest.
+
 ### Automatic gap recovery
 
 The old cursor-based sync (`updated_since >= last_sync_at`) could

--- a/src/ohtv/db/stores/__init__.py
+++ b/src/ohtv/db/stores/__init__.py
@@ -2,6 +2,7 @@
 
 from ohtv.db.stores.action_store import ActionStore
 from ohtv.db.stores.analysis_cache_store import AnalysisCacheStore
+from ohtv.db.stores.cloud_listing_store import CloudListingStore
 from ohtv.db.stores.contributions_store import (
     ChangeRef,
     Contribution,
@@ -13,11 +14,13 @@ from ohtv.db.stores.link_store import LinkStore
 from ohtv.db.stores.reference_store import ReferenceStore
 from ohtv.db.stores.repo_store import RepoStore
 from ohtv.db.stores.stage_store import StageStore
+from ohtv.db.stores.sync_state_store import SyncStateStore
 
 __all__ = [
     "ActionStore",
     "AnalysisCacheStore",
     "ChangeRef",
+    "CloudListingStore",
     "Contribution",
     "ContributionsStore",
     "ConversationStore",
@@ -26,4 +29,5 @@ __all__ = [
     "ReferenceStore",
     "RepoStore",
     "StageStore",
+    "SyncStateStore",
 ]

--- a/src/ohtv/db/stores/cloud_listing_store.py
+++ b/src/ohtv/db/stores/cloud_listing_store.py
@@ -1,0 +1,271 @@
+"""Data store for the cloud-listing snapshot table (Issue #111).
+
+The ``cloud_listing`` table (added by migration 018 in Issue #112) is the
+authoritative snapshot of what the cloud says is visible — populated by a
+full listing pass at the top of every ``ohtv sync``. The four-way set-diff
+helpers (:meth:`missing_locally`, :meth:`stale_locally`,
+:meth:`removed_from_cloud`) compare the snapshot against the local
+``conversations`` table and drive the set-diff sync engine.
+
+Snapshot lifecycle:
+
+* :meth:`start_snapshot` allocates a fresh UUID. Rows written under that
+  UUID are tentative — readers can keep using whatever the previous
+  snapshot wrote.
+* :meth:`upsert_row` is called per-page during the listing pass. Pages
+  commit incrementally (the caller commits the connection) so an
+  interrupted sync can resume mid-listing.
+* :meth:`commit_snapshot` atomically swaps to the new snapshot by
+  pruning every row whose ``snapshot_id`` does not match. Returns the
+  number of rows pruned.
+* :meth:`abandon_snapshot` is the failure-path counterpart: it deletes
+  only rows for the in-flight snapshot, leaving the previous one
+  untouched. This is what makes "mid-listing failure leaves prior
+  snapshot intact" hold.
+
+Set-diff queries return raw conversation-id strings (normalized,
+dashless per AGENTS.md item #14). Callers join back to
+:meth:`get_rows` / :meth:`get` for full payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from collections.abc import Iterable, Iterator
+from datetime import datetime, timezone
+
+
+# Whitelisted columns we write into ``cloud_listing`` from a listing
+# payload. Keeps :meth:`upsert_row` insensitive to extra keys the API
+# may return now or in the future.
+_LISTING_COLUMNS = (
+    "title",
+    "created_at",
+    "updated_at",
+    "selected_repository",
+    "selected_branch",
+    "git_provider",
+    "trigger",
+    "parent_conversation_id",
+    "tags",
+    "sub_conversation_ids",
+    "pr_number",
+)
+
+
+# Columns whose listing-payload value may be a dict/list and must be
+# JSON-encoded before binding into sqlite3.
+_JSON_COLUMNS = frozenset({"tags", "sub_conversation_ids"})
+
+
+def _serialize(col: str, value):
+    """Coerce a listing-payload value into a sqlite-bindable scalar."""
+    if value is None:
+        return None
+    if col in _JSON_COLUMNS:
+        if isinstance(value, (dict, list)):
+            return json.dumps(value)
+    return value
+
+
+def _normalize_id(conv_id: str) -> str:
+    """Strip dashes from a conversation id (AGENTS.md item #14)."""
+    return conv_id.replace("-", "")
+
+
+def _utc_now_iso() -> str:
+    """ISO 8601 UTC timestamp for ``fetched_at`` bookkeeping."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class CloudListingStore:
+    """Read/write helpers for the ``cloud_listing`` snapshot table."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+
+    # ------------------------------------------------------------------
+    # Snapshot lifecycle
+    # ------------------------------------------------------------------
+    def start_snapshot(self) -> str:
+        """Allocate a new snapshot id (UUID4 hex string).
+
+        Returns the id — callers pass it into :meth:`upsert_row` and
+        either :meth:`commit_snapshot` (success) or
+        :meth:`abandon_snapshot` (failure).
+        """
+        return uuid.uuid4().hex
+
+    def upsert_row(
+        self,
+        snapshot_id: str,
+        row: dict,
+        *,
+        fetched_at: str | None = None,
+    ) -> None:
+        """Insert or replace a single cloud-listing row.
+
+        The primary key is ``conversation_id`` (normalized). Any row
+        already present — under the same OR a different snapshot — is
+        overwritten. This is what gives us pagination dedup for free:
+        when keyset drift makes the same id appear on two pages, the
+        second insert just overwrites the first.
+
+        ``row`` MUST contain an ``id`` key (the conversation id from
+        the listing payload). All other keys are best-effort: unknown
+        keys are ignored, missing keys default to NULL. The fully
+        permissive shape matches the cloud's eventual schema growth.
+        """
+        conv_id = row.get("id")
+        if not conv_id:
+            raise ValueError("cloud_listing row missing 'id'")
+        normalized = _normalize_id(conv_id)
+
+        values: list[object] = [normalized]
+        for col in _LISTING_COLUMNS:
+            values.append(_serialize(col, row.get(col)))
+        values.append(fetched_at or _utc_now_iso())
+        values.append(snapshot_id)
+
+        placeholders = ", ".join(["?"] * (len(_LISTING_COLUMNS) + 3))
+        columns = (
+            "conversation_id, "
+            + ", ".join(_LISTING_COLUMNS)
+            + ", fetched_at, snapshot_id"
+        )
+        self.conn.execute(
+            f"INSERT OR REPLACE INTO cloud_listing ({columns}) "
+            f"VALUES ({placeholders})",
+            values,
+        )
+
+    def commit_snapshot(self, snapshot_id: str) -> int:
+        """Atomically swap to ``snapshot_id`` by pruning older rows.
+
+        Deletes every row whose ``snapshot_id`` does NOT match. Returns
+        the number of rows pruned. Safe to call repeatedly — the second
+        call is a no-op because everything is already on this snapshot.
+        """
+        cursor = self.conn.execute(
+            "DELETE FROM cloud_listing WHERE snapshot_id != ?",
+            (snapshot_id,),
+        )
+        return cursor.rowcount or 0
+
+    def abandon_snapshot(self, snapshot_id: str) -> int:
+        """Drop in-flight rows; leave any prior committed snapshot intact.
+
+        The failure-path counterpart to :meth:`commit_snapshot`. Returns
+        the number of rows deleted.
+        """
+        cursor = self.conn.execute(
+            "DELETE FROM cloud_listing WHERE snapshot_id = ?",
+            (snapshot_id,),
+        )
+        return cursor.rowcount or 0
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def get(self, conversation_id: str) -> sqlite3.Row | None:
+        """Fetch one row by (dashed-or-undashed) conversation id."""
+        normalized = _normalize_id(conversation_id)
+        return self.conn.execute(
+            "SELECT * FROM cloud_listing WHERE conversation_id = ?",
+            (normalized,),
+        ).fetchone()
+
+    def get_rows(self, conversation_ids: Iterable[str]) -> list[sqlite3.Row]:
+        """Fetch many rows in one query (preserves DB-returned order)."""
+        ids = [_normalize_id(c) for c in conversation_ids]
+        if not ids:
+            return []
+        placeholders = ", ".join(["?"] * len(ids))
+        return list(
+            self.conn.execute(
+                f"SELECT * FROM cloud_listing WHERE conversation_id IN ({placeholders})",
+                ids,
+            )
+        )
+
+    def count(self) -> int:
+        """Number of rows in the current cloud_listing snapshot."""
+        row = self.conn.execute(
+            "SELECT COUNT(*) AS n FROM cloud_listing"
+        ).fetchone()
+        return int(row["n"] if row is not None else 0)
+
+    # ------------------------------------------------------------------
+    # Set-diff helpers
+    # ------------------------------------------------------------------
+    def missing_locally(self) -> Iterator[str]:
+        """Cloud-listing ids absent from the local ``conversations`` table.
+
+        These are the rows the engine must download. Includes both
+        "never seen" rows and rows whose local row was scrubbed (e.g.
+        manual delete).
+        """
+        cursor = self.conn.execute(
+            """
+            SELECT cl.conversation_id
+            FROM cloud_listing cl
+            LEFT JOIN conversations c ON c.id = cl.conversation_id
+            WHERE c.id IS NULL
+            """
+        )
+        for row in cursor:
+            yield row["conversation_id"]
+
+    def stale_locally(self) -> Iterator[str]:
+        """Local rows whose ``cloud_updated_at`` differs from the cloud snapshot.
+
+        Rule (Issue #111 scenario #3 — "Backdated ``updated_at`` is
+        honored on next sync"):
+
+        * ``cloud_listing.updated_at`` differs (``!=``) from
+          ``conversations.cloud_updated_at`` → stale. We use ``!=``
+          rather than ``>`` so a server-side rewind (e.g. clock skew
+          on the cloud side, manual backfill) is reconciled rather
+          than swallowed.
+        * ``conversations.cloud_updated_at IS NULL`` → stale (never
+          recorded; the migration-018 design note treats NULL as
+          "always stale until first cursor write").
+        * Same timestamp on both sides → fresh; not yielded.
+        """
+        cursor = self.conn.execute(
+            """
+            SELECT cl.conversation_id
+            FROM cloud_listing cl
+            JOIN conversations c ON c.id = cl.conversation_id
+            WHERE cl.updated_at IS NOT NULL
+              AND (
+                c.cloud_updated_at IS NULL
+                OR cl.updated_at != c.cloud_updated_at
+              )
+            """
+        )
+        for row in cursor:
+            yield row["conversation_id"]
+
+    def removed_from_cloud(self) -> Iterator[str]:
+        """Local rows that disappeared from the cloud listing.
+
+        #111 detects these but does NOT delete them — the repair UX
+        (#113) owns the four-category report and any prune action.
+
+        Filters to ``source = 'cloud'`` so CLI-only / LXA-only
+        conversations are not falsely reported as removed.
+        """
+        cursor = self.conn.execute(
+            """
+            SELECT c.id
+            FROM conversations c
+            LEFT JOIN cloud_listing cl ON cl.conversation_id = c.id
+            WHERE cl.conversation_id IS NULL
+              AND c.source = 'cloud'
+            """
+        )
+        for row in cursor:
+            yield row["id"]

--- a/src/ohtv/db/stores/cloud_listing_store.py
+++ b/src/ohtv/db/stores/cloud_listing_store.py
@@ -56,8 +56,13 @@ _LISTING_COLUMNS = (
 
 
 # Columns whose listing-payload value may be a dict/list and must be
-# JSON-encoded before binding into sqlite3.
-_JSON_COLUMNS = frozenset({"tags", "sub_conversation_ids"})
+# JSON-encoded before binding into sqlite3. ``pr_number`` is an
+# ``Array<int>`` in the live cloud API (e.g. ``[133]`` for a
+# PR-tagged conversation, ``[]`` otherwise — see
+# ``REFERENCE_CLOUD_API.md``); without JSON-encoding sqlite rejects
+# the bind with ``ProgrammingError: type 'list' is not supported``
+# and the listing pass crashes on the first PR-tagged row.
+_JSON_COLUMNS = frozenset({"tags", "sub_conversation_ids", "pr_number"})
 
 
 def _serialize(col: str, value):

--- a/src/ohtv/db/stores/conversation_store.py
+++ b/src/ohtv/db/stores/conversation_store.py
@@ -375,3 +375,43 @@ class ConversationStore:
             "SELECT COUNT(*) FROM conversations WHERE labels IS NOT NULL AND labels != '{}'"
         )
         return cursor.fetchone()[0]
+
+    def record_cloud_download(
+        self,
+        conversation_id: str,
+        *,
+        location: str,
+        cloud_updated_at: str | None,
+    ) -> None:
+        """Record that the cloud trajectory for ``conversation_id`` was just synced.
+
+        Inserts a minimal row if the conversation has not been seen
+        before (location + source='cloud' + cloud_updated_at), or
+        updates only ``location`` and ``cloud_updated_at`` on an
+        existing row. Crucially, this method NEVER overwrites
+        metadata columns (``title``, ``event_count``, ``labels``,
+        etc.) — those are owned by the scanner / LLM analysis paths.
+
+        This is the writer for the column reserved by migration 018
+        (Issue #112); Issue #111 is the first consumer.
+        """
+        normalized = conversation_id.replace("-", "")
+        registered_at = datetime.now(timezone.utc).isoformat()
+        # INSERT path: we don't know the metadata yet. The scanner will
+        # backfill on its next run. We set event_count=0 so a
+        # subsequent scanner mtime check still treats the row as
+        # "needs work" (an mtime delta vs the freshly-extracted events
+        # dir always wins).
+        self.conn.execute(
+            """
+            INSERT INTO conversations (
+                id, location, registered_at, event_count, source,
+                cloud_updated_at
+            )
+            VALUES (?, ?, ?, 0, 'cloud', ?)
+            ON CONFLICT(id) DO UPDATE SET
+                location = excluded.location,
+                cloud_updated_at = excluded.cloud_updated_at
+            """,
+            (normalized, location, registered_at, cloud_updated_at),
+        )

--- a/src/ohtv/db/stores/sync_state_store.py
+++ b/src/ohtv/db/stores/sync_state_store.py
@@ -1,0 +1,94 @@
+"""Data store for the ``sync_kv`` key/value table (Issue #111 / #114).
+
+Migration 018 added a minimal K/V table to host the small handful of
+sync-state scalars previously scattered across
+``~/.ohtv/sync_manifest.json``. The schema is intentionally untyped
+(callers JSON-encode values) so new scalars land without further
+migrations.
+
+#111 is the first writer; it persists the three ``last_snapshot_*``
+keys at the end of every successful listing pass. #114 will later
+drain the remaining manifest scalars (``last_sync_at``, ``sync_count``,
+``failed_ids``) into the same table and retire the JSON file.
+
+Documented (non-exhaustive) keys:
+
+* ``last_snapshot_id`` (str, UUID-hex) — id of the most-recently-committed
+  cloud listing snapshot. Written by #111 at the end of a successful
+  listing pass; consumed by ``--status`` UX, ``--repair`` (#113), and a
+  future freshness gate.
+* ``last_snapshot_completed_at`` (str, ISO 8601 UTC) — wall-clock time
+  the snapshot finished. Same writers/readers as above.
+* ``last_snapshot_count`` (int) — number of cloud_listing rows in the
+  committed snapshot. Same writers/readers.
+* ``last_sync_at`` (str, ISO 8601 UTC) — dual-written by #111 alongside
+  the manifest field of the same name. Pure UX field; never consumed by
+  the sync engine as a gate.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _utc_now_iso() -> str:
+    """ISO 8601 UTC timestamp for ``updated_at`` bookkeeping."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class SyncStateStore:
+    """Get/set wrapper around ``sync_kv`` (JSON-encoded scalars)."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the JSON-decoded value for ``key`` or ``default``.
+
+        A row with a NULL ``value`` decodes back to ``None``.
+        """
+        row = self.conn.execute(
+            "SELECT value FROM sync_kv WHERE key = ?", (key,)
+        ).fetchone()
+        if row is None:
+            return default
+        raw = row["value"]
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            # Tolerate hand-written non-JSON values (e.g. plain strings
+            # written by older tooling). Return verbatim.
+            return raw
+
+    def set(self, key: str, value: Any) -> None:
+        """JSON-encode ``value`` and upsert under ``key``.
+
+        ``None`` is stored as a literal SQL NULL rather than the JSON
+        string ``"null"``; this keeps ``SELECT ... WHERE value IS NULL``
+        queries from getting confused.
+        """
+        encoded: str | None
+        if value is None:
+            encoded = None
+        else:
+            encoded = json.dumps(value)
+        self.conn.execute(
+            """
+            INSERT INTO sync_kv (key, value, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = excluded.updated_at
+            """,
+            (key, encoded, _utc_now_iso()),
+        )
+
+    def delete(self, key: str) -> bool:
+        """Remove ``key`` from ``sync_kv``. Returns True if a row existed."""
+        cursor = self.conn.execute("DELETE FROM sync_kv WHERE key = ?", (key,))
+        return (cursor.rowcount or 0) > 0

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -13,6 +13,13 @@ from typing import Callable
 import httpx
 
 from ohtv.config import Config, get_manifest_path
+from ohtv.db.connection import get_db_path
+from ohtv.db.maintenance import ensure_db_ready
+from ohtv.db.stores import (
+    CloudListingStore,
+    ConversationStore,
+    SyncStateStore,
+)
 from ohtv.exporter import TrajectoryExporter, count_events
 from ohtv.sources.cloud import CloudClient, RateLimitExceededError
 
@@ -172,6 +179,13 @@ class SyncManager:
         self.manifest_path = get_manifest_path()
         self.manifest = SyncManifest.load(self.manifest_path)
         self.exporter = TrajectoryExporter(config.synced_conversations_dir)
+        # Thread-coordination for the parallel download path. SQLite
+        # connections are not thread-safe; we buffer ``record_cloud_download``
+        # writes from worker threads and flush them on the main thread
+        # after the pool drains. ``None`` means "no buffering, write
+        # directly" (sequential / non-pool path).
+        self._db_writer_lock = threading.Lock()
+        self._pending_cloud_updated_at: list[tuple[str, str, str | None]] | None = None
 
     def sync(
         self,
@@ -183,33 +197,70 @@ class SyncManager:
         parallel: bool = True,
         shutdown_check: Callable[[], bool] | None = None,
     ) -> SyncResult:
-        """Sync conversations from cloud.
-        
+        """Sync conversations from cloud using the set-diff engine (Issue #111).
+
+        The engine runs in two phases on every invocation:
+
+        1. **Listing pass** — paginate the full cloud listing into the
+           ``cloud_listing`` snapshot table under a fresh ``snapshot_id``.
+           Pages commit incrementally so an interrupted sync can resume
+           mid-listing without losing committed pages. On success the
+           snapshot is atomically swapped; on any failure the in-flight
+           snapshot is abandoned and the previous one stays usable.
+        2. **Set-diff dispatch** — query ``cloud_listing`` against
+           ``conversations`` to produce three categories:
+           ``missing_locally`` (download), ``stale_locally`` (refetch),
+           and ``removed_from_cloud`` (record only — #113 owns the
+           prune UX).
+
+        ``last_sync_at`` survives as a UX field only — it is *not* used
+        as a sync gate. The cursor-based ``updated_since`` filter from
+        the pre-#111 implementation is gone; full listing IS the gate.
+
         Args:
-            force: Re-download all conversations (clears local before re-download)
-            since: Only sync conversations updated after this date
-            dry_run: Show what would sync without downloading
-            max_new: Maximum number of NEW conversations to sync (no limit on updates)
-            on_progress: Callback for progress updates (conv_id, title, action)
-            parallel: Use parallel downloads (default True, uses 20 workers)
-            shutdown_check: Optional function that returns True to request graceful shutdown
+            force: Re-download every cloud conversation regardless of
+                ``cloud_updated_at`` state. Treats every ``cloud_listing``
+                row as ``missing_locally``.
+            since: Filter applied to the WORK LIST (not the listing). The
+                listing is always full per #111's architectural inversion.
+                Useful when the user wants "the last week's deltas only".
+            dry_run: Report what would sync without downloading.
+            max_new: Maximum number of NEW conversations to sync (no
+                limit on updates).
+            on_progress: Callback for progress updates (conv_id, title,
+                action[, total]).
+            parallel: Use parallel downloads (default True).
+            shutdown_check: Optional function returning True to request
+                graceful shutdown between listing pages or downloads.
         """
         if not self.config.api_key:
             raise ValueError("API key required. Set OPENHANDS_API_KEY or OH_API_KEY environment variable.")
 
-        cutoff = self._determine_cutoff(force, since)
-        log.info("Starting sync (force=%s, cutoff=%s, dry_run=%s, max_new=%s, parallel=%s)", 
-                 force, cutoff, dry_run, max_new, parallel)
+        log.info(
+            "Starting set-diff sync (force=%s, since=%s, dry_run=%s, max_new=%s, parallel=%s)",
+            force, since, dry_run, max_new, parallel,
+        )
+
+        # Schema-readiness gate. Runs migrations + maintenance tasks so
+        # a fresh-install ``ohtv sync`` works without a prior ``db scan``.
+        with get_connection_for_sync() as conn:
+            ensure_db_ready(conn, show_progress=False)
+            conn.commit()
 
         try:
             with CloudClient(self.config.cloud_api_url, self.config.api_key) as client:
-                conversations = client.search_all_conversations(updated_since=cutoff)
-                conversations = self._add_failed_conversations(conversations)
-                log.info("Found %d conversations to process", len(conversations))
-                return self._process_conversations(
-                    client, conversations, force, dry_run, max_new, on_progress, 
-                    parallel=parallel, shutdown_check=shutdown_check
-                )
+                with get_connection_for_sync() as conn:
+                    return self._run_set_diff_pass(
+                        client,
+                        conn,
+                        force=force,
+                        since=since,
+                        dry_run=dry_run,
+                        max_new=max_new,
+                        on_progress=on_progress,
+                        parallel=parallel,
+                        shutdown_check=shutdown_check,
+                    )
         except httpx.HTTPStatusError as e:
             log.error("HTTP error during sync: %s %s", e.response.status_code, e.response.reason_phrase)
             if e.response.status_code in (401, 403):
@@ -219,96 +270,313 @@ class SyncManager:
             log.error("Network error during sync: %s", e)
             raise SyncAbortedError(f"Network error: {e}")
 
-    def _add_failed_conversations(self, conversations: list[dict]) -> list[dict]:
-        """Add previously failed conversations to the sync list for retry."""
-        if not self.manifest.failed_ids:
-            return conversations
+    def _run_set_diff_pass(
+        self,
+        client: CloudClient,
+        conn,
+        *,
+        force: bool,
+        since: datetime | None,
+        dry_run: bool,
+        max_new: int | None,
+        on_progress: Callable[[str, str, str], None] | None,
+        parallel: bool,
+        shutdown_check: Callable[[], bool] | None,
+    ) -> SyncResult:
+        """The Issue #111 set-diff sync engine.
 
-        existing_ids = {c["id"] for c in conversations}
+        See :meth:`sync` for the user-facing contract.
+        """
+        listing = CloudListingStore(conn)
+        state = SyncStateStore(conn)
+
+        # Phase 1: rebuild cloud_listing under a fresh snapshot.
+        snapshot_id, total_listed = self._run_listing_pass(
+            client, listing, conn, shutdown_check=shutdown_check
+        )
+
+        # Phase 2: persist snapshot bookkeeping in sync_kv. Read by
+        # ``--status`` UX, ``--repair`` (#113), and a future freshness
+        # gate. The engine itself does NOT branch on these values.
+        state.set("last_snapshot_id", snapshot_id)
+        state.set("last_snapshot_completed_at", _utc_now_iso())
+        state.set("last_snapshot_count", total_listed)
+        conn.commit()
+
+        # Phase 3: compute the set-diff work list.
+        work_items = self._categorize_via_set_diff(
+            listing, conn, force=force, since=since, max_new=max_new
+        )
+
+        # Phase 4: include retry items from previous failed downloads.
+        # The manifest stays the source of truth for "failed last time"
+        # until #114 retires it.
+        work_items = self._add_failed_conversations(work_items)
+        log.info("Set-diff: %d items to process (listing=%d)", len(work_items), total_listed)
+
+        # Phase 5: process the work list (existing pipeline).
+        return self._process_work_items(
+            client,
+            conn,
+            work_items,
+            dry_run=dry_run,
+            max_new=max_new,
+            on_progress=on_progress,
+            parallel=parallel,
+            shutdown_check=shutdown_check,
+        )
+
+    def _run_listing_pass(
+        self,
+        client: CloudClient,
+        listing: CloudListingStore,
+        conn,
+        *,
+        shutdown_check: Callable[[], bool] | None,
+    ) -> tuple[str, int]:
+        """Paginate the full cloud listing into ``cloud_listing``.
+
+        Per #111: NO ``updated_since`` filter. The listing is unconditional;
+        set-diff IS the gate. Returns ``(snapshot_id, total_rows)``.
+
+        On any exception during listing the in-flight snapshot is
+        abandoned (leaving the previous snapshot intact) and the
+        exception re-raises.
+        """
+        snapshot_id = listing.start_snapshot()
+        total = 0
+        page_id: str | None = None
+
+        try:
+            while True:
+                if shutdown_check and shutdown_check():
+                    raise SyncAbortedError("Listing interrupted by shutdown request")
+
+                items, next_page_id = client.search_conversations(
+                    # NO updated_since: the architectural inversion of #111.
+                    limit=100,
+                    page_id=page_id,
+                )
+
+                for row in items:
+                    listing.upsert_row(snapshot_id, row)
+                conn.commit()  # per-page incremental commit
+                total += len(items)
+
+                if not next_page_id:
+                    break
+                page_id = next_page_id
+
+            # Atomic swap: prune rows from prior snapshots.
+            listing.commit_snapshot(snapshot_id)
+            conn.commit()
+        except Exception:
+            # Failure path: abandon only the in-flight snapshot rows so
+            # any previously-committed snapshot stays intact.
+            try:
+                listing.abandon_snapshot(snapshot_id)
+                conn.commit()
+            except Exception as cleanup_exc:  # pragma: no cover
+                log.warning("Failed to abandon snapshot %s: %s", snapshot_id, cleanup_exc)
+            raise
+
+        return snapshot_id, total
+
+    def _categorize_via_set_diff(
+        self,
+        listing: CloudListingStore,
+        conn,
+        *,
+        force: bool,
+        since: datetime | None,
+        max_new: int | None,
+    ) -> list[tuple[dict, str]]:
+        """Build the work list from cloud_listing vs manifest diff.
+
+        Returns ``[(conv_dict, action), ...]`` where ``action`` is one
+        of ``"new"`` (missing locally), ``"updated"`` (stale locally),
+        or — implicitly — items not yielded at all (present and fresh).
+        ``force`` collapses every listing row to ``"new"`` (with
+        cleanup-and-redownload semantics handled by the download path).
+
+        ``since`` filters the work list (not the listing) — items with
+        ``updated_at`` older than ``since`` drop out, matching the
+        ``--since`` UX after #111.
+
+        **Source-of-truth**: the manifest (per AGENTS.md item #27 —
+        "manifest stays authoritative until #114"). The conversations
+        table is consulted as a *consistency check* on
+        ``cloud_updated_at`` (set-diff helpers on
+        :class:`CloudListingStore`), but the manifest is what the
+        engine compares against and what the engine mutates.
+        """
+        # Pre-strip every manifest key into its dashless form for O(1)
+        # set-diff comparisons. Manifest may carry either shape per
+        # AGENTS.md item #14.
+        manifest_norm: dict[str, str] = {
+            mid.replace("-", ""): mid for mid in self.manifest.conversations
+        }
+
+        work: list[tuple[dict, str]] = []
+        seen_in_cloud: set[str] = set()  # for the removed-from-cloud reconciliation below
+
+        for row in conn.execute("SELECT * FROM cloud_listing"):
+            cid = row["conversation_id"]
+            seen_in_cloud.add(cid)
+            conv = _listing_row_to_conv_dict(row)
+
+            if force:
+                # Force mode bypasses the diff: every cloud row is
+                # treated as missing and downloaded.
+                if _passes_since_filter(conv, since):
+                    work.append((conv, "new"))
+                continue
+
+            manifest_key = manifest_norm.get(cid)
+            if manifest_key is None:
+                # Missing locally — download as "new".
+                if _passes_since_filter(conv, since):
+                    work.append((conv, "new"))
+                continue
+
+            # Present locally: compare cloud_updated_at to detect drift.
+            cloud_ts = conv.get("updated_at") or ""
+            manifest_entry = self.manifest.conversations.get(manifest_key) or {}
+            manifest_ts = manifest_entry.get("updated_at") or ""
+
+            if not manifest_ts or cloud_ts != manifest_ts:
+                # Stale (or never recorded). Use != not > so a
+                # server-side rewind also reconciles. Scenario #3.
+                if _passes_since_filter(conv, since):
+                    work.append((conv, "updated"))
+                continue
+
+            # Present-both-synced: no work. Issue #112's set-diff helper
+            # on CloudListingStore exposes the same partition to #113
+            # without us recomputing it.
+
+        # Removed-from-cloud reconciliation: silently drop manifest
+        # entries that disappeared from the listing. #113 will add the
+        # user-facing report; #111 just keeps the manifest coherent so
+        # the property tests pass (scenario #15).
+        for normalized, manifest_key in list(manifest_norm.items()):
+            if normalized in seen_in_cloud:
+                continue
+            del self.manifest.conversations[manifest_key]
+
+        return work
+
+    def _add_failed_conversations(
+        self, work_items: list[tuple[dict, str]]
+    ) -> list[tuple[dict, str]]:
+        """Append retry entries for previously-failed downloads.
+
+        Returns ``[(conv_dict, action), ...]`` with ``failed_ids`` from
+        the manifest folded in as ``"new"`` items (the existing retry
+        contract). Items already present in the work list are deduped.
+        """
+        if not self.manifest.failed_ids:
+            return work_items
+
+        existing_ids = {c["id"].replace("-", "") for c, _ in work_items}
         retry_count = 0
 
         for failed_id in self.manifest.failed_ids:
-            if failed_id not in existing_ids:
-                conversations.append({
+            normalized = failed_id.replace("-", "")
+            if normalized in existing_ids:
+                continue
+            work_items.append((
+                {
                     "id": failed_id,
                     "title": "(retry)",
                     "updated_at": "",
-                })
-                retry_count += 1
+                },
+                "new",
+            ))
+            retry_count += 1
 
         if retry_count > 0:
             log.info("Adding %d previously failed conversations for retry", retry_count)
 
-        return conversations
+        return work_items
 
-    def _determine_cutoff(self, force: bool, since: datetime | None) -> datetime | None:
-        """Determine the cutoff date for syncing."""
-        if force:
-            return None
-        if since:
-            return since
-        return self.manifest.last_sync_at
-
-    def _process_conversations(
+    def _process_work_items(
         self,
         client: CloudClient,
-        conversations: list[dict],
-        force: bool,
+        conn,
+        work_items: list[tuple[dict, str]],
+        *,
         dry_run: bool,
         max_new: int | None,
         on_progress: Callable[[str, str, str], None] | None,
         parallel: bool = True,
         shutdown_check: Callable[[], bool] | None = None,
     ) -> SyncResult:
-        """Process each conversation that needs syncing.
-        
-        Args:
-            client: Cloud API client
-            conversations: List of conversation dicts from API
-            force: Re-download all conversations
-            dry_run: Don't actually download, just report what would happen
-            max_new: Limit on number of new conversations to sync
-            on_progress: Callback for progress updates
-            parallel: Use parallel downloads (default True)
-            shutdown_check: Optional function that returns True to request graceful shutdown
+        """Process the pre-categorized work list from :meth:`_categorize_via_set_diff`.
+
+        ``work_items`` arrives as ``[(conv_dict, action), ...]`` where
+        ``action`` is one of ``"new"``, ``"updated"``, or ``"unchanged"``.
+        This method:
+
+        * Applies ``max_new`` (a count-based skip on ``"new"`` items).
+        * Routes ``"unchanged"`` / ``"skipped"`` / ``dry_run`` items
+          straight to the result tally.
+        * Forwards the remainder to the existing
+          :meth:`_download_parallel` / :meth:`_download_sequential` paths
+          (carrying the open DB connection so successful downloads can
+          write ``conversations.cloud_updated_at``).
         """
         result = SyncResult()
-        
-        # Phase 1: Determine what action to take for each conversation
-        # This handles max_new limit correctly before parallel processing
-        work_items = self._categorize_conversations(conversations, force, max_new, result)
-        
-        # Set total for progress display (excluding skipped items)
-        result.total_to_process = sum(1 for _, action in work_items if action != "skipped")
-        
-        # Phase 2: Handle dry-run or unchanged (no download needed)
-        # Also notify progress callback of total on first call
-        first_progress_call = True
-        to_download = []
+
+        # Phase 1: Apply max_new (count-based skip).
+        capped_items: list[tuple[dict, str]] = []
+        new_count = 0
         for conv, action in work_items:
+            if action == "new":
+                if max_new is not None and new_count >= max_new:
+                    capped_items.append((conv, "skipped"))
+                    result.skipped_new += 1
+                    continue
+                new_count += 1
+            capped_items.append((conv, action))
+
+        # Total for progress display (excludes "skipped" items).
+        result.total_to_process = sum(1 for _, a in capped_items if a != "skipped")
+
+        # Phase 2: Route unchanged / skipped / dry-run straight to tally.
+        first_progress_call = True
+        to_download: list[tuple[dict, str]] = []
+        for conv, action in capped_items:
             if action in ("unchanged", "skipped") or dry_run:
                 self._update_result(result, action)
                 if on_progress:
-                    # Pass total on first call so progress bar can set its total
                     if first_progress_call:
-                        on_progress(conv["id"], conv.get("title", "")[:50], action, result.total_to_process)
+                        on_progress(
+                            conv["id"], conv.get("title", "")[:50],
+                            action, result.total_to_process,
+                        )
                         first_progress_call = False
                     else:
                         on_progress(conv["id"], conv.get("title", "")[:50], action)
             else:
                 to_download.append((conv, action))
-        
-        # Phase 3: Download conversations (parallel or sequential)
+
+        # Phase 3: Download.
         if to_download:
-            # If no items were processed in phase 2, pass total on first download callback
             pass_total = first_progress_call
             if parallel and len(to_download) > 1:
-                self._download_parallel(client, to_download, result, on_progress, shutdown_check, pass_total)
+                self._download_parallel(
+                    client, to_download, result, on_progress,
+                    shutdown_check, pass_total, conn=conn,
+                )
             else:
-                self._download_sequential(client, to_download, result, on_progress, shutdown_check, pass_total)
+                self._download_sequential(
+                    client, to_download, result, on_progress,
+                    shutdown_check, pass_total, conn=conn,
+                )
 
         if not dry_run:
-            self._finalize_sync(result)
+            self._finalize_sync(result, conn=conn)
         return result
 
     def _categorize_conversations(
@@ -318,9 +586,13 @@ class SyncManager:
         max_new: int | None,
         result: SyncResult,
     ) -> list[tuple[dict, str]]:
-        """Determine action for each conversation, respecting max_new limit.
-        
-        Returns list of (conv, action) tuples.
+        """Legacy cursor-based categorizer.
+
+        Retained for backward compatibility with existing unit tests in
+        ``tests/unit/test_sync.py`` (``TestSyncManagerMaxNew``). The
+        production sync path goes through
+        :meth:`_categorize_via_set_diff` (Issue #111). New code should
+        not call this method.
         """
         work_items = []
         new_count = 0
@@ -350,6 +622,7 @@ class SyncManager:
         on_progress: Callable[[str, str, str], None] | None,
         shutdown_check: Callable[[], bool] | None = None,
         pass_total_on_first: bool = False,
+        conn=None,
     ) -> None:
         """Download conversations sequentially."""
         consecutive_failures = 0
@@ -370,7 +643,7 @@ class SyncManager:
                 self._cleanup_conversation_dir(conv_id)
             
             actual_action = self._download_and_update(
-                client, conv, conv_id, cloud_updated_at, planned_action, result
+                client, conv, conv_id, cloud_updated_at, planned_action, result, conn=conn,
             )
             self._update_result(result, actual_action)
             if on_progress:
@@ -390,6 +663,7 @@ class SyncManager:
         on_progress: Callable[[str, str, str], None] | None,
         shutdown_check: Callable[[], bool] | None = None,
         pass_total_on_first: bool = False,
+        conn=None,
     ) -> None:
         """Download conversations in parallel using a thread pool.
         
@@ -400,7 +674,13 @@ class SyncManager:
         max_workers = min(DEFAULT_MAX_WORKERS, len(work_items))
         log.info("Starting parallel download with %d workers for %d conversations", 
                  max_workers, len(work_items))
-        
+
+        # Enable the cloud_updated_at write buffer for the duration of
+        # this parallel pass. SQLite connections are not thread-safe;
+        # workers append, the main thread flushes below.
+        with self._db_writer_lock:
+            self._pending_cloud_updated_at = []
+
         # Thread-safe lock for result updates
         lock = threading.Lock()
         total_failures = 0
@@ -419,7 +699,7 @@ class SyncManager:
                 self._cleanup_conversation_dir(conv_id)
             
             actual_action = self._download_and_update(
-                client, conv, conv_id, cloud_updated_at, planned_action, result
+                client, conv, conv_id, cloud_updated_at, planned_action, result, conn=conn,
             )
             return conv, planned_action, actual_action
         
@@ -478,6 +758,14 @@ class SyncManager:
                         else:
                             on_progress(conv["id"], conv.get("title", "")[:50], actual_action)
 
+        # Flush the cloud_updated_at writes accumulated by worker
+        # threads onto the main-thread DB connection, then disable
+        # buffering so subsequent (sequential) calls write directly.
+        if conn is not None:
+            self._flush_cloud_updated_at_writes(conn)
+        with self._db_writer_lock:
+            self._pending_cloud_updated_at = None
+
     def _check_abort(self, action: str, consecutive_failures: int, max_failures: int) -> int:
         """Check if we should abort due to too many consecutive failures."""
         if action == "failed":
@@ -512,13 +800,26 @@ class SyncManager:
         cloud_updated_at: str,
         action: str,
         result: SyncResult,
+        conn=None,
     ) -> str:
-        """Download conversation and update manifest."""
+        """Download conversation, update manifest, write conversations.cloud_updated_at.
+
+        ``conn`` (optional) is the sync-wide DB connection. When passed,
+        the method writes ``conversations.cloud_updated_at`` via
+        :meth:`ConversationStore.record_cloud_download` so the next
+        sync's set-diff sees this conversation as in-sync. A DB-side
+        failure does NOT count as a download failure — manifest +
+        on-disk export are the user-facing success criteria.
+        """
         try:
             log.debug("Downloading %s", conv_id)
             zip_bytes = client.download_trajectory(conv_id)
             conv_dir = self.exporter.export_from_zip_bytes(conv_id, zip_bytes)
             self._update_manifest_entry(conv, conv_id, cloud_updated_at, conv_dir)
+            if conn is not None:
+                self._record_cloud_download_in_db(
+                    conn, conv_id, conv_dir, cloud_updated_at
+                )
             log.debug("Downloaded %s (%s)", conv_id, action)
             return action
         except httpx.HTTPStatusError as e:
@@ -531,6 +832,75 @@ class SyncManager:
             log.warning("Failed to download %s: %s", conv_id, e)
             self._record_failure(result, conv_id, str(e))
             return "failed"
+
+    def _record_cloud_download_in_db(
+        self,
+        conn,
+        conv_id: str,
+        conv_dir: Path,
+        cloud_updated_at: str,
+    ) -> None:
+        """Persist ``conversations.cloud_updated_at`` after a successful download.
+
+        Best-effort: a DB-side failure is logged but does not bubble up
+        through the download path. SQLite connections are not
+        thread-safe — parallel workers handing the connection from the
+        main thread will trigger ``ProgrammingError: SQLite objects
+        created in a thread can only be used in that same thread.``
+        We serialize all writes through a lock and pin them to a
+        single thread by buffering instead: workers append to
+        :attr:`_pending_cloud_updated_at` (guarded by
+        :attr:`_db_writer_lock`) and the main thread flushes after the
+        thread pool drains. See :meth:`_flush_cloud_updated_at_writes`.
+        """
+        # If we have a writer queue, defer (parallel case). Otherwise
+        # write directly (sequential case).
+        with self._db_writer_lock:
+            if self._pending_cloud_updated_at is not None:
+                self._pending_cloud_updated_at.append(
+                    (conv_id, str(conv_dir), cloud_updated_at or None)
+                )
+                return
+        try:
+            store = ConversationStore(conn)
+            store.record_cloud_download(
+                conv_id,
+                location=str(conv_dir),
+                cloud_updated_at=cloud_updated_at or None,
+            )
+            conn.commit()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning(
+                "Failed to record cloud_updated_at for %s in DB: %s",
+                conv_id, exc,
+            )
+
+    def _flush_cloud_updated_at_writes(self, conn) -> None:
+        """Drain the queued ``record_cloud_download`` writes onto ``conn``.
+
+        Called from the main thread after the parallel download pool
+        drains. Safe to call with an empty queue (no-op).
+        """
+        with self._db_writer_lock:
+            queued = list(self._pending_cloud_updated_at or [])
+            if self._pending_cloud_updated_at is not None:
+                self._pending_cloud_updated_at.clear()
+        if not queued:
+            return
+        try:
+            store = ConversationStore(conn)
+            for conv_id, location, cloud_updated_at in queued:
+                store.record_cloud_download(
+                    conv_id,
+                    location=location,
+                    cloud_updated_at=cloud_updated_at,
+                )
+            conn.commit()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning(
+                "Failed to flush %d queued cloud_updated_at writes: %s",
+                len(queued), exc,
+            )
 
     def _record_failure(self, result: SyncResult, conv_id: str, error: str) -> None:
         """Record a download failure."""
@@ -594,29 +964,50 @@ class SyncManager:
         elif action == "skipped":
             result.skipped_new += 1
 
-    def _finalize_sync(self, result: SyncResult) -> None:
-        """Update and save manifest after sync."""
+    def _finalize_sync(self, result: SyncResult, conn=None) -> None:
+        """Update and save manifest after sync.
+
+        Post-#111: ``last_sync_at`` is a pure UX field. The engine never
+        consumes it as a gate. We dual-write it to ``sync_kv`` so #114
+        can drain the manifest without a flag-day.
+        """
         self.manifest.failed_ids = result.failed_ids
         self.manifest.sync_count += 1
 
-        # Don't advance cutoff if there were failures or skipped new conversations
+        # Advance last_sync_at unless there are unresolved gaps (failures
+        # / skipped-by-max_new). The UX value is "what was the wall-clock
+        # time of the last clean reconciliation" — not consulted by the
+        # set-diff engine.
+        advanced = False
         if result.has_failures:
             log.warning(
-                "Sync complete with %d failures. Not advancing cutoff. "
+                "Sync complete with %d failures. Not advancing last_sync_at. "
                 "Run 'ohtv sync' again to retry failed conversations.",
                 result.failed,
             )
         elif result.has_skipped_new:
             log.info(
                 "Sync complete. Synced %d new, %d additional available. "
-                "Not advancing cutoff so skipped conversations remain visible.",
+                "Not advancing last_sync_at so skipped conversations stay visible.",
                 result.new, result.skipped_new,
             )
         else:
             self.manifest.last_sync_at = datetime.now(timezone.utc)
+            advanced = True
             log.info("Sync complete. Total conversations: %d", len(self.manifest.conversations))
 
         self.manifest.save(self.manifest_path)
+
+        # Dual-write to sync_kv (Issue #114 transition state). Engine
+        # never reads from this key.
+        if advanced and conn is not None:
+            try:
+                SyncStateStore(conn).set(
+                    "last_sync_at", _format_datetime(self.manifest.last_sync_at)
+                )
+                conn.commit()
+            except Exception as exc:  # pragma: no cover - defensive
+                log.warning("Failed to mirror last_sync_at into sync_kv: %s", exc)
 
     def get_status(self) -> dict:
         """Get current sync status."""
@@ -1224,6 +1615,103 @@ def _format_datetime(dt: datetime | None) -> str | None:
     if not dt:
         return None
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_now_iso() -> str:
+    """ISO 8601 UTC timestamp for ``sync_kv`` bookkeeping."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _redash(undashed: str) -> str:
+    """Reinsert canonical UUID dashes into a 32-char hex string.
+
+    Returns the input verbatim if it does not look like a 32-char hex.
+    """
+    if len(undashed) != 32 or not all(c in "0123456789abcdef" for c in undashed.lower()):
+        return undashed
+    return f"{undashed[0:8]}-{undashed[8:12]}-{undashed[12:16]}-{undashed[16:20]}-{undashed[20:32]}"
+
+
+def _listing_row_to_conv_dict(row) -> dict:
+    """Adapt a ``cloud_listing`` table row into the dict shape used by
+    the download pipeline (``conv["id"]``, ``conv["title"]``, etc.).
+    """
+    return {
+        "id": row["conversation_id"],
+        "title": row["title"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "selected_repository": row["selected_repository"],
+        "selected_branch": row["selected_branch"],
+        "tags": _maybe_json_loads(row["tags"]),
+    }
+
+
+def _maybe_json_loads(value):
+    """Best-effort JSON decode for stringified columns.
+
+    The cloud listing API returns ``tags`` as a dict / None; we store
+    it verbatim in :meth:`CloudListingStore.upsert_row`. SQLite
+    coerces dicts/lists to TEXT silently, so this round-trip may
+    receive either a real dict (in-memory store), a JSON string (after
+    an INSERT round-trip), or ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            return value
+    return value
+
+
+def _passes_since_filter(conv: dict, since: datetime | None) -> bool:
+    """Return True if ``conv`` should be retained given a ``--since`` filter.
+
+    ``since`` is interpreted as a UTC datetime; ``None`` disables the
+    filter. Items whose ``updated_at`` is missing OR newer-or-equal to
+    ``since`` are retained (we don't drop unknown timestamps lest a
+    stale cloud row hide a fresh local sync).
+    """
+    if since is None:
+        return True
+    updated_at = conv.get("updated_at")
+    if not updated_at:
+        return True
+    parsed = _parse_datetime(updated_at)
+    if parsed is None:
+        return True
+    return parsed >= since
+
+
+def get_connection_for_sync():
+    """Open a fresh sqlite3 connection at the configured DB path.
+
+    Mirrors :func:`ohtv.db.connection.get_connection` but isolated so
+    tests can monkeypatch ``ohtv.sync.get_db_path`` without affecting
+    other call sites. The returned context manager configures the same
+    pragmas as the canonical connection helper.
+    """
+    import sqlite3
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        db_path = get_db_path()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA journal_mode = WAL")
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    return _ctx()
 
 
 def _normalize_labels(value: object) -> dict[str, str] | None:

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -420,6 +420,14 @@ class SyncManager:
         work: list[tuple[dict, str]] = []
         seen_in_cloud: set[str] = set()  # for the removed-from-cloud reconciliation below
 
+        # Streaming SELECT — sqlite3 returns a cursor we iterate row-by-row,
+        # so peak memory tracks one row at a time, not the full result set.
+        # The local accumulators (``work``, ``seen_in_cloud``, ``manifest_norm``)
+        # do scale with the catalog size: at ~200 bytes/row they comfortably
+        # absorb the low-thousands catalogs we see today and are still well
+        # under 10 MB at 10k conversations. Chunked queries are deferred to a
+        # follow-up if anyone actually hits a scale wall — added in response
+        # to bot-review feedback on PR #133.
         for row in conn.execute("SELECT * FROM cloud_listing"):
             cid = row["conversation_id"]
             seen_in_cloud.add(cid)
@@ -455,14 +463,25 @@ class SyncManager:
             # on CloudListingStore exposes the same partition to #113
             # without us recomputing it.
 
-        # Removed-from-cloud reconciliation: silently drop manifest
-        # entries that disappeared from the listing. #113 will add the
+        # Removed-from-cloud reconciliation: drop manifest entries
+        # that disappeared from the listing. #113 will add the
         # user-facing report; #111 just keeps the manifest coherent so
-        # the property tests pass (scenario #15).
+        # the property tests pass (scenario #15). Emit a WARNING so
+        # accidental cloud-side data loss or permission changes
+        # surface in the log rather than silently shrinking the
+        # manifest — bot-review feedback on this PR.
+        removed_count = 0
         for normalized, manifest_key in list(manifest_norm.items()):
             if normalized in seen_in_cloud:
                 continue
             del self.manifest.conversations[manifest_key]
+            removed_count += 1
+        if removed_count:
+            log.warning(
+                "Removed %d conversation(s) from manifest "
+                "(no longer visible in cloud listing).",
+                removed_count,
+            )
 
         return work
 

--- a/src/ohtv/sync.py
+++ b/src/ohtv/sync.py
@@ -1694,9 +1694,16 @@ def _passes_since_filter(conv: dict, since: datetime | None) -> bool:
     filter. Items whose ``updated_at`` is missing OR newer-or-equal to
     ``since`` are retained (we don't drop unknown timestamps lest a
     stale cloud row hide a fresh local sync).
+
+    ``click.DateTime()`` hands us offset-naive datetimes; normalize them
+    to UTC-aware here so the ``parsed >= since`` comparison doesn't
+    raise ``TypeError`` against the tz-aware values returned by
+    :func:`_parse_datetime` (T6 regression, PR #133).
     """
     if since is None:
         return True
+    if since.tzinfo is None:
+        since = since.replace(tzinfo=timezone.utc)
     updated_at = conv.get("updated_at")
     if not updated_at:
         return True

--- a/tests/unit/db/stores/test_cloud_listing_store.py
+++ b/tests/unit/db/stores/test_cloud_listing_store.py
@@ -1,0 +1,285 @@
+"""Unit tests for :class:`ohtv.db.stores.CloudListingStore` (Issue #111).
+
+These tests exercise the snapshot lifecycle, the set-diff query
+helpers (``missing_locally`` / ``stale_locally`` / ``removed_from_cloud``),
+and id normalization in isolation from the sync engine.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from ohtv.db.stores import CloudListingStore, ConversationStore
+
+
+_UTC = timezone.utc
+
+
+@pytest.fixture
+def listing(db_conn) -> CloudListingStore:
+    return CloudListingStore(db_conn)
+
+
+@pytest.fixture
+def conversations(db_conn) -> ConversationStore:
+    return ConversationStore(db_conn)
+
+
+def _seed_conversation_row(
+    db_conn, conv_id: str, *, cloud_updated_at: str | None = None
+) -> None:
+    """Insert a minimal ``conversations`` row for set-diff tests."""
+    db_conn.execute(
+        """
+        INSERT INTO conversations (
+            id, location, registered_at, event_count, source, cloud_updated_at
+        )
+        VALUES (?, ?, '2024-01-01T00:00:00Z', 0, 'cloud', ?)
+        """,
+        (conv_id, f"/tmp/{conv_id}", cloud_updated_at),
+    )
+
+
+class TestSnapshotLifecycle:
+    """``start_snapshot`` → ``upsert_row`` → ``commit_snapshot``."""
+
+    def test_start_snapshot_returns_unique_id(self, listing):
+        a = listing.start_snapshot()
+        b = listing.start_snapshot()
+        assert a != b
+
+    def test_upsert_row_persists_payload(self, listing, db_conn):
+        snap = listing.start_snapshot()
+        listing.upsert_row(
+            snap,
+            {
+                "id": "abc",
+                "title": "t",
+                "updated_at": "2024-06-01T00:00:00Z",
+                "created_at": "2024-06-01T00:00:00Z",
+                "tags": {"env": "prod"},
+                "selected_repository": "org/repo",
+                "selected_branch": "main",
+            },
+        )
+        db_conn.commit()
+
+        row = listing.get("abc")
+        assert row is not None
+        assert row["conversation_id"] == "abc"
+        assert row["title"] == "t"
+        assert row["selected_repository"] == "org/repo"
+
+    def test_upsert_normalizes_dashed_ids(self, listing, db_conn):
+        """Dashed ids are normalized to undashed at write-time, and
+        ``get`` accepts either form (symmetric normalization)."""
+        snap = listing.start_snapshot()
+        dashed = "00000000-0000-0000-0000-000000000001"
+        undashed = "00000000000000000000000000000001"
+        listing.upsert_row(snap, {"id": dashed, "updated_at": "2024-01-01T00:00:00Z"})
+        db_conn.commit()
+
+        # Both forms resolve to the same row (id-form invariance).
+        row_undashed = listing.get(undashed)
+        row_dashed = listing.get(dashed)
+        assert row_undashed is not None
+        assert row_dashed is not None
+        # Stored canonical form is undashed.
+        assert row_undashed["conversation_id"] == undashed
+
+    def test_upsert_row_dedupes_by_id(self, listing, db_conn):
+        """Two ``upsert_row`` calls with the same id collapse to one row.
+
+        This is the pagination-dedup guarantee: keyset drift can yield
+        an id on two consecutive pages, and the second write must
+        overwrite (not duplicate) the first.
+        """
+        snap = listing.start_snapshot()
+        listing.upsert_row(snap, {"id": "x", "updated_at": "2024-01-01T00:00:00Z"})
+        listing.upsert_row(snap, {"id": "x", "updated_at": "2024-06-01T00:00:00Z"})
+        db_conn.commit()
+
+        # SELECT COUNT(*) to verify physical dedup at the table level.
+        rows = list(db_conn.execute("SELECT * FROM cloud_listing"))
+        assert len(rows) == 1
+        assert rows[0]["updated_at"] == "2024-06-01T00:00:00Z"
+
+    def test_commit_snapshot_prunes_prior_snapshots(self, listing, db_conn):
+        old_snap = listing.start_snapshot()
+        listing.upsert_row(old_snap, {"id": "old", "updated_at": "2024-01-01T00:00:00Z"})
+        listing.commit_snapshot(old_snap)
+        db_conn.commit()
+
+        new_snap = listing.start_snapshot()
+        listing.upsert_row(new_snap, {"id": "new", "updated_at": "2024-06-01T00:00:00Z"})
+        listing.commit_snapshot(new_snap)
+        db_conn.commit()
+
+        # Old row was atomically swapped out.
+        assert listing.get("old") is None
+        assert listing.get("new") is not None
+
+    def test_abandon_snapshot_preserves_prior_snapshot(self, listing, db_conn):
+        """A failed listing must NOT clobber the previous committed snapshot."""
+        committed = listing.start_snapshot()
+        listing.upsert_row(committed, {"id": "stable", "updated_at": "2024-01-01T00:00:00Z"})
+        listing.commit_snapshot(committed)
+        db_conn.commit()
+
+        # Half-finished listing — fails before commit_snapshot.
+        in_flight = listing.start_snapshot()
+        listing.upsert_row(in_flight, {"id": "partial", "updated_at": "2024-06-01T00:00:00Z"})
+        listing.abandon_snapshot(in_flight)
+        db_conn.commit()
+
+        # The committed snapshot survived; the in-flight rows were dropped.
+        assert listing.get("stable") is not None
+        assert listing.get("partial") is None
+
+    def test_missing_id_returns_none(self, listing):
+        assert listing.get("does-not-exist") is None
+
+
+class TestSetDiffHelpers:
+    """``missing_locally`` / ``stale_locally`` / ``removed_from_cloud``."""
+
+    def _commit_snapshot(self, listing, db_conn, payloads):
+        snap = listing.start_snapshot()
+        for p in payloads:
+            listing.upsert_row(snap, p)
+        listing.commit_snapshot(snap)
+        db_conn.commit()
+        return snap
+
+    def test_missing_locally_yields_ids_not_in_conversations(
+        self, listing, db_conn
+    ):
+        self._commit_snapshot(
+            listing,
+            db_conn,
+            [
+                {"id": "a", "updated_at": "2024-01-01T00:00:00Z"},
+                {"id": "b", "updated_at": "2024-01-01T00:00:00Z"},
+            ],
+        )
+        _seed_conversation_row(db_conn, "a", cloud_updated_at="2024-01-01T00:00:00Z")
+        db_conn.commit()
+
+        assert set(listing.missing_locally()) == {"b"}
+
+    def test_stale_locally_uses_inequality_not_greater_than(
+        self, listing, db_conn
+    ):
+        """The stale check uses ``!=`` so a backdated cloud timestamp also
+        counts as stale (Issue #111 scenario #3)."""
+        self._commit_snapshot(
+            listing,
+            db_conn,
+            [{"id": "a", "updated_at": "2024-01-01T00:00:00Z"}],
+        )
+        _seed_conversation_row(db_conn, "a", cloud_updated_at="2024-06-01T00:00:00Z")
+        db_conn.commit()
+
+        # Local has the NEWER ts; cloud was rewound. Stale check must yield "a".
+        assert set(listing.stale_locally()) == {"a"}
+
+    def test_stale_locally_null_local_ts_is_stale(self, listing, db_conn):
+        self._commit_snapshot(
+            listing,
+            db_conn,
+            [{"id": "a", "updated_at": "2024-01-01T00:00:00Z"}],
+        )
+        _seed_conversation_row(db_conn, "a", cloud_updated_at=None)
+        db_conn.commit()
+
+        assert set(listing.stale_locally()) == {"a"}
+
+    def test_stale_locally_matching_ts_is_fresh(self, listing, db_conn):
+        self._commit_snapshot(
+            listing,
+            db_conn,
+            [{"id": "a", "updated_at": "2024-01-01T00:00:00Z"}],
+        )
+        _seed_conversation_row(db_conn, "a", cloud_updated_at="2024-01-01T00:00:00Z")
+        db_conn.commit()
+
+        assert list(listing.stale_locally()) == []
+
+    def test_removed_from_cloud_yields_local_only_rows(
+        self, listing, db_conn
+    ):
+        self._commit_snapshot(
+            listing,
+            db_conn,
+            [{"id": "a", "updated_at": "2024-01-01T00:00:00Z"}],
+        )
+        _seed_conversation_row(db_conn, "a", cloud_updated_at="2024-01-01T00:00:00Z")
+        _seed_conversation_row(db_conn, "ghost", cloud_updated_at=None)
+        db_conn.commit()
+
+        assert set(listing.removed_from_cloud()) == {"ghost"}
+
+
+class TestUpsertValidation:
+    def test_missing_id_raises(self, listing):
+        snap = listing.start_snapshot()
+        with pytest.raises(ValueError, match="missing 'id'"):
+            listing.upsert_row(snap, {"title": "no id here"})
+
+    def test_unknown_keys_silently_dropped(self, listing, db_conn):
+        snap = listing.start_snapshot()
+        listing.upsert_row(
+            snap,
+            {
+                "id": "x",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "future_api_field": "ignored",
+            },
+        )
+        db_conn.commit()
+        assert listing.get("x") is not None
+
+    def test_fetched_at_defaults_to_now(self, listing, db_conn):
+        snap = listing.start_snapshot()
+        listing.upsert_row(snap, {"id": "x", "updated_at": "2024-01-01T00:00:00Z"})
+        db_conn.commit()
+
+        row = listing.get("x")
+        # ``fetched_at`` should be a parseable iso timestamp.
+        assert row["fetched_at"]
+        datetime.fromisoformat(row["fetched_at"].rstrip("Z"))
+
+
+class TestJSONColumnSerialization:
+    def test_tags_dict_round_trip(self, listing, db_conn):
+        snap = listing.start_snapshot()
+        listing.upsert_row(
+            snap,
+            {
+                "id": "x",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "tags": {"team": "platform", "env": "prod"},
+            },
+        )
+        db_conn.commit()
+        row = listing.get("x")
+        # tags column stores JSON text — caller is responsible for decoding.
+        assert isinstance(row["tags"], str)
+        assert "platform" in row["tags"]
+
+    def test_sub_conversation_ids_list_round_trip(self, listing, db_conn):
+        snap = listing.start_snapshot()
+        listing.upsert_row(
+            snap,
+            {
+                "id": "x",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "sub_conversation_ids": ["a", "b"],
+            },
+        )
+        db_conn.commit()
+        row = listing.get("x")
+        assert isinstance(row["sub_conversation_ids"], str)
+        assert "a" in row["sub_conversation_ids"]

--- a/tests/unit/db/stores/test_cloud_listing_store.py
+++ b/tests/unit/db/stores/test_cloud_listing_store.py
@@ -283,3 +283,41 @@ class TestJSONColumnSerialization:
         row = listing.get("x")
         assert isinstance(row["sub_conversation_ids"], str)
         assert "a" in row["sub_conversation_ids"]
+
+    def test_pr_number_list_round_trip(self, listing, db_conn):
+        """Regression: the live cloud API returns ``pr_number`` as an
+        ``Array<int>`` (e.g. ``[133]``). The PR-#133 fixture set never
+        populated this field so CI missed the
+        ``sqlite3.ProgrammingError: type 'list' is not supported``
+        crash that the first manual sync hit. Asserting the list shape
+        round-trips locks in the JSON encoding."""
+        snap = listing.start_snapshot()
+        listing.upsert_row(
+            snap,
+            {
+                "id": "x",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "pr_number": [133],
+            },
+        )
+        db_conn.commit()
+        row = listing.get("x")
+        # Stored as JSON text — matches tags / sub_conversation_ids policy.
+        assert isinstance(row["pr_number"], str)
+        assert "133" in row["pr_number"]
+
+    def test_pr_number_empty_list_round_trip(self, listing, db_conn):
+        """The common case for non-PR conversations: ``pr_number=[]``.
+        sqlite3 would still reject the raw list before JSON encoding."""
+        snap = listing.start_snapshot()
+        listing.upsert_row(
+            snap,
+            {
+                "id": "x",
+                "updated_at": "2024-01-01T00:00:00Z",
+                "pr_number": [],
+            },
+        )
+        db_conn.commit()
+        row = listing.get("x")
+        assert row["pr_number"] == "[]"

--- a/tests/unit/db/stores/test_sync_state_store.py
+++ b/tests/unit/db/stores/test_sync_state_store.py
@@ -1,0 +1,75 @@
+"""Unit tests for :class:`ohtv.db.stores.SyncStateStore` (Issue #111)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ohtv.db.stores import SyncStateStore
+
+
+@pytest.fixture
+def state(db_conn) -> SyncStateStore:
+    return SyncStateStore(db_conn)
+
+
+class TestGetSet:
+    def test_get_unknown_key_returns_default(self, state):
+        assert state.get("nope") is None
+        assert state.get("nope", default="x") == "x"
+
+    def test_set_then_get_round_trip(self, state, db_conn):
+        state.set("last_snapshot_id", "snap-42")
+        db_conn.commit()
+        assert state.get("last_snapshot_id") == "snap-42"
+
+    def test_set_overwrites_existing_value(self, state, db_conn):
+        state.set("k", "first")
+        db_conn.commit()
+        state.set("k", "second")
+        db_conn.commit()
+        assert state.get("k") == "second"
+
+    def test_set_stores_non_string_values_via_sqlite_coercion(self, state, db_conn):
+        """SQLite stores the value verbatim (no application-level coercion).
+
+        Callers wanting string canonicalization should convert before
+        calling ``set()``. This test documents the actual behaviour so
+        a future refactor that adds eager ``str()`` coercion would
+        break it intentionally.
+        """
+        state.set("count", 1234)
+        db_conn.commit()
+        # SQLite TEXT column receives int — ``sqlite3`` will return it
+        # as the original type (no schema-driven type coercion).
+        assert state.get("count") == 1234
+
+    def test_set_none_clears_value(self, state, db_conn):
+        state.set("k", "value")
+        db_conn.commit()
+        state.set("k", None)
+        db_conn.commit()
+        # NULL value reads back as None.
+        assert state.get("k") is None
+
+
+class TestSnapshotBookkeepingKeys:
+    """The keys #111 writes to ``sync_kv`` are conventional, not enforced.
+
+    The store is a thin k/v wrapper; these tests document the intent
+    and catch regressions if the engine's key naming drifts.
+    """
+
+    def test_snapshot_id_key_round_trip(self, state, db_conn):
+        state.set("last_snapshot_id", "abc123")
+        db_conn.commit()
+        assert state.get("last_snapshot_id") == "abc123"
+
+    def test_snapshot_completed_at_key_round_trip(self, state, db_conn):
+        state.set("last_snapshot_completed_at", "2024-06-01T00:00:00Z")
+        db_conn.commit()
+        assert state.get("last_snapshot_completed_at") == "2024-06-01T00:00:00Z"
+
+    def test_snapshot_count_key_round_trip(self, state, db_conn):
+        state.set("last_snapshot_count", 1234)
+        db_conn.commit()
+        assert state.get("last_snapshot_count") == 1234

--- a/tests/unit/db/test_018_set_diff_sync_schema.py
+++ b/tests/unit/db/test_018_set_diff_sync_schema.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -663,111 +662,20 @@ class TestBackfill:
 
 
 class TestScopeGuarantee:
-    """The migration is observable but no consumer code touches it.
+    """Migration 018 schema is now consumed by #111.
 
-    The user-facing acceptance criterion is:
+    This class previously enforced that no production code touched
+    ``cloud_listing`` / ``sync_kv`` / ``conversations.cloud_updated_at``
+    until the set-diff engine landed. With Issue #111 merged the
+    schema has legitimate consumers — :mod:`ohtv.db.stores.cloud_listing_store`,
+    :mod:`ohtv.db.stores.sync_state_store`, the
+    :meth:`ConversationStore.record_cloud_download` method, and the
+    :meth:`SyncManager.sync` engine itself.
 
-        grep -rE 'cloud_listing|cloud_updated_at|sync_kv' \
-            src/ohtv/ --include='*.py'
-        # should match ONLY the new migration file
-
-    That literal grep is a useful smoke check but is intentionally
-    coarse — it produces incidental matches against pre-existing
-    identifiers in ``src/ohtv/sync.py``:
-
-    * ``cloud_updated_at`` — a local variable / parameter holding the
-      cloud's ``updated_at`` from the listing API response (predates
-      this PR by months).
-    * ``cloud_listing`` — substring inside the method names
-      ``_fetch_cloud_listing_for_repair`` and
-      ``_fetch_cloud_listing_by_id`` (the "cloud listing" API
-      endpoint, not the new table).
-
-    Neither reference is an SQL read/write of the new schema. To
-    keep the scope guarantee enforceable in CI we test two stronger
-    properties:
-
-    1. ``sync_kv`` is brand new — it must appear *only* in the
-       migration file. (No prior collisions possible.)
-    2. No file other than the migration contains an SQL-shaped
-       reference to ``cloud_listing``, ``sync_kv``, or
-       ``cloud_updated_at`` — i.e. preceded by ``FROM``, ``JOIN``,
-       ``INTO``, ``UPDATE``, ``TABLE``, or appearing inside a SET /
-       WHERE clause on those tables/columns.
+    The class is intentionally left in place (rather than deleted) as
+    a marker that the scope-guarantee invariant was retired by #111.
     """
 
-    @staticmethod
-    def _grep(pattern: str, src_dir: Path) -> set[Path]:
-        result = subprocess.run(
-            [
-                "grep",
-                "-rE",
-                pattern,
-                str(src_dir),
-                "--include=*.py",
-                "-l",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        return {
-            Path(line).resolve()
-            for line in result.stdout.splitlines()
-            if line.strip()
-        }
-
-    def test_sync_kv_only_in_migration(self):
-        """Brand-new identifier; should appear in exactly one file."""
-        repo_root = Path(__file__).resolve().parents[3]
-        src_dir = repo_root / "src" / "ohtv"
-        migration_file = (
-            src_dir / "db" / "migrations" / MIGRATION_NAME
-        ).resolve()
-        assert self._grep(r"\bsync_kv\b", src_dir) == {migration_file}
-
-    def test_no_sql_consumer_of_new_schema(self):
-        """No SQL operation outside the migration touches the new schema.
-
-        Looks for SQL-context references: keywords that bind a name
-        to a table or column in SQLite DML/DDL. The migration file
-        is the only legitimate match; any other hit means a consumer
-        has snuck in.
-        """
-        repo_root = Path(__file__).resolve().parents[3]
-        src_dir = repo_root / "src" / "ohtv"
-        migration_file = (
-            src_dir / "db" / "migrations" / MIGRATION_NAME
-        ).resolve()
-
-        # Anything in ``src/ohtv`` that mentions a new-schema token
-        # at all. We then filter the matches against a pre-existing
-        # allow-list (see below).
-        sql_token_pattern = r"(?:cloud_listing|sync_kv|cloud_updated_at)"
-        candidates = self._grep(sql_token_pattern, src_dir)
-        offenders = candidates - {migration_file}
-
-        # For each offender, verify the mentions are only the known
-        # pre-existing local-variable / method-name collisions in
-        # ``sync.py``. Anything else is a consumer leak.
-        allowed_collisions = {
-            (src_dir / "sync.py").resolve(): {
-                # Local variable name; predates the column.
-                "cloud_updated_at",
-                # Substring of two pre-existing method names.
-                "cloud_listing",
-            },
-        }
-
-        unexplained: list[str] = []
-        for offender in offenders:
-            allowed = allowed_collisions.get(offender, set())
-            text = offender.read_text()
-            for token in ("cloud_listing", "sync_kv", "cloud_updated_at"):
-                if token in text and token not in allowed:
-                    unexplained.append(f"{offender}: contains '{token}'")
-
-        assert not unexplained, (
-            "Unexpected consumer references to the migration-018 schema:\n"
-            + "\n".join(unexplained)
-        )
+    def test_schema_is_consumed_by_issue_111(self):
+        """The #112 schema now has at least one production consumer."""
+        from ohtv.db.stores import CloudListingStore, SyncStateStore  # noqa: F401

--- a/tests/unit/sync/conftest.py
+++ b/tests/unit/sync/conftest.py
@@ -88,6 +88,13 @@ def sync_manager_factory(
             "ohtv.sync.get_manifest_path", lambda: manifest_path
         )
 
+        # Route the set-diff sync engine's DB writes (Issue #111) into a
+        # per-test sqlite file. The engine opens its own connection via
+        # ``ohtv.sync.get_db_path`` so a single monkeypatch covers every
+        # sync()/repair() invocation inside this fixture's scope.
+        db_path = tmp_path / "index.db"
+        monkeypatch.setattr("ohtv.sync.get_db_path", lambda: db_path)
+
         # The import-site patch is the bridge until #111 lands.
         # ``CloudClient(...)`` is the production-code constructor call; we
         # discard the (base_url, api_key) args and hand back the
@@ -95,6 +102,15 @@ def sync_manager_factory(
         # context manager.
         monkeypatch.setattr(
             "ohtv.sync.CloudClient", lambda *_a, **_kw: cloud
+        )
+
+        # Silence the maintenance-task progress UI in tests; the
+        # behavioral suite asserts on result counts, not stderr noise.
+        monkeypatch.setattr(
+            "ohtv.sync.ensure_db_ready",
+            lambda conn, show_progress=False: __import__(
+                "ohtv.db", fromlist=["migrate"]
+            ).migrate(conn),
         )
 
         return SyncManager(config)

--- a/tests/unit/sync/fakes.py
+++ b/tests/unit/sync/fakes.py
@@ -72,6 +72,13 @@ class FakeConversation:
             listing but blob still on disk" case).
         selected_repository: Optional repo for Issue #87 metadata. Surfaces
             in the listing payload only.
+        pr_number: Cloud-side PR-number tag list. The real API returns
+            this as an ``Array<int>`` (e.g. ``[133]`` for a PR-tagged
+            conversation, ``[]`` for plain ones — see
+            ``REFERENCE_CLOUD_API.md``). Defaults to ``None`` so existing
+            scenarios stay opt-in; populate it on at least one fixture
+            per sync scenario to exercise the cloud_listing JSON-encoding
+            path (PR #133 regression).
     """
 
     id: str
@@ -82,6 +89,7 @@ class FakeConversation:
     trajectory_zip: bytes | None = None
     visible: bool = True
     selected_repository: str | None = None
+    pr_number: list[int] | None = None
 
     def to_listing_dict(self) -> dict:
         """Serialize to the dict shape the real listing API returns."""
@@ -92,6 +100,10 @@ class FakeConversation:
             "updated_at": _iso_z(self.updated_at),
             "tags": self.tags,
             "selected_repository": self.selected_repository,
+            # Mirror the real API: empty list when no PR is associated,
+            # ``[N]`` when a PR is tagged. ``None`` is preserved so tests
+            # can deliberately probe the "key absent" path.
+            "pr_number": self.pr_number if self.pr_number is not None else [],
         }
 
 

--- a/tests/unit/sync/fakes.py
+++ b/tests/unit/sync/fakes.py
@@ -259,7 +259,30 @@ class FakeCloudClient:
         limit: int = 100,
         page_id: str | None = None,
     ) -> tuple[list[dict], str | None]:
-        """Mirror :meth:`CloudClient.search_conversations`."""
+        """Mirror :meth:`CloudClient.search_conversations`.
+
+        Post-#111 the production sync engine drives pagination through
+        ``search_conversations`` directly (it commits each page to
+        ``cloud_listing`` between calls). For ``mutate_between_pages``
+        to fire in that flow, this method runs registered mutators
+        when called with a non-empty ``page_id`` — i.e. on every
+        page *after* the first. ``search_all_conversations`` continues
+        to run them through its private ``_serve_page`` path, so the
+        two surfaces produce the same observable behaviour.
+        """
+        # Run inter-page mutators on subsequent pages so the production
+        # set-diff engine's manual pagination loop exercises the same
+        # injection knob as ``search_all_conversations``.
+        if page_id:
+            for mutator in self._mutators_between_pages:
+                mutator(self)
+        else:
+            # First page of a fresh listing — record the cursor value on
+            # ``search_calls`` so back-compat tests built around the
+            # pre-#111 ``search_all_conversations`` recording surface keep
+            # working. (One entry per logical sync, not per page.)
+            self.search_calls.append(updated_since)
+
         self.search_log.append(
             SearchCall(
                 method="search_conversations",
@@ -353,11 +376,29 @@ class FakeCloudClient:
         return sum(1 for c in self._store.values() if c.visible)
 
     def download_trajectory(self, conversation_id: str) -> bytes:
-        """Mirror :meth:`CloudClient.download_trajectory`."""
+        """Mirror :meth:`CloudClient.download_trajectory`.
+
+        Production ``CloudClient`` accepts either the dashed or
+        undashed conversation-id form; the real cloud API normalizes
+        internally. We mirror that here by trying both the verbatim
+        id AND the normalized (dashed) form so callers downstream of
+        the #111 set-diff engine (which stores ids in their normalized
+        undashed form) can still resolve to the original
+        :class:`FakeConversation`.
+        """
         self.download_calls.append(conversation_id)
         if conversation_id in self._fail_downloads:
             raise self._fail_downloads[conversation_id]
         conv = self._store.get(conversation_id)
+        if conv is None:
+            # Try matching by normalized id — the fake may have been
+            # populated with a dashed UUID while the engine is asking
+            # for the undashed form (or vice versa).
+            target = conversation_id.replace("-", "")
+            for stored_id, candidate in self._store.items():
+                if stored_id.replace("-", "") == target:
+                    conv = candidate
+                    break
         if conv is None:
             # The real API returns 404 → httpx raises HTTPStatusError; we
             # raise a plain LookupError here so tests can distinguish a

--- a/tests/unit/sync/test_behavioral.py
+++ b/tests/unit/sync/test_behavioral.py
@@ -77,7 +77,6 @@ def test_initial_empty_sync_downloads_full_cloud_listing(
 # updated_since cutoff filters it out — that's the 1126-item gap that
 # motivated #111.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (cutoff filter loses backdated items)")
 def test_sync_resume_after_cursor_advance_recovers_backdated_items(
     sync_manager_factory, fake_cloud: FakeCloudClient
 ):
@@ -105,7 +104,6 @@ def test_sync_resume_after_cursor_advance_recovers_backdated_items(
 # EXISTING item is mutated server-side AND its updated_at is rewound. Today's
 # cutoff-only logic skips it; #111's set-diff catches the mismatch.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (no set-diff against listing)")
 def test_backdated_updated_at_on_existing_item_is_re_synced(
     sync_manager_factory, fake_cloud: FakeCloudClient
 ):
@@ -154,7 +152,6 @@ def test_item_disappearing_from_cloud_is_reported_as_removed(
 # ---------------------------------------------------------------------------
 # Scenario 5 — visibility flip (visible → hidden → visible) is reconciled (#111).
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (no visibility tracking)")
 def test_visibility_flip_is_reconciled_across_syncs(
     sync_manager_factory, fake_cloud: FakeCloudClient
 ):
@@ -248,7 +245,18 @@ def test_set_diff_against_cloud_listing_snapshot_categorizes_changes(
 # Simulates keyset drift: between pages, a new item is inserted that pushes
 # an existing item from page 1 down into page 2, causing it to appear twice.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (no listing dedup)")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "blocked by fake's naive offset-based pagination — keyset drift "
+        "permanently hides newcomer from a single sync. The production "
+        "cloud uses keyset pagination so this is a fake-only artifact; "
+        "the FakeCloudClient needs a keyset cursor (separate issue) "
+        "before this assertion can pass in one pass. #111 itself "
+        "delivers the gap-recovery: a second manager.sync() *does* "
+        "catch the missed item."
+    ),
+)
 def test_pagination_dedup_counts_same_id_once(
     sync_manager_factory, fake_cloud: FakeCloudClient
 ):
@@ -298,7 +306,17 @@ def test_pagination_dedup_counts_same_id_once(
 # both the newcomer AND the bottom-most original item; post-#111 the
 # set-diff catches them.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (no mid-listing reconciliation)")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "blocked by fake's naive offset-based pagination — newcomer "
+        "is invisible to a single sync because it never lands on a "
+        "page the engine fetches. #111's set-diff *does* recover this "
+        "on a subsequent sync (re-listing yields a stable set). "
+        "Single-sync recovery requires the fake to model keyset "
+        "pagination (separate issue)."
+    ),
+)
 def test_item_appearing_mid_listing_is_picked_up_on_next_sync(
     sync_manager_factory, fake_cloud: FakeCloudClient, conv_factory: ConvFactory
 ):
@@ -338,7 +356,6 @@ def test_item_appearing_mid_listing_is_picked_up_on_next_sync(
 # newly-discovered backfilled conversation — today the cutoff filter drops
 # the backfilled item, so the assertion `len(manifest) == 6` fails.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (cutoff loses backfilled items after crash)")
 def test_mid_sync_crash_then_next_run_resumes_without_losing_items(
     sync_manager_factory, fake_cloud: FakeCloudClient, conv_factory: ConvFactory
 ):
@@ -478,7 +495,6 @@ def test_manifest_as_canonical_metadata_source_survives_sync(
 # ---------------------------------------------------------------------------
 # Scenario 15 — Property: reconciliation is idempotent over arbitrary states (#111).
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (set-diff reconciliation)")
 @settings(
     max_examples=15,
     deadline=None,
@@ -486,22 +502,43 @@ def test_manifest_as_canonical_metadata_source_survives_sync(
 )
 @given(cloud_state=fake_listing_state(max_size=8))
 def test_reconciliation_is_idempotent_over_arbitrary_states(
-    sync_manager_factory, fake_cloud: FakeCloudClient, cloud_state
+    sync_manager_factory, fake_cloud: FakeCloudClient, cloud_state, tmp_path
 ):
+    # NB: pytest fixtures are shared across hypothesis examples
+    # (suppress_health_check ``function_scoped_fixture`` documents this).
+    # Reset both the in-memory and on-disk state at the start of each
+    # example so the property "manifest == cloud after sync" is
+    # testable against the CURRENT cloud_state rather than the
+    # cumulative one. Assertions are unchanged.
+    fake_cloud._store.clear()
+    fake_cloud._fail_downloads.clear()
+    fake_cloud._mutators_between_pages.clear()
+    fake_cloud.search_calls.clear()
+    fake_cloud.search_log.clear()
+    fake_cloud.download_calls.clear()
+    # Disk-side: nuke the manifest file and the index.db so the
+    # next SyncManager(...) starts from a clean slate.
+    (tmp_path / "sync_manifest.json").unlink(missing_ok=True)
+    (tmp_path / "index.db").unlink(missing_ok=True)
+    (tmp_path / "index.db-wal").unlink(missing_ok=True)
+    (tmp_path / "index.db-shm").unlink(missing_ok=True)
+
     # Visible-only items count — others get filtered out by both the fake
-    # and (post-#111) the production code.
-    visible_ids = {c.id for c in cloud_state if c.visible}
+    # and (post-#111) the production code. ids are NORMALIZED (dashes
+    # stripped) to match how the engine stores manifest keys
+    # post-#111 — see AGENTS.md item #14 on id-form normalization.
+    visible_ids = {c.id.replace("-", "") for c in cloud_state if c.visible}
     for c in cloud_state:
         fake_cloud.add(c)
 
     manager = sync_manager_factory(fake_cloud)
     manager.sync()
-    first_keys = set(manager.manifest.conversations.keys())
+    first_keys = {k.replace("-", "") for k in manager.manifest.conversations}
 
     # Second sync against the SAME cloud state must produce the SAME local
     # state (the property #111 is meant to guarantee).
     manager.sync()
-    second_keys = set(manager.manifest.conversations.keys())
+    second_keys = {k.replace("-", "") for k in manager.manifest.conversations}
 
     assert first_keys == second_keys == visible_ids
 
@@ -518,7 +555,6 @@ def test_reconciliation_is_idempotent_over_arbitrary_states(
 # queries with ``updated_since=None`` and the assertion holds — and the
 # idempotency property follows for free.
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, reason="blocked by #111 (cutoff still drives second sync)")
 @settings(
     max_examples=10,
     deadline=None,

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -16,6 +16,7 @@ from ohtv.sync import (
     SyncResult,
     _metadata_differs,
     _normalize_labels,
+    _passes_since_filter,
     _read_selected_branch,
 )
 # Issue #110: _RecordingCloudClient (formerly inline at line 890) and
@@ -2072,3 +2073,29 @@ class TestResetToNNewest:
         assert result.new == 0
         assert result.skipped_new == 0
 
+
+
+class TestPassesSinceFilterNaiveDatetime:
+    """Regression for T6 (PR #133): ``--since`` is wired through
+    ``click.DateTime()`` which yields offset-naive ``datetime`` values;
+    ``_parse_datetime`` returns UTC-aware values. The pre-fix code did
+    ``parsed >= since`` directly and raised
+    ``TypeError: can't compare offset-naive and offset-aware datetimes``.
+    """
+
+    @pytest.mark.parametrize(
+        "since_naive,expected",
+        [
+            # click.DateTime() returns naive datetimes. Past since -> kept.
+            (datetime(2024, 1, 1), True),
+            # Future since -> conv predates it, dropped.
+            (datetime(2099, 1, 1), False),
+        ],
+    )
+    def test_naive_since_compared_against_utc_aware_updated_at(
+        self, since_naive, expected
+    ):
+        assert since_naive.tzinfo is None
+        conv = {"updated_at": "2025-06-15T12:00:00Z"}
+        # Pre-fix: TypeError. Post-fix: ``expected`` boolean.
+        assert _passes_since_filter(conv, since_naive) is expected


### PR DESCRIPTION
Fixes #111.

This is the keystone of the sync rewrite. It replaces the pre-#111 cursor-based listing (`updated_since=last_sync_at`) with a **set-diff engine** that always lists the full cloud catalog and reconciles against the local manifest. The 1126-item gap that motivated the issue is now impossible.

## Architecture

Two phases per `ohtv sync`:

1. **Listing pass** — paginate the entire cloud listing into the `cloud_listing` snapshot table under a fresh `snapshot_id`. Pages commit incrementally so an interrupted sync can resume mid-listing without losing committed pages. On any failure the in-flight snapshot is abandoned (the previous one stays usable); on success the snapshot is atomically swapped via `commit_snapshot`.
2. **Set-diff dispatch** — categorize `cloud_listing` rows against the manifest:
   - **missing locally** → download as `"new"`
   - **stale locally**   → download as `"updated"` (`!=` not `>`, so a server-side rewind / backdated `updated_at` is also reconciled — Issue #111 scenario #3)
   - **removed from cloud** → silently dropped from the manifest, **logged as a WARN line per id** (#113 owns the user-facing report; #111 just keeps the manifest coherent so the idempotency property holds and the operator has a paper trail)

`last_sync_at` survives only as a UX field. The engine never consults it as a gate. It's also mirrored into `sync_kv` so #114 can drain the manifest without a flag-day.

## What landed

### New code

| File | Role |
|---|---|
| `src/ohtv/db/stores/cloud_listing_store.py` | Snapshot lifecycle (`start_snapshot` / `upsert_row` / `commit_snapshot` / `abandon_snapshot`) + set-diff helpers (`missing_locally` / `stale_locally` / `removed_from_cloud`) |
| `src/ohtv/db/stores/sync_state_store.py` | Thin k/v wrapper over `sync_kv` for snapshot bookkeeping |
| `ConversationStore.record_cloud_download` | Minimal upsert that **never** overwrites scanner-owned metadata (`title`, `event_count`, `labels`) but always updates `cloud_updated_at` |
| `SyncManager._run_set_diff_pass` | The engine: listing → snapshot bookkeeping → set-diff → reuse existing parallel/sequential download pipeline |

### Tests

- **25 new unit tests** across `tests/unit/db/stores/test_cloud_listing_store.py` and `tests/unit/db/stores/test_sync_state_store.py` covering snapshot lifecycle, set-diff helpers, id normalization (dashed ↔ undashed per AGENTS.md item #14), JSON column round-trip, and k/v bookkeeping.
- **Six behavioral xfail markers dropped** — all scenarios that the cursor-only sync could not satisfy now pass:
  - Sync resume after cursor advance
  - Backdated `updated_at` honored on next sync
  - Visibility flip reconciled
  - Mid-sync crash → resume without losing items
  - Same-listing idempotency
  - Reconciliation is idempotent over arbitrary states (Hypothesis property)
- **`TestScopeGuarantee` retired** — migration 018's schema is now legitimately consumed by #111. The class is left in place with a one-line marker test so the refactor is observable in git history.

## Review-cycle fixes on this branch

Three follow-up commits landed during review and are part of this squash:

- **`a4a5f92` — `fix(sync): json-encode pr_number list in cloud_listing`**
  Round-1 manual test T1 blocker. `pr_number` came off the cloud API as a list and SQLite rejected the bind in `upsert_row`. Now JSON-encoded on write and decoded on read; round-trip covered by an added store test.

- **`5184d1f` — `feat(sync): warn on cloud-side removals + document scalability boundary`**
  Round-1 review-r1 response. Removed-from-cloud ids now emit a per-id `WARN sync.removed_from_cloud id=<conv_id>` log line (still silently dropped from the manifest — #113 owns user-facing reporting). The syncing guide also picked up a "Scalability boundary" note explaining the full-listing cost model and when an operator would want to wait for #113.

- **`9f23eca` — `fix(sync): normalize offset-naive --since to UTC`**
  Round-2 manual test T6 blocker. `--since YYYY-MM-DD` produced a naive `datetime` that crashed comparison against the aware `cloud_updated_at`. Normalized at the top of `_passes_since_filter`. Added parametrized regression test `TestPassesSinceFilterNaiveDatetime::test_naive_since_compared_against_utc_aware_updated_at` (past-since kept, future-since dropped) — fails on `5184d1f`, passes here.

## Test results

```
1805 passed, 3 skipped, 4 xfailed
ruff check (touched files only): All checks passed
```

(+2 over the original 1801: T6 regression test, parametrized.)

## Manual verification

Round-2 re-test against the real cloud (T1–T8 + T6 fix) returned **APPROVE (LGTM)** at 2026-05-28T22:56:47Z. Steady-state sync, gap recovery, `--since` filter, manifest coherence, and docs accuracy all verified end-to-end.

## Remaining xfails (with reasons)

| Scenario | Reason |
|---|---|
| `test_item_disappearing_from_cloud_is_reported_as_removed` (#4) | Owned by **#113** (repair UX). Item IS removed from manifest by this PR; the count surface (`result.removed_from_cloud`) is what #113 adds. |
| `test_pagination_dedup_counts_same_id_once` (#8) | Blocked by **fake's naive offset pagination**. With keyset drift, the newcomer is permanently invisible to a single sync. A second sync DOES catch it. Follow-up issue needed to model keyset pagination in `FakeCloudClient`. |
| `test_item_appearing_mid_listing_is_picked_up_on_next_sync` (#9) | Same fake-only artifact as #8. |
| `test_timestamps_round_trip_with_microsecond_fidelity` (#12) | Owned by **#112**'s in-progress timestamp canonicalization. |

## AGENTS.md compliance

- **#27** (manifest as canonical metadata) — preserved. Manifest is the source-of-truth for the set-diff comparison; `conversations.cloud_updated_at` is opportunistically populated for #114 but is NOT consulted as the engine's primary store.
- **#11** (DB stage order) — untouched. Stages still run in `refs → actions → branch_context → push_pr_links` order.
- **#14** (id normalization) — respected. Stores normalize dashed ↔ undashed at the boundary; both forms resolve to the same row.

## Out of scope (deliberately)

- **#113** repair-fix UX — `removed_from_cloud` reporting + `--repair --fix` rebuild flow.
- **#114** manifest retirement — flipping `conversations` to be the engine's source-of-truth.
- **FakeCloudClient keyset pagination** — needed to lift scenarios #8/#9 to single-sync passing.

---

_This PR was authored by an AI agent (OpenHands) on behalf of @jpshackelford as part of the planned sync-rewrite arc (#110 harness → #112 schema → **#111 engine** → #113 repair → #114 retire manifest)._
