### PR TITLE
ci: auto-merge release-please PRs so each merge ships a release

### DIFF
--- a/.github/workflows/release-please-automerge.yml
+++ b/.github/workflows/release-please-automerge.yml
@@ -1,0 +1,31 @@
+name: auto-merge release-please PRs
+
+# When release-please opens (or updates) its release PR, immediately enable
+# auto-merge so the release fires without a manual click. The release PR exists
+# for seconds, not days. This preserves release-please's batching semantics
+# (multiple feature merges in quick succession produce one release, not many)
+# while removing the human gate that surprised us in the v0.14.0 cycle.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Match release-please's own PRs: opened by the GitHub Actions bot, head
+    # branch named release-please--*. Both conditions required so we never
+    # auto-merge an unrelated bot PR.
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --auto --squash --delete-branch


### PR DESCRIPTION
## Why

The original release intent was "every PR merge ships a release." release-please's design instead opens a *release PR* that batches commits until a human merges it — which is why [PR #139](https://github.com/jpshackelford/ohtv/pull/139) is currently sitting open instead of `v0.14.0` already being tagged.

Two ways to close that gap:
1. **Auto-merge release-please's release PRs** (this PR) — keeps release-please, just removes the manual click.
2. **Swap to a tool that tags directly on push** (e.g. `python-semantic-release`) — bigger change, throws away the existing config and changelog wiring.

This PR is option 1. It's ~30 lines and preserves all of the existing setup (`release-please-config.json`, `.release-please-manifest.json`, the `chore(worklog):` / `docs:` / `ci:` hidden-from-changelog scopes, etc).

## How it works

A new workflow `.github/workflows/release-please-automerge.yml` triggers on every `pull_request` event, filters to **only** PRs opened by `github-actions[bot]` from a `release-please--*` head branch, and runs:

```
gh pr merge "$PR_URL" --auto --squash --delete-branch
```

End-to-end flow after this merges:

```
feat: PR merges  →  release-please opens release PR  →  auto-merge fires
                                                            ↓
                                       squash + tag + GitHub Release + branch deleted
                                                            ↓
                                                    (≈30 seconds total)
```

**Batching is preserved.** If three feature PRs merge in five minutes, release-please updates a single release PR three times rather than opening three. Auto-merge attaches once and fires when the last update lands. One release covers all three commits — which is genuinely the right behavior when the orchestrator is dispatching merges back-to-back.

**Noise is minimal.** Release PRs exist for seconds, not days. `docs:` / `chore:` / `ci:` / `chore(worklog):` commits don't trigger a release PR at all (per the existing `changelog-sections` config), so there's no release PR for worklog entries or this very PR.

## Prerequisite (one-time repo setting)

`gh pr merge --auto` requires the repo's auto-merge feature to be enabled:

> Settings → General → Pull Requests → **Allow auto-merge** ✅

If that toggle is off, the workflow run will fail loudly (and the release PR will just sit there as it does today — no regression). Worth flipping it now if it isn't already.

## Handling the in-flight PR #139

PR #139 was opened before this workflow exists, so it won't auto-trigger. Two options once this PR merges:

- **Just merge #139 by hand** — one last manual click, then auto-merge takes over from here.
- **Or close-and-reopen #139** — the `reopened` event will fire the new workflow.

Either is fine. From the next release-please run onward (i.e. the next `feat:`/`fix:` merge after #139), the flow is fully automatic.

## Risk

Low. The `if:` guard requires both `user.login == 'github-actions[bot]'` AND `startsWith(head_ref, 'release-please--')`, so no unrelated bot PR (Dependabot, etc.) can trip it. Worst case if the filter misfires: a non-release PR gets `--auto` enabled, which still respects branch protection and required checks — it won't merge anything that wouldn't have been mergeable manually.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4cbf6cc-07da-4fd0-a273-d680769ae077)