### PR TITLE
fix(classify): label sub-conversations 'sub_agent' (#126)

### DIFF
--- a/docs/guides/classification.md
+++ b/docs/guides/classification.md
@@ -10,9 +10,13 @@ prerequisite for accurate human-vs-automation breakdowns in
 `ohtv report velocity` and other downstream metrics.
 
 The command has three behavior modes - single-conversation override, read-only
-discovery, and bulk heuristic with a `--confirm` safety gate. **Bulk
-operations only ever touch rows currently set to `unknown`**, so prior manual
-overrides are never clobbered by a re-run.
+discovery, and bulk heuristic with a `--confirm` safety gate. **The heuristic
+bulk operations only ever touch rows currently set to `unknown`**, so prior
+manual overrides are never clobbered by a re-run of `--no-followups` /
+`--has-followups`. (The automatic sub-conversation step described
+[below](#automatic-sub-conversation-classification) is the one exception — it
+runs on every invocation and *can* overwrite a sub previously set to
+`human`, by design.)
 
 ```bash
 # 1) Discovery - list conversations still classified as unknown.
@@ -60,6 +64,71 @@ against a conversation that does not yet have a row in
 run `ohtv db process human_input` first. Silent inserts would mask an
 unfinished ingestion pipeline and would distort downstream LOC + velocity
 metrics that assume the row reflects the actual events.
+
+## Automatic Sub-Conversation Classification
+
+A **sub-conversation** is a delegated agent run — a conversation spawned by
+another OpenHands conversation rather than initiated by a human. In the
+database, sub-conversations are exactly the rows where
+`conversations.parent_conversation_id IS NOT NULL` (populated by migration
+019 from the cloud listing API; see AGENTS.md item #31).
+
+Sub-conversations are **never human-initiated by definition** — the parent
+agent generates their initial prompt (the delegated task description), so
+the only correct value for `initial_prompt_source` on a sub is `automation`.
+To enforce this invariant, every `ohtv classify` invocation runs a single
+self-healing SQL `UPDATE` *before* dispatching to its mode-specific work
+(single override, `--list-unknown`, or bulk heuristic). The update flips
+every sub-conversation whose `initial_prompt_source` is not already
+`automation` (typically `unknown`, occasionally a stale `human` left over
+from a pre-fix `--has-followups --source human` bulk run) to `automation`.
+
+When the auto-step changes one or more rows, the CLI prints:
+
+```
+Auto-classified N sub-conversation(s) as 'automation'.
+```
+
+(Suppressed when `N = 0`, i.e. the steady-state case once your DB is
+consistent.)
+
+**Key properties:**
+
+- **Always-on.** Runs at the top of every `ohtv classify` invocation —
+  including `--list-unknown` and single-conversation overrides. No new
+  flag, no opt-out.
+- **Idempotent.** A second back-to-back invocation reports `N = 0` and
+  performs no writes (the `WHERE initial_prompt_source <> 'automation'`
+  guard makes the second pass a no-op).
+- **Roots are untouched.** The `WHERE EXISTS (... parent_conversation_id
+  IS NOT NULL ...)` predicate excludes root conversations entirely —
+  their classification is still owned by the heuristic / single-override
+  paths above.
+- **Subs without a `conversation_human_input` row are silently skipped.**
+  If the `human_input` stage has not processed a sub yet, the `EXISTS`
+  join has nothing to update. No error, no special-case branch.
+- **One overwrite case.** If you previously ran
+  `ohtv classify <sub_id> --source human` (or a pre-fix bulk heuristic)
+  and left a sub at `human`, the next `ohtv classify` invocation will
+  revert it to `automation`. This is the intended behavior of Issue
+  \#126: a sub marked `human` was always a misclassification, since the
+  initial prompt on a sub is the parent's delegated task, not a human
+  request.
+- **Within a single invocation, manual overrides still win.** The
+  auto-step runs first, then the mode-specific work. So
+  `ohtv classify <sub_id> --source human` will flip the sub back to
+  `human` *for that invocation* — but the next `classify` run will
+  correct it again. To make a sub stay `human` you would have to suppress
+  the auto-step entirely, which the CLI deliberately does not allow.
+
+**Schema guardrail.** The auto-step requires the
+`conversations.parent_conversation_id` column to exist. If it is missing
+(e.g. an older DB that has not been re-scanned since migration 019), the
+command prints an actionable error and exits non-zero:
+
+```
+Error: classify requires migration 019 (parent_conversation_id); run 'ohtv db scan' to apply pending migrations
+```
 
 ---
 

--- a/docs/guides/classification.md
+++ b/docs/guides/classification.md
@@ -73,20 +73,37 @@ database, sub-conversations are exactly the rows where
 `conversations.parent_conversation_id IS NOT NULL` (populated by migration
 019 from the cloud listing API; see AGENTS.md item #31).
 
-Sub-conversations are **never human-initiated by definition** — the parent
-agent generates their initial prompt (the delegated task description), so
-the only correct value for `initial_prompt_source` on a sub is `automation`.
-To enforce this invariant, every `ohtv classify` invocation runs a single
+A sub-conversation has **no trigger of its own**. It is a delegated
+continuation of its parent — the parent agent generated the sub's initial
+prompt (the delegated task description). To make this structurally
+distinct from the three operator-facing trigger types
+(`human` / `automation` / `unknown`), migration 022 widens the
+`conversation_human_input.initial_prompt_source` CHECK constraint to
+include a fourth value: **`sub_agent`**. This value is **system-managed**
+— it is not a valid choice for the `--source` flag, because operators
+have no need to pick "sub-agent" as a trigger; the row's
+`parent_conversation_id` is the ground truth.
+
+> **Why a dedicated value instead of reusing `automation`?** `automation`
+> already means "an automation run dispatched this conversation" (cron /
+> webhook). Conflating that with sub-agent delegation would silently
+> slurp every sub into the automation-run bucket of `report velocity` and
+> `report weekly-counts`. The parent's actual trigger type is always
+> recoverable by walking up `parent_conversation_id` to the root, so
+> giving subs their own label loses no information.
+
+To enforce the invariant, every `ohtv classify` invocation runs a single
 self-healing SQL `UPDATE` *before* dispatching to its mode-specific work
 (single override, `--list-unknown`, or bulk heuristic). The update flips
 every sub-conversation whose `initial_prompt_source` is not already
-`automation` (typically `unknown`, occasionally a stale `human` left over
-from a pre-fix `--has-followups --source human` bulk run) to `automation`.
+`sub_agent` (typically `unknown`, occasionally a stale `human` left over
+from a pre-fix `--has-followups --source human` bulk run, or a stale
+`automation` left over from an earlier draft of this fix) to `sub_agent`.
 
 When the auto-step changes one or more rows, the CLI prints:
 
 ```
-Auto-classified N sub-conversation(s) as 'automation'.
+Auto-classified N sub-conversation(s) as 'sub_agent'.
 ```
 
 (Suppressed when `N = 0`, i.e. the steady-state case once your DB is
@@ -98,7 +115,7 @@ consistent.)
   including `--list-unknown` and single-conversation overrides. No new
   flag, no opt-out.
 - **Idempotent.** A second back-to-back invocation reports `N = 0` and
-  performs no writes (the `WHERE initial_prompt_source <> 'automation'`
+  performs no writes (the `WHERE initial_prompt_source <> 'sub_agent'`
   guard makes the second pass a no-op).
 - **Roots are untouched.** The `WHERE EXISTS (... parent_conversation_id
   IS NOT NULL ...)` predicate excludes root conversations entirely —
@@ -107,19 +124,22 @@ consistent.)
 - **Subs without a `conversation_human_input` row are silently skipped.**
   If the `human_input` stage has not processed a sub yet, the `EXISTS`
   join has nothing to update. No error, no special-case branch.
-- **One overwrite case.** If you previously ran
+- **Overwrite cases.** If you previously ran
   `ohtv classify <sub_id> --source human` (or a pre-fix bulk heuristic)
-  and left a sub at `human`, the next `ohtv classify` invocation will
-  revert it to `automation`. This is the intended behavior of Issue
-  \#126: a sub marked `human` was always a misclassification, since the
-  initial prompt on a sub is the parent's delegated task, not a human
-  request.
+  and left a sub at `human`, or you have residual `automation` rows from
+  an earlier draft of this fix, the next `ohtv classify` invocation will
+  revert them all to `sub_agent`. This is the intended behavior of Issue
+  \#126: any non-`sub_agent` value on a sub was always a misclassification.
 - **Within a single invocation, manual overrides still win.** The
   auto-step runs first, then the mode-specific work. So
   `ohtv classify <sub_id> --source human` will flip the sub back to
   `human` *for that invocation* — but the next `classify` run will
   correct it again. To make a sub stay `human` you would have to suppress
   the auto-step entirely, which the CLI deliberately does not allow.
+- **Reports treat `sub_agent` as 0 contribution.** `report velocity`
+  contributes `0` words and `0` messages for `sub_agent` rows — subs are
+  extensions of the parent and counting them independently would
+  double-count work that is already rolled up into the parent's totals.
 
 **Schema guardrail.** The auto-step requires the
 `conversations.parent_conversation_id` column to exist. If it is missing

--- a/src/ohtv/classify.py
+++ b/src/ohtv/classify.py
@@ -334,6 +334,71 @@ def count_matching(
     return int(cur.fetchone()[0])
 
 
+def _assert_parent_column_present(conn: sqlite3.Connection) -> None:
+    """Guardrail: verify migration 019 (``parent_conversation_id``) has run.
+
+    Mirrors the #123 / #124 / #125 pattern. Raised at runtime (not
+    import time) so the CLI can format a friendly error and exit before
+    any classification work happens.
+
+    The issue body (#126) refers to this as "migration 018" because the
+    parent column was committed to ``018_parent_conversation_id.py``
+    pre-merge; it was renumbered to ``019_parent_conversation_id.py``
+    when the set-diff-sync schema landed first. The check is on the
+    column name, not the migration filename, so the error message
+    points users at the actual repair path (``ohtv db scan`` reapplies
+    pending migrations regardless of number).
+    """
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(conversations)")}
+    if "parent_conversation_id" not in cols:
+        raise RuntimeError(
+            "classify requires migration 019 (parent_conversation_id); "
+            "run 'ohtv db scan' to apply pending migrations"
+        )
+
+
+def apply_sub_classification(conn: sqlite3.Connection) -> int:
+    """Set ``initial_prompt_source='automation'`` on every sub-conversation.
+
+    A "sub-conversation" is one whose ``conversations.parent_conversation_id``
+    is non-NULL (populated by migration 019, originally proposed as 018
+    in #108). This is the one deterministic label in the system: a sub
+    is by construction initiated by the parent agent, not a human.
+
+    Unlike :func:`apply_classification` (#83), this CAN overwrite rows
+    whose current value is ``'human'`` or ``'unknown'`` — those values
+    are wrong for subs and the helper is idempotent in either direction.
+    Returns the number of rows actually changed (``0`` on a second
+    identical run by construction).
+
+    Issue #126. Self-healing: every ``ohtv classify`` invocation runs
+    this before its mode-specific work, so any residual mis-classification
+    (e.g. from a pre-fix ``--has-followups --source human`` bulk run that
+    flipped subs to ``'human'`` because subs frequently have follow-ups
+    from the orchestrating agent) is corrected automatically. No new flag
+    is added.
+
+    The ``UPDATE ... WHERE EXISTS (...)`` form silently skips subs that
+    have no ``conversation_human_input`` row yet (the ``human_input``
+    stage hasn't processed them) — there's nothing to update. No
+    exception, no special-case branch.
+    """
+    cur = conn.execute(
+        """
+        UPDATE conversation_human_input AS chi
+        SET initial_prompt_source = 'automation'
+        WHERE chi.initial_prompt_source <> 'automation'
+          AND EXISTS (
+              SELECT 1 FROM conversations c
+              WHERE c.id = chi.conversation_id
+                AND c.parent_conversation_id IS NOT NULL
+          )
+        """
+    )
+    conn.commit()
+    return cur.rowcount or 0
+
+
 def apply_classification(
     conn: sqlite3.Connection,
     *,
@@ -514,7 +579,9 @@ __all__ = [
     "Source",
     "UnknownRow",
     "VALID_SOURCES",
+    "_assert_parent_column_present",
     "apply_classification",
+    "apply_sub_classification",
     "count_matching",
     "list_unknown",
     "set_single",

--- a/src/ohtv/classify.py
+++ b/src/ohtv/classify.py
@@ -1,8 +1,18 @@
 """Conversation classification helpers.
 
 Populates ``conversation_human_input.initial_prompt_source`` (created by
-migration 016, defaulted to ``'unknown'``) with one of
-``'human' | 'automation' | 'unknown'``.
+migration 016, widened by migration 022 — see issue #126) with one of
+``'human' | 'automation' | 'unknown' | 'sub_agent'``.
+
+Of those four values, the first three (``'human'`` / ``'automation'`` /
+``'unknown'``) are the operator-facing *trigger* answers exposed via the
+CLI ``--source`` flag. The fourth, ``'sub_agent'``, is a
+**system-managed** label that ``classify`` writes automatically for every
+sub-conversation — see :func:`apply_sub_classification`. It is not a
+valid value for ``--source`` because a sub-conversation has no trigger of
+its own (it is an extension of its parent, not an independently
+triggered run). The parent's actual trigger type is always recoverable
+by walking up ``conversations.parent_conversation_id`` to the root.
 
 This is the pure data-layer module backing ``ohtv classify``. It has no
 Click / Rich dependencies so it can be unit-tested directly against an
@@ -38,13 +48,20 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Literal
 
-# Allowed values for ``initial_prompt_source``. Mirrors the
-# ``CHECK(initial_prompt_source IN (...))`` constraint in migration 016
-# so callers can ``from ohtv.classify import VALID_SOURCES`` and feed it
-# straight into ``click.Choice``.
+# Operator-facing values for ``--source``. Intentionally **excludes**
+# ``'sub_agent'``: that label is system-managed (see
+# :func:`apply_sub_classification`) and is not selectable by the
+# operator. Callers can ``from ohtv.classify import VALID_SOURCES`` and
+# feed it straight into ``click.Choice``.
 VALID_SOURCES: tuple[str, ...] = ("human", "automation", "unknown")
 
 Source = Literal["human", "automation", "unknown"]
+
+# System-managed value for sub-conversations (issue #126). Authorized
+# by the widened CHECK constraint in migration 022. Lives outside
+# :data:`VALID_SOURCES` on purpose: ``set_single`` and the heuristic
+# bulk path must never accept ``'sub_agent'`` as a user choice.
+SUB_AGENT_SOURCE = "sub_agent"
 
 # Heuristic filter names. Kept as string constants (not an enum) for
 # easy use as Click ``flag_value`` and clean error messages.
@@ -358,25 +375,36 @@ def _assert_parent_column_present(conn: sqlite3.Connection) -> None:
 
 
 def apply_sub_classification(conn: sqlite3.Connection) -> int:
-    """Set ``initial_prompt_source='automation'`` on every sub-conversation.
+    """Set ``initial_prompt_source='sub_agent'`` on every sub-conversation.
 
     A "sub-conversation" is one whose ``conversations.parent_conversation_id``
     is non-NULL (populated by migration 019, originally proposed as 018
-    in #108). This is the one deterministic label in the system: a sub
-    is by construction initiated by the parent agent, not a human.
+    in #108).
+
+    Why a dedicated ``'sub_agent'`` value rather than reusing
+    ``'automation'``: a sub-conversation has no trigger of its own — it
+    is a delegated continuation of its parent. ``'automation'`` already
+    means something specific (an automation run dispatched the
+    conversation, cron / webhook), and conflating those two would
+    silently slurp every sub-agent delegation into the automation-run
+    bucket of ``report velocity`` / ``report weekly-counts``. The
+    parent's actual trigger type is always recoverable by walking up
+    ``parent_conversation_id``, so nothing is lost by giving subs their
+    own label. (The widened CHECK constraint lives in migration 022;
+    see issue #126 PR discussion for the design rationale.)
 
     Unlike :func:`apply_classification` (#83), this CAN overwrite rows
-    whose current value is ``'human'`` or ``'unknown'`` — those values
-    are wrong for subs and the helper is idempotent in either direction.
-    Returns the number of rows actually changed (``0`` on a second
-    identical run by construction).
+    whose current value is ``'human'``, ``'automation'``, or
+    ``'unknown'`` — those values are wrong for subs and the helper is
+    idempotent in either direction. Returns the number of rows actually
+    changed (``0`` on a second identical run by construction).
 
-    Issue #126. Self-healing: every ``ohtv classify`` invocation runs
-    this before its mode-specific work, so any residual mis-classification
-    (e.g. from a pre-fix ``--has-followups --source human`` bulk run that
+    Self-healing: every ``ohtv classify`` invocation runs this before
+    its mode-specific work, so any residual mis-classification (e.g.
+    from a pre-fix ``--has-followups --source human`` bulk run that
     flipped subs to ``'human'`` because subs frequently have follow-ups
-    from the orchestrating agent) is corrected automatically. No new flag
-    is added.
+    from the orchestrating agent) is corrected automatically. No new
+    flag is added.
 
     The ``UPDATE ... WHERE EXISTS (...)`` form silently skips subs that
     have no ``conversation_human_input`` row yet (the ``human_input``
@@ -386,8 +414,8 @@ def apply_sub_classification(conn: sqlite3.Connection) -> int:
     cur = conn.execute(
         """
         UPDATE conversation_human_input AS chi
-        SET initial_prompt_source = 'automation'
-        WHERE chi.initial_prompt_source <> 'automation'
+        SET initial_prompt_source = 'sub_agent'
+        WHERE chi.initial_prompt_source <> 'sub_agent'
           AND EXISTS (
               SELECT 1 FROM conversations c
               WHERE c.id = chi.conversation_id
@@ -576,6 +604,7 @@ __all__ = [
     "InvalidSourceError",
     "MissingHumanInputRowError",
     "SingleResult",
+    "SUB_AGENT_SOURCE",
     "Source",
     "UnknownRow",
     "VALID_SOURCES",

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10479,10 +10479,13 @@ def classify(
         raise SystemExit(1)
 
     # Self-healing (issue #126): sub-conversations are deterministically
-    # 'automation' (the parent agent's delegated task description, not a
-    # human request). Run this on every invocation so any residual
-    # 'human' / 'unknown' on subs — including the residue of a pre-fix
-    # ``--has-followups --source human`` bulk run — is corrected
+    # labelled 'sub_agent' (the system-managed value introduced by
+    # migration 022). A sub has no trigger of its own — it is a
+    # delegated continuation of its parent — so it must never collide
+    # with the three operator-facing trigger types ('human',
+    # 'automation', 'unknown'). Run this on every invocation so any
+    # residual mis-classification on subs (including the residue of a
+    # pre-fix ``--has-followups --source human`` bulk run) is corrected
     # automatically. No new flag, no LLM, single SQL UPDATE.
     try:
         with get_connection() as conn:
@@ -10494,7 +10497,7 @@ def classify(
     if sub_changed:
         console.print(
             f"[dim]Auto-classified {sub_changed} sub-conversation(s) "
-            "as 'automation'.[/dim]"
+            "as 'sub_agent'.[/dim]"
         )
 
     if conversation_id:

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -10478,6 +10478,25 @@ def classify(
         )
         raise SystemExit(1)
 
+    # Self-healing (issue #126): sub-conversations are deterministically
+    # 'automation' (the parent agent's delegated task description, not a
+    # human request). Run this on every invocation so any residual
+    # 'human' / 'unknown' on subs — including the residue of a pre-fix
+    # ``--has-followups --source human`` bulk run — is corrected
+    # automatically. No new flag, no LLM, single SQL UPDATE.
+    try:
+        with get_connection() as conn:
+            classify_mod._assert_parent_column_present(conn)
+            sub_changed = classify_mod.apply_sub_classification(conn)
+    except RuntimeError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+    if sub_changed:
+        console.print(
+            f"[dim]Auto-classified {sub_changed} sub-conversation(s) "
+            "as 'automation'.[/dim]"
+        )
+
     if conversation_id:
         _classify_single(classify_mod, get_connection, conversation_id, source)
         return

--- a/src/ohtv/db/migrations/022_classify_sub_agent.py
+++ b/src/ohtv/db/migrations/022_classify_sub_agent.py
@@ -1,0 +1,101 @@
+"""Widen ``conversation_human_input.initial_prompt_source`` CHECK constraint.
+
+Issue #126. ``classify`` needs to mark sub-conversations (rows whose
+``conversations.parent_conversation_id`` is non-NULL) with a value that
+is distinct from the three operator-facing trigger types
+(``'human'`` / ``'automation'`` / ``'unknown'``). The original PR
+(#146 initial draft) proposed reusing ``'automation'``, but
+``'automation'`` is a real trigger type meaning "an automation run
+(cron / webhook) dispatched a conversation" — conflating it with
+"a parent agent delegated to a sub-agent" breaks every downstream
+report that wants to count automation-triggered work separately from
+sub-agent delegations.
+
+This migration adds ``'sub_agent'`` as the fourth allowed value. The
+parent agent's trigger type is recoverable at any time by walking up
+``parent_conversation_id`` to the root, so nothing is lost by giving
+subs their own label.
+
+SQLite does not support ``ALTER TABLE ... DROP CHECK``, so we follow
+the canonical 12-step ALTER pattern (see migration 017 for the
+precedent on ``change_refs.status``):
+
+1. Disable FK enforcement (``PRAGMA foreign_keys = OFF``).
+2. Create a *new* table with the wider CHECK.
+3. Copy data, preserving primary keys.
+4. Drop the original and rename the replacement into place.
+5. Recreate the original index.
+6. Re-enable FK enforcement.
+
+Row IDs (the ``conversation_id`` text PK) are preserved verbatim so
+any existing FK references from ``conversations`` resolve correctly
+after the swap.
+
+This migration is purely additive at the value level — every row in
+the table keeps its existing value. The widening only authorizes
+future ``classify`` runs to write ``'sub_agent'``; nothing about
+existing rows changes.
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Recreate ``conversation_human_input`` with a widened CHECK constraint."""
+
+    fk_enabled = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    conn.execute("PRAGMA foreign_keys = OFF")
+
+    try:
+        # 1. Create the replacement table under a temporary name.
+        #    Same shape as migration 016, plus ``'sub_agent'`` in the CHECK.
+        conn.execute("""
+            CREATE TABLE conversation_human_input_new (
+                conversation_id TEXT PRIMARY KEY,
+                initial_prompt_words INTEGER NOT NULL DEFAULT 0,
+                initial_prompt_source TEXT NOT NULL DEFAULT 'unknown'
+                    CHECK(initial_prompt_source IN
+                          ('human', 'automation', 'unknown', 'sub_agent')),
+                followup_word_count INTEGER NOT NULL DEFAULT 0,
+                followup_message_count INTEGER NOT NULL DEFAULT 0,
+                processed_at TEXT NOT NULL,
+                event_count INTEGER NOT NULL,
+                FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+                    ON DELETE CASCADE
+            )
+        """)
+
+        # 2. Copy data verbatim. No value migration: existing rows keep
+        #    whatever they had. The classify auto-step (see
+        #    ``apply_sub_classification`` in src/ohtv/classify.py) will
+        #    re-label any pre-existing sub rows on the next invocation.
+        conn.execute("""
+            INSERT INTO conversation_human_input_new
+                (conversation_id, initial_prompt_words, initial_prompt_source,
+                 followup_word_count, followup_message_count,
+                 processed_at, event_count)
+            SELECT
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count,
+                processed_at, event_count
+            FROM conversation_human_input
+        """)
+
+        # 3. Drop the original (which also drops attached indexes).
+        conn.execute("DROP TABLE conversation_human_input")
+
+        # 4. Rename the replacement into place. No other table references
+        #    ``conversation_human_input_new``, so no FKs are perturbed.
+        conn.execute(
+            "ALTER TABLE conversation_human_input_new "
+            "RENAME TO conversation_human_input"
+        )
+
+        # 5. Recreate the original index from migration 016.
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_human_input_source "
+            "ON conversation_human_input(initial_prompt_source)"
+        )
+    finally:
+        if fk_enabled:
+            conn.execute("PRAGMA foreign_keys = ON")

--- a/src/ohtv/reports/velocity.py
+++ b/src/ohtv/reports/velocity.py
@@ -30,6 +30,13 @@ Design notes:
                      msgs  = ``followup_message_count``
   - ``'unknown'``   → treated as ``'human'`` (optimistic default;
                      see issue #83 for proper classification)
+  - ``'sub_agent'`` → contributes ``0`` words and ``0`` messages
+                     (issue #126). A sub-conversation is a delegated
+                     continuation of its parent — its words are already
+                     accounted for in the parent's roll-up, so counting
+                     them again would double-count. The parent's actual
+                     trigger type is recoverable by walking up
+                     ``parent_conversation_id``.
 
 * LOC NULL handling per bucket:
 
@@ -74,6 +81,7 @@ SELECT
             WHEN 'human'      THEN chi.initial_prompt_words + chi.followup_word_count
             WHEN 'automation' THEN chi.followup_word_count
             WHEN 'unknown'    THEN chi.initial_prompt_words + chi.followup_word_count
+            WHEN 'sub_agent'  THEN 0  -- issue #126: subs are extensions of the parent
             ELSE 0
         END
     ), 0) AS human_words,
@@ -82,6 +90,7 @@ SELECT
             WHEN 'human'      THEN 1 + chi.followup_message_count
             WHEN 'automation' THEN chi.followup_message_count
             WHEN 'unknown'    THEN 1 + chi.followup_message_count
+            WHEN 'sub_agent'  THEN 0  -- issue #126: subs are extensions of the parent
             ELSE 0
         END
     ), 0) AS human_messages

--- a/tests/unit/reports/test_velocity.py
+++ b/tests/unit/reports/test_velocity.py
@@ -283,6 +283,36 @@ def test_initial_prompt_source_unknown_counts_as_human(conn: sqlite3.Connection)
     assert report.rows[0].human_messages == 3  # 1 + 2
 
 
+def test_initial_prompt_source_sub_agent_contributes_zero(
+    conn: sqlite3.Connection,
+) -> None:
+    """Issue #126: ``'sub_agent'`` rows contribute 0 words and 0 messages.
+
+    A sub-conversation is an extension of its parent, not an independent
+    triggered run. Counting its words against the change_ref the parent
+    contributed to would double-count work that is already rolled up in
+    the parent's totals. The velocity CASE statement maps ``'sub_agent'``
+    explicitly to ``0`` (rather than relying on the ``ELSE 0`` fallback)
+    so the intent is visible in the SQL.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "c1")
+    seed_human_input(
+        conn,
+        conversation_id="c1",
+        initial_prompt_words=500,       # ignored
+        initial_prompt_source="sub_agent",
+        followup_word_count=200,        # ignored
+        followup_message_count=10,      # ignored
+    )
+    pr_id = seed_pr(conn, repo_id=repo_id, pr_number=1, merged_at="2024-03-05T12:00:00Z")
+    seed_contribution(conn, conversation_id="c1", change_ref_id=pr_id)
+
+    report = aggregate_velocity(conn=conn)
+    assert report.rows[0].human_words == 0
+    assert report.rows[0].human_messages == 0
+
+
 def test_words_per_loc_zero_denominator(conn: sqlite3.Connection) -> None:
     """All LOC NULL → words_per_loc is None (no divide-by-zero crash)."""
     repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -41,7 +41,9 @@ from ohtv.classify import (
     InvalidSourceError,
     MissingHumanInputRowError,
     NoSuchConversationError,
+    _assert_parent_column_present,
     apply_classification,
+    apply_sub_classification,
     count_matching,
     list_unknown,
     set_single,
@@ -77,14 +79,20 @@ def _insert_conversation(
     created_at: str | None = None,
     location: str = "/tmp/fake",
     event_count: int = 1,
+    parent_conversation_id: str | None = None,
 ) -> None:
-    """Insert a row into ``conversations``. ID is stored normalised."""
+    """Insert a row into ``conversations``. ID is stored normalised.
+
+    ``parent_conversation_id`` is optional (issue #126); pass a non-NULL
+    value to mark the row as a sub-conversation.
+    """
     if created_at is None:
         created_at = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc).isoformat()
     conn.execute(
-        "INSERT INTO conversations (id, location, event_count, title, created_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (conv_id, location, event_count, title, created_at),
+        "INSERT INTO conversations "
+        "(id, location, event_count, title, created_at, parent_conversation_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (conv_id, location, event_count, title, created_at, parent_conversation_id),
     )
 
 
@@ -602,3 +610,186 @@ class TestListUnknown:
         _insert_conversation(conn, cid)
         _insert_human_input(conn, cid, initial_prompt_source="automation")
         assert list_unknown(conn) == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #126 — sub-conversation auto-classification
+# ---------------------------------------------------------------------------
+
+
+def _seed_root_and_sub(
+    conn: sqlite3.Connection,
+    *,
+    root_source: str = "unknown",
+    sub_source: str = "unknown",
+) -> tuple[str, str]:
+    """Seed one root + one sub. Returns ``(root_id, sub_id)`` (normalised)."""
+    root_id = "root1" + "0".zfill(27)
+    sub_id = "sub01" + "0".zfill(27)
+    _insert_conversation(conn, root_id, title="root")
+    _insert_conversation(
+        conn, sub_id, title="sub", parent_conversation_id=root_id
+    )
+    _insert_human_input(conn, root_id, initial_prompt_source=root_source)
+    _insert_human_input(conn, sub_id, initial_prompt_source=sub_source)
+    return root_id, sub_id
+
+
+def _read_source(conn: sqlite3.Connection, cid: str) -> str | None:
+    row = conn.execute(
+        "SELECT initial_prompt_source FROM conversation_human_input "
+        "WHERE conversation_id = ?",
+        (cid,),
+    ).fetchone()
+    return row["initial_prompt_source"] if row else None
+
+
+class TestApplySubClassification:
+    """Issue #126 — :func:`apply_sub_classification`.
+
+    Test plan mapping (numbering matches the issue body):
+
+    * T-A — sub gets auto-classified from ``unknown`` (AC3).
+    * T-B — sub residual ``human`` is corrected (AC4).
+    * T-C — already-correct sub is a no-op (idempotency).
+    * T-D — sub without a ``conversation_human_input`` row no-ops without
+      raising (AC2 robustness).
+    * T-E — manual override (``set_single``) wins within one invocation
+      (AC5; documents the operator-agency vs deterministic-ground-truth
+      tension).
+    """
+
+    def test_t_a_sub_auto_classified_from_unknown(self, conn):
+        """T-A: sub 'unknown' -> 'automation'; root untouched; returns 1."""
+        root_id, sub_id = _seed_root_and_sub(conn)
+
+        changed = apply_sub_classification(conn)
+
+        assert changed == 1
+        assert _read_source(conn, sub_id) == "automation"
+        # Root is NOT a sub (parent_conversation_id IS NULL) so it must
+        # stay 'unknown' — the auto-step refuses to touch roots even by
+        # accident.
+        assert _read_source(conn, root_id) == "unknown"
+
+    def test_t_b_sub_residual_human_corrected(self, conn):
+        """T-B: residual 'human' on a sub flips to 'automation'.
+
+        Models the post-bug state after a pre-fix
+        ``--has-followups --source human`` bulk run mis-classified subs.
+        """
+        _, sub_id = _seed_root_and_sub(conn, sub_source="human")
+
+        changed = apply_sub_classification(conn)
+
+        assert changed == 1
+        assert _read_source(conn, sub_id) == "automation"
+
+    def test_t_c_already_correct_sub_is_noop(self, conn):
+        """T-C: idempotency — second invocation returns 0."""
+        _seed_root_and_sub(conn)
+
+        first = apply_sub_classification(conn)
+        second = apply_sub_classification(conn)
+
+        assert first == 1
+        assert second == 0
+
+    def test_t_d_sub_without_human_input_row_silently_skipped(self, conn):
+        """T-D: sub with no ``conversation_human_input`` row no-ops.
+
+        The ``human_input`` stage hasn't processed the sub yet. The
+        helper's ``UPDATE ... WHERE EXISTS (...)`` form has nothing to
+        update — return 0, no exception, no special-case branch.
+        """
+        root_id = "rootB" + "0".zfill(27)
+        sub_id = "subB1" + "0".zfill(27)
+        _insert_conversation(conn, root_id, title="root no-hi")
+        _insert_conversation(
+            conn, sub_id, title="sub no-hi", parent_conversation_id=root_id
+        )
+        # NOTE: NO _insert_human_input for either row.
+
+        changed = apply_sub_classification(conn)
+
+        assert changed == 0
+
+    def test_t_e_manual_override_wins_within_invocation(self, conn):
+        """T-E: ``set_single`` after the auto-step flips back to 'human'.
+
+        Documents AC5: within one ``ohtv classify`` invocation the
+        operator override is the terminal write. On the NEXT invocation
+        the auto-step would correct it back to 'automation' — that's
+        the desired deterministic-ground-truth behavior.
+        """
+        _, sub_id = _seed_root_and_sub(conn)
+
+        # Step 1: auto-step runs first (this is what the CLI command
+        # body does at the top of `classify`).
+        assert apply_sub_classification(conn) == 1
+        assert _read_source(conn, sub_id) == "automation"
+
+        # Step 2: operator passes `ohtv classify <sub_id> --source human`.
+        # `set_single` flips already-classified rows by design.
+        result = set_single(conn, conversation_id=sub_id, source="human")
+
+        assert result.changed is True
+        assert result.previous_source == "automation"
+        assert result.new_source == "human"
+        assert _read_source(conn, sub_id) == "human"
+
+    def test_followup_counts_untouched(self, conn):
+        """AC6: auto-step only writes ``initial_prompt_source``.
+
+        ``followup_word_count`` and ``followup_message_count`` are
+        written by the ``human_input`` stage from event data and must
+        survive the auto-step unchanged.
+        """
+        root_id = "rootC" + "0".zfill(27)
+        sub_id = "subC1" + "0".zfill(27)
+        _insert_conversation(conn, root_id, title="root")
+        _insert_conversation(
+            conn, sub_id, title="sub", parent_conversation_id=root_id
+        )
+        _insert_human_input(
+            conn,
+            sub_id,
+            followup_word_count=42,
+            followup_message_count=7,
+        )
+
+        apply_sub_classification(conn)
+
+        row = conn.execute(
+            "SELECT followup_word_count, followup_message_count "
+            "FROM conversation_human_input WHERE conversation_id = ?",
+            (sub_id,),
+        ).fetchone()
+        assert row["followup_word_count"] == 42
+        assert row["followup_message_count"] == 7
+
+
+class TestAssertParentColumnPresent:
+    """AC7 — guardrail when migration 019 hasn't run."""
+
+    def test_passes_on_migrated_schema(self, conn):
+        """No exception on the current migration chain (column present)."""
+        _assert_parent_column_present(conn)  # does not raise
+
+    def test_raises_when_column_missing(self):
+        """Drop the column and confirm the guardrail fires.
+
+        Using a fresh in-memory DB and a minimal `conversations` table
+        without the column models the pre-migration-019 state. This is
+        cheaper and more robust than partial-replaying the migration
+        chain.
+        """
+        c = sqlite3.connect(":memory:")
+        c.row_factory = sqlite3.Row
+        c.execute(
+            "CREATE TABLE conversations (id TEXT PRIMARY KEY, title TEXT)"
+        )
+
+        with pytest.raises(RuntimeError, match="migration 019"):
+            _assert_parent_column_present(c)
+        c.close()

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -647,33 +647,36 @@ def _read_source(conn: sqlite3.Connection, cid: str) -> str | None:
 class TestApplySubClassification:
     """Issue #126 — :func:`apply_sub_classification`.
 
-    Test plan mapping (numbering matches the issue body):
+    Test plan (the auto-step writes the system-managed ``'sub_agent'``
+    value introduced by migration 022; see the PR discussion on #146 for
+    why ``'sub_agent'`` is distinct from ``'automation'``):
 
-    * T-A — sub gets auto-classified from ``unknown`` (AC3).
-    * T-B — sub residual ``human`` is corrected (AC4).
+    * T-A — sub gets auto-classified from ``unknown``.
+    * T-B — sub residual ``human`` (from a pre-fix bulk run) is corrected.
+    * T-B2 — sub residual ``automation`` (from an earlier draft of this
+      fix that reused the automation label) is corrected.
     * T-C — already-correct sub is a no-op (idempotency).
     * T-D — sub without a ``conversation_human_input`` row no-ops without
-      raising (AC2 robustness).
+      raising.
     * T-E — manual override (``set_single``) wins within one invocation
-      (AC5; documents the operator-agency vs deterministic-ground-truth
-      tension).
+      (operator-agency vs deterministic-ground-truth tension).
     """
 
     def test_t_a_sub_auto_classified_from_unknown(self, conn):
-        """T-A: sub 'unknown' -> 'automation'; root untouched; returns 1."""
+        """T-A: sub 'unknown' -> 'sub_agent'; root untouched; returns 1."""
         root_id, sub_id = _seed_root_and_sub(conn)
 
         changed = apply_sub_classification(conn)
 
         assert changed == 1
-        assert _read_source(conn, sub_id) == "automation"
+        assert _read_source(conn, sub_id) == "sub_agent"
         # Root is NOT a sub (parent_conversation_id IS NULL) so it must
         # stay 'unknown' — the auto-step refuses to touch roots even by
         # accident.
         assert _read_source(conn, root_id) == "unknown"
 
     def test_t_b_sub_residual_human_corrected(self, conn):
-        """T-B: residual 'human' on a sub flips to 'automation'.
+        """T-B: residual 'human' on a sub flips to 'sub_agent'.
 
         Models the post-bug state after a pre-fix
         ``--has-followups --source human`` bulk run mis-classified subs.
@@ -683,7 +686,23 @@ class TestApplySubClassification:
         changed = apply_sub_classification(conn)
 
         assert changed == 1
-        assert _read_source(conn, sub_id) == "automation"
+        assert _read_source(conn, sub_id) == "sub_agent"
+
+    def test_t_b2_sub_residual_automation_corrected(self, conn):
+        """T-B2: residual 'automation' on a sub flips to 'sub_agent'.
+
+        Models the post-bug state of any DB that ran an earlier draft of
+        issue #126 (which set subs to ``'automation'``) before the
+        switch to a dedicated ``'sub_agent'`` value. The auto-step must
+        repair these silently — operators do not need to re-classify
+        manually.
+        """
+        _, sub_id = _seed_root_and_sub(conn, sub_source="automation")
+
+        changed = apply_sub_classification(conn)
+
+        assert changed == 1
+        assert _read_source(conn, sub_id) == "sub_agent"
 
     def test_t_c_already_correct_sub_is_noop(self, conn):
         """T-C: idempotency — second invocation returns 0."""
@@ -719,7 +738,7 @@ class TestApplySubClassification:
 
         Documents AC5: within one ``ohtv classify`` invocation the
         operator override is the terminal write. On the NEXT invocation
-        the auto-step would correct it back to 'automation' — that's
+        the auto-step would correct it back to ``'sub_agent'`` — that's
         the desired deterministic-ground-truth behavior.
         """
         _, sub_id = _seed_root_and_sub(conn)
@@ -727,14 +746,14 @@ class TestApplySubClassification:
         # Step 1: auto-step runs first (this is what the CLI command
         # body does at the top of `classify`).
         assert apply_sub_classification(conn) == 1
-        assert _read_source(conn, sub_id) == "automation"
+        assert _read_source(conn, sub_id) == "sub_agent"
 
         # Step 2: operator passes `ohtv classify <sub_id> --source human`.
         # `set_single` flips already-classified rows by design.
         result = set_single(conn, conversation_id=sub_id, source="human")
 
         assert result.changed is True
-        assert result.previous_source == "automation"
+        assert result.previous_source == "sub_agent"
         assert result.new_source == "human"
         assert _read_source(conn, sub_id) == "human"
 

--- a/tests/unit/test_cli_classify.py
+++ b/tests/unit/test_cli_classify.py
@@ -110,6 +110,46 @@ def _read_source(db_path: Path, cid: str) -> str | None:
     return row["initial_prompt_source"] if row else None
 
 
+def _seed_root_and_sub(db_path: Path) -> tuple[str, str]:
+    """Seed 1 root + 1 sub-conversation, both ``initial_prompt_source='unknown'``.
+
+    Used by the issue #126 auto-classification smoke tests. Returns
+    ``(root_id, sub_id)`` (normalised, no dashes).
+    """
+    root_id = "rootcli" + "0".zfill(25)
+    sub_id = "subcli0" + "0".zfill(25)
+    created = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    # Root: parent_conversation_id IS NULL.
+    conn.execute(
+        "INSERT INTO conversations "
+        "(id, location, event_count, title, created_at, parent_conversation_id) "
+        "VALUES (?, ?, ?, ?, ?, NULL)",
+        (root_id, "/tmp/fake/root", 1, "root", created),
+    )
+    # Sub: parent_conversation_id = root_id.
+    conn.execute(
+        "INSERT INTO conversations "
+        "(id, location, event_count, title, created_at, parent_conversation_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (sub_id, "/tmp/fake/sub", 1, "sub", created, root_id),
+    )
+    for cid in (root_id, sub_id):
+        conn.execute(
+            """
+            INSERT INTO conversation_human_input (
+                conversation_id, initial_prompt_words, initial_prompt_source,
+                followup_word_count, followup_message_count, processed_at, event_count
+            ) VALUES (?, ?, 'unknown', ?, ?, ?, ?)
+            """,
+            (cid, 5, 0, 0, "2024-06-01T12:00:00+00:00", 1),
+        )
+    conn.commit()
+    conn.close()
+    return root_id, sub_id
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -381,3 +421,144 @@ def test_classify_single_no_such_conversation_distinct_error(
     assert "ohtv db process human_input" not in result.output
     # And it should point at the real remediation.
     assert "ohtv db scan" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Issue #126 — sub-conversation auto-classification, end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_classify_list_unknown_auto_classifies_subs(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """T-F (--list-unknown): auto-step runs ahead of mode dispatch.
+
+    Seeds 1 root + 1 sub (both ``'unknown'``). Runs
+    ``ohtv classify --list-unknown``. After the auto-step the sub is
+    ``'automation'``, so --list-unknown only shows the root.
+    """
+    root_id, sub_id = _seed_root_and_sub(isolated_db)
+
+    result = runner.invoke(main, ["classify", "--list-unknown"])
+
+    assert result.exit_code == 0, result.output
+    # Auto-step notice fires (1 sub flipped).
+    assert "Auto-classified 1 sub-conversation(s) as 'automation'" in result.output
+    # Sub is now 'automation'; root is unchanged.
+    assert _read_source(isolated_db, sub_id) == "automation"
+    assert _read_source(isolated_db, root_id) == "unknown"
+    # --list-unknown output mentions the root's short_id but NOT the sub's.
+    assert root_id[:8] in result.output
+    assert sub_id[:8] not in result.output
+
+
+def test_classify_bulk_auto_classifies_subs(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """T-F (bulk): auto-step runs ahead of the bulk apply path.
+
+    Even on the bulk path that only touches 'unknown' rows for roots,
+    the auto-step has already moved subs to 'automation' first.
+    """
+    root_id, sub_id = _seed_root_and_sub(isolated_db)
+
+    result = runner.invoke(
+        main,
+        ["classify", "--no-followups", "--source", "automation", "--confirm"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Auto-classified 1 sub-conversation(s) as 'automation'" in result.output
+    assert _read_source(isolated_db, sub_id) == "automation"
+    # The bulk apply also flipped the root (no followups).
+    assert _read_source(isolated_db, root_id) == "automation"
+
+
+def test_classify_single_auto_classifies_subs(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """T-F (single): auto-step runs ahead of ``set_single``.
+
+    The single-conversation override path is the only one where the
+    operator's intent can outlive the auto-step within a single
+    invocation — set_single runs after the auto-step and is allowed to
+    flip already-classified rows (AC5). Target the root here to keep
+    the assertion clean: the auto-step touched the sub, then
+    set_single touched the root.
+    """
+    root_id, sub_id = _seed_root_and_sub(isolated_db)
+
+    result = runner.invoke(
+        main, ["classify", root_id, "--source", "human"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Auto-classified 1 sub-conversation(s) as 'automation'" in result.output
+    # Sub flipped by auto-step.
+    assert _read_source(isolated_db, sub_id) == "automation"
+    # Root flipped by set_single (operator override).
+    assert _read_source(isolated_db, root_id) == "human"
+
+
+def test_classify_auto_step_is_idempotent_across_invocations(
+    runner: CliRunner, isolated_db: Path
+) -> None:
+    """Running classify twice in a row only changes rows on the first call.
+
+    Models AC2 + AC3 idempotency at the CLI surface: invocation #1
+    flips the sub and emits the "Auto-classified 1 sub-conversation(s)"
+    notice; invocation #2 finds nothing to change and emits no notice.
+    """
+    _seed_root_and_sub(isolated_db)
+
+    first = runner.invoke(main, ["classify", "--list-unknown"])
+    second = runner.invoke(main, ["classify", "--list-unknown"])
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    # First call: notice present.
+    assert "Auto-classified 1 sub-conversation(s)" in first.output
+    # Second call: no rows changed -> no notice.
+    assert "Auto-classified" not in second.output
+
+
+def test_classify_guardrail_missing_migration_019(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T-G (AC7): pre-019 schema raises a clear migration error.
+
+    Builds a tmp DB with just a minimal ``conversations`` table missing
+    ``parent_conversation_id``. Any classify mode must surface the
+    guardrail message before doing any DB work.
+    """
+    ohtv_dir = tmp_path / "ohtv"
+    ohtv_dir.mkdir()
+    db_path = ohtv_dir / "index.db"
+
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_dir))
+    monkeypatch.setenv("OHTV_DB_PATH", str(db_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Pre-migration-019 shape: conversations table without
+    # parent_conversation_id. conversation_human_input table present so
+    # the CLI doesn't fail earlier on a different missing-table error.
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE conversations (id TEXT PRIMARY KEY, title TEXT)")
+    conn.execute(
+        "CREATE TABLE conversation_human_input ("
+        "conversation_id TEXT PRIMARY KEY, "
+        "initial_prompt_source TEXT NOT NULL DEFAULT 'unknown', "
+        "followup_message_count INTEGER NOT NULL DEFAULT 0"
+        ")"
+    )
+    conn.commit()
+    conn.close()
+
+    result = runner.invoke(main, ["classify", "--list-unknown"])
+
+    assert result.exit_code == 1, result.output
+    assert "migration 019" in result.output
+    # Rich may wrap "ohtv db scan" mid-string with a soft newline; collapse
+    # whitespace before asserting on the remediation hint.
+    normalized = " ".join(result.output.split())
+    assert "ohtv db scan" in normalized

--- a/tests/unit/test_cli_classify.py
+++ b/tests/unit/test_cli_classify.py
@@ -435,7 +435,7 @@ def test_classify_list_unknown_auto_classifies_subs(
 
     Seeds 1 root + 1 sub (both ``'unknown'``). Runs
     ``ohtv classify --list-unknown``. After the auto-step the sub is
-    ``'automation'``, so --list-unknown only shows the root.
+    ``'sub_agent'``, so --list-unknown only shows the root.
     """
     root_id, sub_id = _seed_root_and_sub(isolated_db)
 
@@ -443,9 +443,9 @@ def test_classify_list_unknown_auto_classifies_subs(
 
     assert result.exit_code == 0, result.output
     # Auto-step notice fires (1 sub flipped).
-    assert "Auto-classified 1 sub-conversation(s) as 'automation'" in result.output
-    # Sub is now 'automation'; root is unchanged.
-    assert _read_source(isolated_db, sub_id) == "automation"
+    assert "Auto-classified 1 sub-conversation(s) as 'sub_agent'" in result.output
+    # Sub is now 'sub_agent'; root is unchanged.
+    assert _read_source(isolated_db, sub_id) == "sub_agent"
     assert _read_source(isolated_db, root_id) == "unknown"
     # --list-unknown output mentions the root's short_id but NOT the sub's.
     assert root_id[:8] in result.output
@@ -458,7 +458,8 @@ def test_classify_bulk_auto_classifies_subs(
     """T-F (bulk): auto-step runs ahead of the bulk apply path.
 
     Even on the bulk path that only touches 'unknown' rows for roots,
-    the auto-step has already moved subs to 'automation' first.
+    the auto-step has already moved subs to 'sub_agent' first — so the
+    subsequent ``--source automation`` heuristic only flips the root.
     """
     root_id, sub_id = _seed_root_and_sub(isolated_db)
 
@@ -468,9 +469,11 @@ def test_classify_bulk_auto_classifies_subs(
     )
 
     assert result.exit_code == 0, result.output
-    assert "Auto-classified 1 sub-conversation(s) as 'automation'" in result.output
-    assert _read_source(isolated_db, sub_id) == "automation"
-    # The bulk apply also flipped the root (no followups).
+    assert "Auto-classified 1 sub-conversation(s) as 'sub_agent'" in result.output
+    # Sub is 'sub_agent' (auto-step); the bulk heuristic only touches
+    # 'unknown' rows so it does NOT clobber the sub back to 'automation'.
+    assert _read_source(isolated_db, sub_id) == "sub_agent"
+    # The bulk apply flipped the root (no followups, --source automation).
     assert _read_source(isolated_db, root_id) == "automation"
 
 
@@ -493,9 +496,9 @@ def test_classify_single_auto_classifies_subs(
     )
 
     assert result.exit_code == 0, result.output
-    assert "Auto-classified 1 sub-conversation(s) as 'automation'" in result.output
+    assert "Auto-classified 1 sub-conversation(s) as 'sub_agent'" in result.output
     # Sub flipped by auto-step.
-    assert _read_source(isolated_db, sub_id) == "automation"
+    assert _read_source(isolated_db, sub_id) == "sub_agent"
     # Root flipped by set_single (operator override).
     assert _read_source(isolated_db, root_id) == "human"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes #126.

Every `ohtv classify` invocation now runs a deterministic SQL UPDATE that sets `initial_prompt_source='sub_agent'` for every conversation with a non-NULL `parent_conversation_id`. Sub-conversations are by construction a delegated continuation of their parent, not an independently triggered run — they have **no trigger of their own**. This is a self-healing pure-DB correctness fix; no LLM calls, no new flag.

### Design pivot from initial draft (PR review)

The original draft of this PR labelled subs as `'automation'`. PR review pointed out that `'automation'` is a real trigger type meaning "an automation run (cron / webhook) dispatched this conversation" — conflating it with sub-agent delegation would silently slurp every sub into the automation-run bucket of `report velocity` and `report weekly-counts`, even though those are completely different things in the real world.

This revision adds a dedicated fourth value, **`'sub_agent'`**, via a new migration (022) that widens the CHECK constraint on `conversation_human_input.initial_prompt_source`. `'sub_agent'` is **system-managed** — it is not a valid value for the operator-facing `--source` flag (operators should never pick "sub-agent" as a trigger). The parent's actual trigger type is always recoverable by walking up `parent_conversation_id` to the root, so nothing is lost by giving subs their own label.

### Why this matters

Without this fix, after #108 lands and sub-conversations become first-class rows, the `--has-followups --source human` bulk heuristic would flip subs to `'human'` (subs frequently have follow-up messages from the orchestrating agent). The bad values then corrupt every downstream report: `report velocity` and `report weekly-counts` inflate human-attributed work, and the `velocity.py` `unknown → human` optimistic default silently makes the picture worse over time.

### What changes

- **New migration 022** (`022_classify_sub_agent.py`) — widens the CHECK constraint on `conversation_human_input.initial_prompt_source` to include `'sub_agent'`. Follows the same recreate-table pattern as migration 017 (`change_refs.status` enum widening). Existing data preserved verbatim.
- **New helper** `apply_sub_classification(conn) -> int` in `src/ohtv/classify.py` — single `UPDATE ... WHERE EXISTS (...)` that flips every non-`'sub_agent'` sub to `'sub_agent'`. Returns the row count changed. Idempotent and self-healing for residual `'human'`, `'automation'`, or `'unknown'` values on subs.
- **New constant** `SUB_AGENT_SOURCE = "sub_agent"` exported alongside `VALID_SOURCES`. `VALID_SOURCES` intentionally still contains only the three operator-facing values — `'sub_agent'` is system-managed and never a `--source` choice.
- **Guardrail** `_assert_parent_column_present(conn)` mirroring the #123/#124/#125 pattern — raises `RuntimeError` if migration 019 hasn't run.
- **Wire-up** in the `classify` Click command body — single insertion point right after the `is_db_available()` check and before mode dispatch. Prints a dim `Auto-classified N sub-conversation(s) as 'sub_agent'.` notice when the row count is non-zero.
- **Velocity report** — adds explicit `WHEN 'sub_agent' THEN 0` cases to both CASE statements. The `ELSE 0` fallback already produced the correct result for the unhandled case, but spelling it out keeps the policy visible in the SQL. New regression test confirms subs contribute 0 words and 0 messages.

### Acceptance criteria

- [x] **AC1** — `apply_sub_classification(conn) -> int` exported, issues exactly one UPDATE, returns changed row count, writes `'sub_agent'`.
- [x] **AC2** — All three CLI modes (`<id> --source ...`, `--list-unknown`, `--no-followups/--has-followups --confirm`) call the auto-step before mode-specific work. No new flag added.
- [x] **AC3** — Regression test (`T-A` + `T-F`): sub `'unknown'` → `'sub_agent'`, root unchanged. Zero LLM calls.
- [x] **AC4** — `T-B`: residual `'human'` on subs is corrected. `T-B2`: residual `'automation'` (from an earlier draft of this fix) is also corrected.
- [x] **AC5** — `T-E`: manual `set_single` override wins within one invocation.
- [x] **AC6** — `test_followup_counts_untouched`: `followup_word_count` / `followup_message_count` unchanged.
- [x] **AC7** — `T-G`: missing `parent_conversation_id` column → friendly RuntimeError before any work.
- [x] **AC8 (new)** — `test_initial_prompt_source_sub_agent_contributes_zero`: velocity report contributes 0 words and 0 messages for `'sub_agent'` rows.

### Migration number divergence (documented divergence from issue body)

The issue body and technical-approach comment refer to "migration 018 (`parent_conversation_id` from #108)" several times. On `main` today, `parent_conversation_id` is actually added by **migration 019** (`019_parent_conversation_id.py`). The guardrail's error message and the related test reference `migration 019` to match the actual repo state; the column check itself is name-based, not number-based, so this is purely a user-facing message difference.

### Tests

- `tests/unit/test_classify.py` — 9 tests in `TestApplySubClassification` + `TestAssertParentColumnPresent` (T-A / T-B / T-B2 / T-C / T-D / T-E + follow-up-counts + guardrail).
- `tests/unit/test_cli_classify.py` — 5 smoke tests covering all three CLI modes + idempotency + guardrail.
- `tests/unit/reports/test_velocity.py` — 1 new test confirming `'sub_agent'` rows contribute 0.
- All 1948 unit tests pass (`uv run pytest tests/unit -q`).

### Files touched

- `src/ohtv/db/migrations/022_classify_sub_agent.py` — new migration (~100 LOC, mostly the recreate-table boilerplate).
- `src/ohtv/classify.py` — module docstring + `SUB_AGENT_SOURCE` constant + helper + guardrail.
- `src/ohtv/cli.py` — wire-up in the classify command body.
- `src/ohtv/reports/velocity.py` — explicit `WHEN 'sub_agent' THEN 0` + policy bullet.
- `tests/unit/test_classify.py`, `tests/unit/test_cli_classify.py`, `tests/unit/reports/test_velocity.py` — assertions updated.
- `docs/guides/classification.md` — new "Automatic Sub-Conversation Classification" section with full design rationale.

### Out of scope

Per the issue body: this PR does **not** change the `human` vs `unknown` policy for roots, the `velocity.py:38` optimistic default, the `human_input` stage's counts-only contract, or add any `--include-subs` opt-in flag.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._