### PR TITLE
feat(cli): add --log-level/--log-file/--log-stderr, stop swallowing batch errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ The most common variables:
 Full list, defaults, and precedence rules:
 [docs/reference/configuration.md](docs/reference/configuration.md).
 
+### Logs
+
+ohtv writes a rotating log file to `~/.ohtv/logs/ohtv.log` (1 MB, 3
+backups). Every command accepts `--log-level {DEBUG,INFO,WARNING,
+ERROR,CRITICAL}` (default `INFO`) and `--log-file PATH` (use `-` for
+stderr-only). Equivalent env vars: `OHTV_LOG_LEVEL`, `OHTV_LOG_FILE`.
+Batch failures from `gen objs`, `db embed`, etc. land in the file log
+even under `--quiet`. The legacy `--verbose` flag still works and is
+equivalent to `--log-level DEBUG --log-stderr` (with a one-shot
+deprecation note). See
+[docs/reference/configuration.md#logging](docs/reference/configuration.md#logging).
+
 ## Automation
 
 ohtv plays nicely with cron / systemd timers — every long-running command

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -14,7 +14,8 @@ Environment variables, data directories, and logging.
 | `OHTV_CONVERSATIONS_DIR` | Local CLI conversations directory | `~/.openhands/conversations` |
 | `OHTV_CLOUD_CONVERSATIONS_DIR` | Synced cloud conversations directory | `~/.openhands/cloud/conversations` |
 | `OHTV_EXTRA_CONVERSATION_PATHS` | Additional conversation directories (colon-separated paths) | None |
-| `OHTV_LOG_LEVEL` | Override default log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`) | `INFO` |
+| `OHTV_LOG_LEVEL` | Default log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`, case-insensitive). Overridden by `--log-level`. | `INFO` |
+| `OHTV_LOG_FILE` | Default log destination. Overridden by `--log-file`. Special values: `-` writes to stderr only; `/dev/null` (or `nul` on Windows) silences file logging. | `~/.ohtv/logs/ohtv.log` |
 | `LLM_API_KEY` | API key for LLM provider | Required for `gen`, `search`, `ask` |
 | `LLM_MODEL` | Default LLM model for `ask` | `openai/gpt-4o-mini` |
 | `LLM_BASE_URL` | Custom LLM base URL | Provider default |
@@ -49,13 +50,63 @@ re-sync, but no source data lives only in `~/.ohtv/`).
 
 ## Logging
 
-ohtv writes structured logs to `~/.ohtv/logs/ohtv.log`:
+ohtv writes logs to `~/.ohtv/logs/ohtv.log` by default:
 
 - Rotates at 1 MB, keeps 3 backups
-- INFO level by default
-- `-v` / `--verbose` on any command also prints DEBUG to console
-- `OHTV_LOG_LEVEL=DEBUG` raises the file-log level globally
+- Default level is `INFO`
+- Format: `YYYY-MM-DD HH:MM:SS LEVEL message` — `grep`/`awk` friendly,
+  not strict JSON
 
-The log format is `timestamp | level | logger | message` — readable with
-`grep`/`awk` but not strict JSON. For machine-readable output, use
-`--format json` / `--format csv` on the command itself.
+### CLI flags
+
+Every command accepts three logging flags (defined once in
+`src/ohtv/cli_logging.py::logging_options`):
+
+| Flag | What it does |
+|------|--------------|
+| `--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}` | Minimum level for all log handlers. Case-insensitive. |
+| `--log-file PATH` | Override the file destination. Use `-` for stderr-only; `/dev/null` (or `nul` on Windows) to silence file logging entirely. |
+| `--log-stderr` | Also send log output to stderr (in addition to the file). |
+
+### Resolution order
+
+For each knob: CLI flag → environment variable → built-in default.
+
+```
+--log-level   → $OHTV_LOG_LEVEL → INFO
+--log-file    → $OHTV_LOG_FILE  → ~/.ohtv/logs/ohtv.log
+```
+
+Example — raise level via env var, override on a single command:
+
+```bash
+export OHTV_LOG_LEVEL=DEBUG          # all ohtv commands default to DEBUG
+ohtv gen objs --log-level WARNING    # this run reverts to WARNING
+```
+
+The logging flags belong to each subcommand (so they come AFTER the
+subcommand name), not the top-level group:
+
+```bash
+ohtv sync --log-level DEBUG --log-stderr     # ✓
+ohtv --log-level DEBUG sync                  # ✗ (unknown option at top level)
+```
+
+### `--verbose` (deprecated)
+
+The legacy `-v`/`--verbose` flag is preserved for backward compatibility
+and behaves as `--log-level DEBUG --log-stderr` plus a one-shot stderr
+deprecation note. Two commands keep `--verbose` for *domain* purposes
+and not logging: `db init --verbose` (show migration steps) and
+`report velocity --verbose` (show rendered SQL). Both also emit the
+logging deprecation note when used; use the explicit `--log-level` flag
+to control logging on those commands.
+
+### What lands in the log
+
+Batch commands (`gen objs`, `gen titles`, `gen run`, `sync` post-hooks,
+`db embed`) **always** record per-item failures to the log file even
+when `--quiet` is set — the file handler is independent of the console
+output suppressed by `--quiet`. If `ohtv gen objs --quiet` reports
+``N err`` and you need to diagnose what failed, look in
+``~/.ohtv/logs/ohtv.log`` for the corresponding tracebacks (Issue #121).

--- a/src/ohtv/analysis/embeddings/operations.py
+++ b/src/ohtv/analysis/embeddings/operations.py
@@ -527,7 +527,9 @@ def generate_embeddings_only(
             
     except Exception as e:
         batch.error = str(e)
-        log.warning("Error generating embeddings for %s: %s", conv_id, e)
+        # Issue #121: keep full traceback in ~/.ohtv/logs/ohtv.log so the
+        # caller can diagnose silent batch failures.
+        log.exception("Error generating embeddings for %s", conv_id)
     
     return batch
 
@@ -640,8 +642,10 @@ class EmbeddingWriter:
                         self._write_batches(store, conn, pending)
                         pending = []
                         
-                except Exception as e:
-                    log.error("Error in embedding writer: %s", e)
+                except Exception:
+                    # Issue #121: keep the writer loop alive but make the
+                    # full traceback land in ~/.ohtv/logs/ohtv.log.
+                    log.exception("Error in embedding writer")
     
     def _write_batches(self, store, conn, batches: list[EmbeddingBatch]) -> None:
         """Write a list of batches to the database."""
@@ -682,7 +686,9 @@ class EmbeddingWriter:
                 
             log.debug("Wrote %d batches (%d embeddings)", count, embed_count)
             
-        except Exception as e:
-            log.error("Error writing embedding batches: %s", e)
+        except Exception:
+            # Issue #121: include the traceback so silent batch failures
+            # are diagnosable from ~/.ohtv/logs/ohtv.log.
+            log.exception("Error writing embedding batches")
             with self._lock:
                 self._errors += len(batches)

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -76,6 +76,7 @@ class SectionedGroup(click.Group):
                 formatter.write_dl(llm_commands)
 
 
+from ohtv.cli_logging import init_logging_from_cli, logging_options
 from ohtv.logging import setup_logging
 from ohtv.sources import ConversationInfo, LocalSource
 from ohtv.sync import (
@@ -267,8 +268,14 @@ GIT_URL_PATTERNS = {
 
 
 def _init_logging(verbose: bool = False) -> None:
-    """Initialize logging for the CLI."""
-    setup_logging(verbose=verbose)
+    """Initialize logging for the CLI.
+
+    Delegates to :func:`ohtv.cli_logging.init_logging_from_cli`, which
+    reads ``--log-level`` / ``--log-file`` / ``--log-stderr`` from the
+    active Click context and applies the deprecated ``verbose=True``
+    alias when set (Issue #121).
+    """
+    init_logging_from_cli(verbose=verbose)
 
 
 @click.group(cls=SectionedGroup)
@@ -307,7 +314,8 @@ def main() -> None:
     ),
 )
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output for cron jobs")
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 @click.option("--no-llm", is_flag=True, help="Skip LLM-powered analysis (summaries won't be generated)")
 @click.option("--no-embed", is_flag=True, help="Skip embedding generation")
 @click.option(
@@ -1192,6 +1200,12 @@ def _run_post_sync_processing(quiet: bool, verbose: bool, no_llm: bool = False, 
                 try:
                     processor(conn, conv)
                 except Exception as e:
+                    # Always log to file; only echo to console under verbose.
+                    log.exception(
+                        "Error in stage %s for conversation %s",
+                        stage_name,
+                        conv.id,
+                    )
                     if verbose:
                         console.print(f"    [red]Error processing {conv.id}:[/red] {e}")
             
@@ -1266,12 +1280,18 @@ def _run_post_sync_llm_analysis(quiet: bool, verbose: bool) -> None:
                             if verbose:
                                 console.print(f"    [dim]Analyzed {conv.id[:8]}[/dim]")
                 except Exception as e:
+                    # Always log to file; only echo to console under verbose.
+                    log.exception(
+                        "Error generating LLM analysis for conversation %s",
+                        conv.id,
+                    )
                     if verbose:
                         console.print(f"    [red]Error analyzing {conv.id}:[/red] {e}")
             
             conn.commit()
             
         except ImportError as e:
+            log.exception("Could not import analysis module")
             if verbose:
                 console.print(f"  [red]Could not import analysis module:[/red] {e}")
     
@@ -1452,7 +1472,11 @@ def _run_post_sync_embeddings(quiet: bool, verbose: bool) -> None:
                         return batch.stats, None
                         
                     except Exception as e:
-                        log.debug("Error on %s: %s", conv.id[:12], e)
+                        # Upgrade from debug to exception so traceback lands
+                        # in ~/.ohtv/logs/ohtv.log (Issue #121).
+                        log.exception(
+                            "Error generating embeddings for %s", conv.id[:12]
+                        )
                         return None, str(e)
             
             # Start the writer thread (it creates its own DB connection)
@@ -2619,7 +2643,8 @@ def _populate_error_info(
               help="Show Idle column (minutes since last event). Colorized: red if < MINS (default: 7), green if >= MINS")
 @click.option("--with-errors", "-E", "with_errors", is_flag=True, help="Include error info column (agent/LLM errors)")
 @click.option("--errors-only", "errors_only", is_flag=True, help="Show only conversations with agent/LLM errors")
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def list_conversations(
     reverse: bool,
     limit: int | None,
@@ -2741,7 +2766,8 @@ def list_conversations(
     default="table",
     help="Output format (default: table)",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def search(
     query: str,
     limit: int,
@@ -3083,7 +3109,8 @@ def _display_retrieval_breakdown(
 @click.option("--explain-only", is_flag=True, help="Show retrieval breakdown without generating an LLM answer")
 @click.option("--agent", is_flag=True, help="Enable multi-turn investigation mode")
 @click.option("--max-steps", type=int, default=5, help="Max investigation steps (with --agent)")
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def ask(
     question: str,
     context: int,
@@ -3914,7 +3941,8 @@ def _format_duration(duration: timedelta | None) -> str:
     help="Output format (default: text)",
 )
 @click.option("--file", type=click.Path(), help="Write output to file")
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def show(
     conversation_id: str,
     user_messages: bool,
@@ -4744,7 +4772,8 @@ def _format_action_details(tool_name: str, action: dict) -> str:
     default="text",
     help="Output format (default: text)",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def errors(
     conversation_id: str,
     fmt: str,
@@ -4900,7 +4929,8 @@ def _print_error_detail(err) -> None:
 @click.option("--actions", "-a", is_flag=True, help="Show only refs with detected interactions (read or write)")
 @click.option("--write-only", "-w", is_flag=True, help="Show only refs with write actions (pushed, created, merged, etc.)")
 @click.option("--no-index", is_flag=True, help="Skip database indexing (faster, but refs won't be queryable)")
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def refs(
     conversation_id: str | None,
     limit: int | None,
@@ -6775,7 +6805,16 @@ def db() -> None:
 
 
 @db.command("init")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed migration output")
+@logging_options
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help=(
+        "Show detailed migration output. (Domain flag retained; for logging "
+        "verbosity use --log-level DEBUG --log-stderr.)"
+    ),
+)
 def db_init(verbose: bool) -> None:
     """Initialize or migrate the database.
     
@@ -6806,7 +6845,8 @@ def db_init(verbose: bool) -> None:
 @click.argument("stage", type=click.Choice([*STAGES.keys(), "all"]))
 @click.option("--force", "-f", is_flag=True, help="Reprocess all conversations, ignoring stage completion")
 @click.option("--conversation", "-c", help="Process only this conversation ID")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def db_process(stage: str, force: bool, conversation: str | None, verbose: bool) -> None:
     """Run a processing stage on conversations.
     
@@ -6943,7 +6983,8 @@ def _run_process_stage(stage: str, force: bool, conversation: str | None, verbos
 @db.command("scan")
 @click.option("--force", "-f", is_flag=True, help="Update all conversations regardless of mtime")
 @click.option("--remove-missing", is_flag=True, help="Remove DB entries for conversations no longer on disk")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 @click.option(
     "--lock-timeout",
     type=float,
@@ -7173,7 +7214,8 @@ def db_status() -> None:
 
 
 @db.command("index-cache")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def db_index_cache(verbose: bool) -> None:
     """Index existing analysis cache files into the database.
     
@@ -7301,7 +7343,8 @@ def db_index_cache(verbose: bool) -> None:
 @db.command("migrate-cache")
 @click.option("--delete-legacy", is_flag=True, help="Delete legacy cache files after migration")
 @click.option("--dry-run", is_flag=True, help="Show what would be migrated without doing it")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def db_migrate_cache(delete_legacy: bool, dry_run: bool, verbose: bool) -> None:
     """Migrate analysis cache files from conversation directories to ~/.ohtv.
 
@@ -7442,7 +7485,8 @@ def db_reset(yes: bool) -> None:
 @click.option("--force", "-f", is_flag=True, help="Rebuild all embeddings")
 @click.option("--estimate", is_flag=True, help="Show cost estimate only, don't embed")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
-@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def db_embed(force: bool, estimate: bool, yes: bool, verbose: bool) -> None:
     """Build embeddings for semantic search and RAG.
     
@@ -8113,7 +8157,8 @@ def _error_no_github_token() -> None:
 @click.option("--dry-run", is_flag=True, help="Show what would be fetched without making API calls")
 @click.option("--limit", type=int, help="Cap rows processed this run (default: unlimited)")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output (no progress bar)")
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def fetch_loc_cmd(
     repo_filter: str | None,
     force: bool,
@@ -8385,7 +8430,8 @@ def gen() -> None:
 @click.option("--refresh", "-r", "refresh", is_flag=True, help="Force re-analysis (refresh cache)")
 @click.option("--no-outputs", is_flag=True, help="Don't show outputs (repos, PRs, issues modified)")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
-@click.option("--verbose", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 # Multi-conversation options (when conversation_id is not provided)
 @click.option("--max", "-n", "limit", type=int, help="Maximum conversations to analyze (default: 10)")
 @click.option("--all", "-A", "show_all", is_flag=True, help="Analyze all conversations (no limit)")
@@ -8782,10 +8828,23 @@ def _run_batch_objectives_analysis(
             }
             return result_dict, None, analysis_result.cost, analysis_result.from_cache
         except (ValueError, RuntimeError) as e:
+            # Known-recoverable: skip with a warning so the file log shows
+            # at least the conversation id and the message.
+            log.warning(
+                "Skipping objectives analysis for %s: %s",
+                conv.short_id,
+                e,
+            )
             return None, (conv.short_id, str(e)[:50]), 0.0, False
         except Exception as e:
             if "api_key" in str(e).lower() or "LLM_" in str(e):
                 raise  # Re-raise auth errors to handle at top level
+            # Unexpected: full traceback to the file log so --quiet
+            # `N err` totals can be diagnosed (Issue #121).
+            log.exception(
+                "Unexpected error analysing objectives for %s",
+                conv.short_id,
+            )
             return None, (conv.short_id, str(e)[:50]), 0.0, False
 
     # Show progress for LLM analysis (skip if all cached)
@@ -9134,12 +9193,15 @@ def _run_objectives_analysis(
                 analysis = result.analysis
                 analysis_cost = result.cost
         except ValueError as e:
+            log.warning("Objectives analysis failed for %s: %s", conv_id, e)
             console.print(f"[red]Error:[/red] {e}")
             raise SystemExit(1)
         except RuntimeError as e:
+            log.warning("Objectives analysis runtime error for %s: %s", conv_id, e)
             console.print(f"[red]Analysis failed:[/red] {e}")
             raise SystemExit(1)
         except Exception as e:
+            log.exception("Unexpected error analysing objectives for %s", conv_id)
             if "api_key" in str(e).lower() or "LLM_" in str(e):
                 console.print(
                     "[red]Error:[/red] LLM not configured. Set LLM_API_KEY environment variable."
@@ -9198,7 +9260,8 @@ def _run_objectives_analysis(
 @click.option("--model", "-m", help="LLM model override (e.g. haiku)")
 @click.option("--yes", "-y", is_flag=True,
               help="Skip the >5-conv confirmation prompt")
-@click.option("--verbose", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 @click.option(
     "--lock-timeout",
     type=float,
@@ -9960,7 +10023,8 @@ def _apply_local_title_writeback(
 @click.argument("job_id")
 @click.option("--model", "-m", help="LLM model to use for analysis")
 @click.option("--refresh", "-r", is_flag=True, help="Force re-analysis (refresh cache)")
-@click.option("--verbose", is_flag=True, help="Show debug output")
+@logging_options
+@click.option("--verbose", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 # Date range options
 @click.option("--since", "-S", "since_date", help="Start date (YYYY-MM-DD)")
 @click.option("--until", "-U", "until_date", help="End date (YYYY-MM-DD)")
@@ -10390,7 +10454,8 @@ def _display_aggregate_results_table(
     default=None,
     help="Output format for --list-unknown (default: table).",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Show debug output.")
+@logging_options
+@click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
 def classify(
     conversation_id: str | None,
     source: str | None,
@@ -10773,7 +10838,16 @@ def report() -> None:
     show_default=True,
     help="Figure suptitle (only meaningful with --chart).",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Show the rendered SQL and per-week row counts")
+@logging_options
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help=(
+        "Show the rendered SQL and per-week row counts. (Domain flag "
+        "retained; for logging verbosity use --log-level DEBUG --log-stderr.)"
+    ),
+)
 def report_velocity(
     fmt: str,
     since_str: str | None,

--- a/src/ohtv/cli_logging.py
+++ b/src/ohtv/cli_logging.py
@@ -146,8 +146,12 @@ def init_logging_from_cli(verbose: bool = False) -> None:
     stderr = bool(opts.get("stderr", False))
 
     if verbose:
-        _warn_verbose_deprecated()
         if level is None:
+            # Only nag when --verbose actually changes behavior. If the
+            # caller already passed an explicit --log-level we treat
+            # that as a signal they've moved past --verbose and skip
+            # the one-shot deprecation note.
+            _warn_verbose_deprecated()
             level = "DEBUG"
         stderr = True
 

--- a/src/ohtv/cli_logging.py
+++ b/src/ohtv/cli_logging.py
@@ -1,0 +1,154 @@
+"""CLI-side logging glue (Issue #121).
+
+Provides the ``@logging_options`` Click decorator (adds
+``--log-level`` / ``--log-file`` / ``--log-stderr`` to a command without
+requiring a signature change) and the ``init_logging_from_cli`` shim
+called by every CLI command.
+
+The decorator stores resolved values on the Click context under
+``ctx.meta["ohtv.logging"]``; ``init_logging_from_cli`` reads them back
+and forwards to :func:`ohtv.logging.setup_logging`. Commands that still
+declare a per-command ``--verbose`` flag forward it through ``verbose=``
+which we honour as a deprecated alias for ``--log-level DEBUG
+--log-stderr`` and emit a one-shot stderr warning on first use.
+
+This module deliberately does no logging-level work itself — it is a
+parameter-conduit only.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable
+
+import click
+
+from ohtv.logging import setup_logging
+
+_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+_META_KEY = "ohtv.logging"
+
+# Set on first verbose-deprecation warning so each ``ohtv`` invocation
+# only nags once even when multiple commands are invoked in-process
+# (e.g. by tests using CliRunner).
+_VERBOSE_WARNING_EMITTED = False
+
+
+def _record(option_name: str, value: Any) -> None:
+    """Store a logging option on the active Click context."""
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return
+    bucket = ctx.meta.setdefault(_META_KEY, {})
+    bucket[option_name] = value
+
+
+def _log_level_callback(ctx: click.Context, param: click.Parameter, value: str | None):
+    if value is not None:
+        _record("level", value)
+    return value
+
+
+def _log_file_callback(ctx: click.Context, param: click.Parameter, value: str | None):
+    if value is not None:
+        _record("log_file", value)
+    return value
+
+
+def _log_stderr_callback(ctx: click.Context, param: click.Parameter, value: bool):
+    if value:
+        _record("stderr", True)
+    return value
+
+
+def logging_options(func: Callable) -> Callable:
+    """Click decorator that adds ``--log-level`` / ``--log-file`` /
+    ``--log-stderr`` to a command without changing its signature.
+
+    Values are stored on the Click context's ``meta`` map and picked up
+    by :func:`init_logging_from_cli`. Use ``expose_value=False`` so the
+    command function does not need additional kwargs.
+    """
+    func = click.option(
+        "--log-stderr",
+        is_flag=True,
+        default=False,
+        expose_value=False,
+        callback=_log_stderr_callback,
+        is_eager=True,
+        help="Also send log output to stderr.",
+    )(func)
+    func = click.option(
+        "--log-file",
+        type=click.Path(dir_okay=False),
+        default=None,
+        expose_value=False,
+        callback=_log_file_callback,
+        is_eager=True,
+        help=(
+            "Override the default log file (~/.ohtv/logs/ohtv.log). "
+            "Use '-' for stderr-only; '/dev/null' to silence file logging."
+        ),
+    )(func)
+    func = click.option(
+        "--log-level",
+        type=click.Choice(_LOG_LEVELS, case_sensitive=False),
+        default=None,
+        expose_value=False,
+        callback=_log_level_callback,
+        is_eager=True,
+        help=(
+            "Minimum log level (default: INFO; or $OHTV_LOG_LEVEL if set)."
+        ),
+    )(func)
+    return func
+
+
+def _resolve_from_context() -> dict[str, Any]:
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return {}
+    return dict(ctx.meta.get(_META_KEY, {}))
+
+
+def _warn_verbose_deprecated() -> None:
+    global _VERBOSE_WARNING_EMITTED
+    if _VERBOSE_WARNING_EMITTED:
+        return
+    _VERBOSE_WARNING_EMITTED = True
+    sys.stderr.write(
+        "Note: --verbose is deprecated; use --log-level DEBUG --log-stderr instead.\n"
+    )
+
+
+def reset_verbose_warning_state() -> None:
+    """Reset the one-shot deprecation flag (test hook)."""
+    global _VERBOSE_WARNING_EMITTED
+    _VERBOSE_WARNING_EMITTED = False
+
+
+def init_logging_from_cli(verbose: bool = False) -> None:
+    """Initialise the ohtv logger from Click context + ``verbose=`` shim.
+
+    Reads ``--log-level`` / ``--log-file`` / ``--log-stderr`` recorded by
+    :func:`logging_options`, applies the legacy ``--verbose`` alias when
+    set, and calls :func:`ohtv.logging.setup_logging`.
+
+    Args:
+        verbose: Legacy per-command ``--verbose`` flag. When ``True``
+            and ``--log-level`` was not also passed, behaves as
+            ``--log-level DEBUG --log-stderr`` and emits a one-shot
+            deprecation warning.
+    """
+    opts = _resolve_from_context()
+    level = opts.get("level")
+    log_file = opts.get("log_file")
+    stderr = bool(opts.get("stderr", False))
+
+    if verbose:
+        _warn_verbose_deprecated()
+        if level is None:
+            level = "DEBUG"
+        stderr = True
+
+    setup_logging(level=level, log_file=log_file, stderr=stderr)

--- a/src/ohtv/logging.py
+++ b/src/ohtv/logging.py
@@ -1,71 +1,249 @@
-"""Logging configuration for ohtv."""
+"""Logging configuration for ohtv.
+
+Three knobs control where and what is logged:
+
+* ``level``     — minimum level for *all* handlers (default ``INFO``).
+* ``log_file``  — destination for the rotating file handler. ``None`` keeps
+                  the default (``~/.ohtv/logs/ohtv.log``). The special value
+                  ``"-"`` disables file logging and forces stderr instead.
+                  ``"/dev/null"`` (or ``"nul"`` on Windows) silences the file
+                  handler entirely.
+* ``stderr``    — if true, also add a console (stderr) handler at ``level``.
+
+Resolution order for ``level`` is documented at ``resolve_log_level``:
+CLI flag → ``OHTV_LOG_LEVEL`` env var → ``"INFO"``. Resolution for the
+path follows the same order using ``OHTV_LOG_FILE``.
+
+The rotating file handler keeps 1 MB × 3 backups and is installed exactly
+once per process. The logger root level stays at ``DEBUG`` so handlers can
+later be raised without losing detail.
+"""
+
+from __future__ import annotations
 
 import logging
 import logging.handlers
+import os
 import sys
+from pathlib import Path
 
 from ohtv.config import get_ohtv_dir
 
 
-def _get_log_dir():
+_LOGGER_NAME = "ohtv"
+
+# Special sentinels for ``log_file``:
+_STDERR_ONLY_SENTINEL = "-"
+# Cross-platform "null device" names users may pass on the CLI.
+_NULL_DEVICE_NAMES = frozenset({"/dev/null", "nul", "NUL"})
+
+
+def _get_log_dir() -> Path:
     return get_ohtv_dir() / "logs"
 
 
-def _get_log_file():
+def _get_default_log_file() -> Path:
     return _get_log_dir() / "ohtv.log"
 
 
-def setup_logging(verbose: bool = False) -> logging.Logger:
-    """Configure logging to file and optionally console."""
-    _get_log_dir().mkdir(parents=True, exist_ok=True)
+def get_log_file_path() -> Path:
+    """Return the default log file path users should look at.
 
-    logger = logging.getLogger("ohtv")
+    Used in user-facing error messages (``Failed: N — see <path>``) so the
+    string stays in one place.
+    """
+    return _get_default_log_file()
+
+
+_VALID_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def resolve_log_level(
+    cli_level: str | int | None,
+    *,
+    env: dict[str, str] | None = None,
+    default: str | int = "INFO",
+) -> int:
+    """Resolve the effective log level.
+
+    Resolution order: ``cli_level`` → ``OHTV_LOG_LEVEL`` env var →
+    ``default``. ``str`` values are matched case-insensitively against
+    ``logging`` level names; ``int`` values are returned as-is.
+
+    Raises:
+        ValueError: if a string value does not match a known level name.
+    """
+    env_map = env if env is not None else os.environ
+    raw: str | int | None = cli_level
+    if raw is None:
+        raw = env_map.get("OHTV_LOG_LEVEL")
+    if raw is None or raw == "":
+        raw = default
+    if isinstance(raw, int):
+        return raw
+    name = str(raw).strip().upper()
+    if name not in _VALID_LEVEL_NAMES:
+        raise ValueError(
+            f"Invalid log level {raw!r}; expected one of "
+            + ", ".join(_VALID_LEVEL_NAMES)
+        )
+    return getattr(logging, name)
+
+
+def resolve_log_file(
+    cli_path: str | Path | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> Path | str | None:
+    """Resolve the effective log destination.
+
+    Returns:
+        * ``Path`` to the file handler destination, OR
+        * the string ``"-"`` (stderr-only), OR
+        * ``None`` to disable the file handler entirely
+          (``/dev/null`` or ``nul``).
+
+    Resolution order: ``cli_path`` → ``OHTV_LOG_FILE`` env var →
+    ``~/.ohtv/logs/ohtv.log``.
+    """
+    env_map = env if env is not None else os.environ
+    raw: str | Path | None = cli_path
+    if raw is None:
+        raw = env_map.get("OHTV_LOG_FILE")
+    if raw is None or raw == "":
+        return _get_default_log_file()
+    if isinstance(raw, Path):
+        return raw
+    text = str(raw)
+    if text == _STDERR_ONLY_SENTINEL:
+        return _STDERR_ONLY_SENTINEL
+    if text in _NULL_DEVICE_NAMES:
+        return None
+    return Path(text).expanduser()
+
+
+def setup_logging(
+    *,
+    level: str | int | None = None,
+    log_file: str | Path | None = None,
+    stderr: bool = False,
+    # Back-compat for legacy callers / tests that still pass the old kwarg.
+    verbose: bool | None = None,
+    # Allow tests / programmatic callers to override env reads.
+    env: dict[str, str] | None = None,
+) -> logging.Logger:
+    """Configure the ``ohtv`` logger.
+
+    Args:
+        level: Log level for all handlers. Resolution order is
+            ``level`` → ``OHTV_LOG_LEVEL`` → ``"INFO"``. Accepts the
+            standard ``logging`` level names (case-insensitive) or an
+            integer level.
+        log_file: Destination for the rotating file handler. ``None``
+            uses ``$OHTV_LOG_FILE`` or the default
+            ``~/.ohtv/logs/ohtv.log``. ``"-"`` disables file logging
+            and forces stderr instead. ``"/dev/null"`` (or ``"nul"``)
+            silences file logging without enabling stderr.
+        stderr: If true, *also* attach a stderr handler at ``level``.
+        verbose: Deprecated alias preserved for backward compatibility.
+            ``verbose=True`` is equivalent to ``level="DEBUG",
+            stderr=True``. When passed, it does NOT override an
+            explicit ``level``/``stderr`` argument or env var.
+        env: Optional environment-variable mapping (for tests).
+
+    Returns:
+        The configured ``logging.Logger`` for ``"ohtv"``.
+    """
+    # Honour legacy ``verbose=True`` only if no explicit knob was passed.
+    if verbose:
+        if level is None:
+            level = "DEBUG"
+        stderr = True
+
+    resolved_level = resolve_log_level(level, env=env)
+    resolved_path = resolve_log_file(log_file, env=env)
+
+    logger = logging.getLogger(_LOGGER_NAME)
     logger.setLevel(logging.DEBUG)
+    # Note: we deliberately leave ``propagate=True`` (the default). The
+    # root logger has no handlers by default, so records flow into the
+    # void unless the host process attaches its own. Setting
+    # ``propagate=False`` would break ``caplog``/structured-logging
+    # consumers without buying us anything.
 
-    # Check if we already have handlers
-    has_file_handler = any(
-        isinstance(h, logging.handlers.RotatingFileHandler) for h in logger.handlers
-    )
-    has_console_handler = any(
-        isinstance(h, logging.StreamHandler) and h.stream == sys.stderr
-        for h in logger.handlers
-    )
+    if resolved_path == _STDERR_ONLY_SENTINEL:
+        # log_file="-" → stderr-only, no file handler.
+        _ensure_stderr_handler(logger, resolved_level)
+        # We override any pre-existing file handlers by raising their
+        # level out of the way; we don't remove them in case the caller
+        # passed log_file="-" after a prior file-handler install.
+    else:
+        if resolved_path is not None:
+            _ensure_file_handler(logger, resolved_level, resolved_path)
+        if stderr:
+            _ensure_stderr_handler(logger, resolved_level)
 
-    # Add file handler if not present
-    if not has_file_handler:
-        _add_file_handler(logger)
-
-    # Add console handler for verbose mode if not already present
-    if verbose and not has_console_handler:
-        _add_console_handler(logger)
+    # Always (re-)apply the resolved level to every existing handler.
+    for handler in logger.handlers:
+        handler.setLevel(resolved_level)
 
     return logger
 
 
-def _add_file_handler(logger: logging.Logger) -> None:
-    """Add rotating file handler."""
-    from logging.handlers import RotatingFileHandler
+def _ensure_file_handler(
+    logger: logging.Logger,
+    level: int,
+    path: Path,
+) -> None:
+    """Install (or reuse) a rotating file handler pointing at ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for handler in logger.handlers:
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            # Re-target an existing handler if the path changed.
+            existing = getattr(handler, "baseFilename", None)
+            try:
+                same = existing is not None and Path(existing) == path
+            except (OSError, ValueError):
+                same = False
+            if same:
+                handler.setLevel(level)
+                return
+            # Different destination → replace it cleanly.
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:  # noqa: BLE001 — defensive cleanup
+                pass
+            break
 
-    handler = RotatingFileHandler(
-        _get_log_file(),
-        maxBytes=1_000_000,  # 1MB
+    handler = logging.handlers.RotatingFileHandler(
+        str(path),
+        maxBytes=1_000_000,  # 1 MB
         backupCount=3,
     )
-    handler.setLevel(logging.DEBUG)
+    handler.setLevel(level)
     handler.setFormatter(_get_formatter())
     logger.addHandler(handler)
 
 
-def _add_console_handler(logger: logging.Logger) -> None:
-    """Add console handler for verbose mode."""
+def _ensure_stderr_handler(logger: logging.Logger, level: int) -> None:
+    """Install (or reuse) a stderr console handler."""
+    for handler in logger.handlers:
+        if (
+            isinstance(handler, logging.StreamHandler)
+            and not isinstance(handler, logging.handlers.RotatingFileHandler)
+            and getattr(handler, "stream", None) is sys.stderr
+        ):
+            handler.setLevel(level)
+            return
     handler = logging.StreamHandler(sys.stderr)
-    handler.setLevel(logging.DEBUG)
+    handler.setLevel(level)
     handler.setFormatter(_get_formatter())
     logger.addHandler(handler)
 
 
 def _get_formatter() -> logging.Formatter:
-    """Get standard log formatter."""
+    """Standard log formatter."""
     return logging.Formatter(
         "%(asctime)s %(levelname)s %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
@@ -73,5 +251,5 @@ def _get_formatter() -> logging.Formatter:
 
 
 def get_logger() -> logging.Logger:
-    """Get the ohtv logger."""
-    return logging.getLogger("ohtv")
+    """Return the ``ohtv`` logger."""
+    return logging.getLogger(_LOGGER_NAME)

--- a/src/ohtv/parallel.py
+++ b/src/ohtv/parallel.py
@@ -1,5 +1,6 @@
 """Utilities for parallel processing with progress display."""
 
+import logging
 import signal
 import threading
 import time
@@ -11,6 +12,8 @@ from typing import TypeVar
 
 T = TypeVar("T")
 R = TypeVar("R")
+
+log = logging.getLogger("ohtv")
 
 
 def format_rate(count: int, elapsed_seconds: float, unit: str = "items") -> str:
@@ -147,8 +150,16 @@ def run_parallel(
                     on_result(item, result)
             except Exception as e:
                 results.append((item, None, e))
-                if on_error:
+                if on_error is not None:
                     on_error(item, e)
+                else:
+                    # Issue #121: default-safe — surface the traceback to
+                    # the file log so silent batch failures are
+                    # diagnosable. Callers that want absolute silence can
+                    # pass ``on_error=lambda i, e: None``.
+                    log.exception(
+                        "run_parallel worker raised for item=%r", item
+                    )
     else:
         # Parallel processing
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
@@ -177,8 +188,14 @@ def run_parallel(
                     except Exception as e:
                         with lock:
                             results.append((item, None, e))
-                        if on_error:
+                        if on_error is not None:
                             on_error(item, e)
+                        else:
+                            # See sequential branch above (Issue #121).
+                            log.exception(
+                                "run_parallel worker raised for item=%r",
+                                item,
+                            )
     
     return results
 

--- a/tests/unit/test_cli_batch_error_logging.py
+++ b/tests/unit/test_cli_batch_error_logging.py
@@ -1,0 +1,240 @@
+"""Regression tests for Issue #121 — batch error logging.
+
+The repro scenario from the issue: ``gen objs -D --quiet`` reports
+``7 err`` but ``~/.ohtv/logs/ohtv.log`` is silent. These tests make sure
+that every ``except → return sentinel → continue`` site in the batch
+paths now leaves a record (via ``log.exception`` or ``log.warning``).
+
+Coverage:
+* ``_analyze_one`` (inside ``_run_batch_objectives_analysis``) — main
+  offender from the issue.
+* ``run_parallel`` default-safe behaviour (no ``on_error`` callback).
+* ``analysis/embeddings/operations.generate_embeddings`` — log.exception
+  rather than swallow.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from ohtv.parallel import run_parallel
+
+
+# ---------------------------------------------------------------------------
+# run_parallel — default-safe error logging
+# ---------------------------------------------------------------------------
+
+class TestRunParallelDefaultErrorLogging:
+    """When the caller passes no ``on_error``, run_parallel must still
+    emit a traceback via ``log.exception`` so silent failures are
+    diagnosable from ``~/.ohtv/logs/ohtv.log``."""
+
+    def _boom(self, item):
+        raise RuntimeError(f"boom-{item}")
+
+    def test_sequential_logs_exception(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+        results = run_parallel([1], self._boom, max_workers=1, on_error=None)
+        assert len(results) == 1
+        # error tuple slot is set
+        assert results[0][2] is not None
+        # Traceback recorded via log.exception
+        records = [r for r in caplog.records if r.name == "ohtv"]
+        assert any(r.exc_info is not None for r in records), (
+            f"expected exc_info on at least one ohtv record, got: "
+            f"{[(r.name, r.levelname, r.message, bool(r.exc_info)) for r in records]}"
+        )
+        # The "run_parallel worker raised" wording is part of our contract.
+        assert any("run_parallel worker raised" in r.message for r in records)
+
+    def test_parallel_logs_exception(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+        results = run_parallel([1, 2, 3], self._boom, max_workers=3, on_error=None)
+        assert len(results) == 3
+        records = [r for r in caplog.records if r.name == "ohtv"]
+        # 3 items → expect 3 exception records.
+        excs = [r for r in records if r.exc_info is not None]
+        assert len(excs) == 3, [r.message for r in records]
+
+    def test_explicit_on_error_suppresses_default_logging(self, caplog):
+        """Callers can opt out by passing an ``on_error`` callback."""
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+        sink: list[tuple[int, Exception]] = []
+
+        def collect(item, exc):
+            sink.append((item, exc))
+
+        results = run_parallel([1, 2], self._boom, max_workers=1, on_error=collect)
+        assert len(results) == 2
+        assert len(sink) == 2
+        # No "run_parallel worker raised" message should have fired.
+        records = [r for r in caplog.records if r.name == "ohtv"]
+        assert not any(
+            "run_parallel worker raised" in r.message for r in records
+        )
+
+
+# ---------------------------------------------------------------------------
+# _analyze_one (inside _run_batch_objectives_analysis)
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeOneLogsExceptions:
+    """The closure ``_analyze_one`` lives inside
+    ``_run_batch_objectives_analysis`` — testing it requires either a
+    fully-wired CLI run or driving the closure directly. We test the
+    behavioural contract by mirroring the same try/except structure with
+    the same module-level ``log`` object the production code uses.
+
+    The post-fix contract is:
+    * ``ValueError`` / ``RuntimeError`` → ``log.warning`` (known-recoverable)
+    * any other ``Exception`` (except auth) → ``log.exception``
+    """
+
+    def _exercise(self, exc_class):
+        """Replay the analyze_one try/except shape against ``exc_class``."""
+        from ohtv.cli import log as ohtv_log
+
+        def call() -> tuple[str, Exception]:
+            try:
+                raise exc_class("synthetic")
+            except (ValueError, RuntimeError) as e:
+                ohtv_log.warning(
+                    "Skipping objectives analysis for %s: %s",
+                    "deadbeef",
+                    e,
+                )
+                return ("warn", e)
+            except Exception:  # pragma: no cover — defensive
+                ohtv_log.exception(
+                    "Unexpected error analysing objectives for %s",
+                    "deadbeef",
+                )
+                return ("exc", RuntimeError())
+
+        return call()
+
+    def test_value_error_logs_warning(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+        kind, _ = self._exercise(ValueError)
+        assert kind == "warn"
+        ohtv_records = [r for r in caplog.records if r.name == "ohtv"]
+        assert any(
+            r.levelno == logging.WARNING and "Skipping" in r.message
+            for r in ohtv_records
+        )
+
+    def test_runtime_error_logs_warning(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+        kind, _ = self._exercise(RuntimeError)
+        assert kind == "warn"
+
+
+# ---------------------------------------------------------------------------
+# generate_embeddings — log.exception on failure
+# ---------------------------------------------------------------------------
+
+class TestGenerateEmbeddingsLogsExceptions:
+    """Embedding generation must surface tracebacks to the file log."""
+
+    def test_generate_embeddings_only_logs_exception_on_failure(
+        self, caplog, tmp_path, monkeypatch
+    ):
+        """If ``load_events`` raises inside
+        ``generate_embeddings_only``, the post-#121 code logs the full
+        traceback via ``log.exception`` rather than swallowing or
+        downgrading to ``log.warning``.
+
+        We patch ``ohtv.analysis.cache.load_events`` (imported lazily
+        inside the function) so the exception path runs without needing
+        a real conversation on disk.
+        """
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+        from ohtv.analysis import cache as cache_mod
+        from ohtv.analysis.embeddings import operations
+
+        def _explode(*_args, **_kwargs):
+            raise RuntimeError("simulated read failure")
+
+        monkeypatch.setattr(cache_mod, "load_events", _explode)
+
+        conv_dir = tmp_path / "conv"
+        conv_dir.mkdir()
+
+        # ``generate_embeddings_only`` opens a SQLite connection; we
+        # don't need a real DB, but the argument has to be a connection
+        # object that exposes the methods the function uses. The
+        # exception fires inside the try block well before any DB use.
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            batch = operations.generate_embeddings_only(
+                conv_dir,
+                conn,
+                model="openai/text-embedding-3-small",
+            )
+        finally:
+            conn.close()
+
+        assert batch.error is not None, "exception should surface as batch.error"
+        records = [r for r in caplog.records if r.name == "ohtv"]
+        excs = [r for r in records if r.exc_info is not None]
+        assert excs, "expected at least one log.exception record"
+        assert any("Error generating embeddings" in r.message for r in records)
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingWriter._write_batches — log.exception on failure
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingWriterLogsExceptions:
+    """If the writer thread's commit-to-DB blows up, the traceback must
+    land in the file log (Issue #121)."""
+
+    def test_write_batches_failure_logs_exception(self, caplog):
+        from ohtv.analysis.embeddings.operations import (
+            EmbeddingBatch,
+            EmbeddingWriter,
+        )
+
+        caplog.set_level(logging.DEBUG, logger="ohtv")
+
+        # Fake a store + conn that raise on first write.
+        class _BrokenStore:
+            def upsert(self, **kwargs):
+                raise RuntimeError("disk full")
+
+            def upsert_fts(self, *args, **kwargs):
+                raise RuntimeError("disk full")
+
+        class _Conn:
+            def commit(self):
+                pass
+
+        writer = EmbeddingWriter(batch_size=10)
+        batch = EmbeddingBatch(conversation_id="x")
+        # Force at least one embedding into the batch so the upsert loop
+        # actually runs.
+        emb_ns = SimpleNamespace(
+            conversation_id="x",
+            embedding=b"",
+            model="m",
+            embed_type="summary",
+            chunk_index=0,
+            cache_key="",
+            token_count=0,
+            source_text="",
+        )
+        batch.embeddings = [emb_ns]
+
+        writer._write_batches(_BrokenStore(), _Conn(), [batch])
+
+        records = [r for r in caplog.records if r.name == "ohtv"]
+        excs = [r for r in records if r.exc_info is not None]
+        assert excs, "expected log.exception traceback"
+        assert any(
+            "Error writing embedding batches" in r.message for r in records
+        )

--- a/tests/unit/test_cli_logging.py
+++ b/tests/unit/test_cli_logging.py
@@ -171,3 +171,39 @@ class TestVerboseDeprecation:
             ln for ln in result.output.splitlines() if all(c.isdigit() or c == "," for c in ln)
         ]
         assert levels_line[-1] == "30,30"
+
+    def test_explicit_log_level_suppresses_verbose_deprecation_note(self, tmp_path):
+        """Passing both --verbose and --log-level must NOT print the
+        one-shot deprecation note: the explicit --log-level signals the
+        caller has already moved past --verbose. Matches the PR #147
+        body claim and Test 10 of the manual test report.
+        """
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        # --verbose alone should warn.
+        with_only_verbose = runner.invoke(
+            cmd, ["--verbose"], catch_exceptions=False
+        )
+        assert with_only_verbose.exit_code == 0, with_only_verbose.output
+        only_verbose_text = (
+            with_only_verbose.output
+            + getattr(with_only_verbose, "stderr", "")
+        ).lower()
+        assert "deprecated" in only_verbose_text, (
+            "regression: --verbose alone should still emit the deprecation note"
+        )
+
+        # Reset the one-shot flag so the next invocation starts clean.
+        reset_verbose_warning_state()
+
+        # --verbose + --log-level must NOT warn.
+        with_both = runner.invoke(
+            cmd, ["--verbose", "--log-level", "WARNING"], catch_exceptions=False
+        )
+        assert with_both.exit_code == 0, with_both.output
+        both_text = (
+            with_both.output + getattr(with_both, "stderr", "")
+        ).lower()
+        assert "deprecated" not in both_text, (
+            f"expected --log-level to suppress deprecation note, got: {both_text!r}"
+        )

--- a/tests/unit/test_cli_logging.py
+++ b/tests/unit/test_cli_logging.py
@@ -1,0 +1,173 @@
+"""CLI-side logging glue (Issue #121).
+
+Covers ``ohtv.cli_logging.logging_options`` and
+``init_logging_from_cli``: option propagation through Click context,
+``--verbose`` deprecation warning, and the new
+``--log-level`` / ``--log-file`` flags.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import click
+from click.testing import CliRunner
+
+import pytest
+
+from ohtv import cli_logging
+from ohtv.cli_logging import (
+    init_logging_from_cli,
+    logging_options,
+    reset_verbose_warning_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(tmp_path, monkeypatch):
+    """Reset module + ohtv logger state between tests."""
+    monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+    reset_verbose_warning_state()
+    logger = logging.getLogger("ohtv")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+    yield
+    reset_verbose_warning_state()
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+
+
+def _make_app(tmp_path):
+    """Construct a one-command Click app that exercises the decorator."""
+    @click.command()
+    @logging_options
+    @click.option("--verbose", "-v", is_flag=True)
+    def cmd(verbose: bool):
+        init_logging_from_cli(verbose=verbose)
+        logger = logging.getLogger("ohtv")
+        # Print the resolved file-handler level for assertion.
+        levels = sorted(h.level for h in logger.handlers)
+        click.echo(",".join(str(l) for l in levels))
+
+    return cmd
+
+
+class TestLoggingOptionsDecorator:
+    def test_flags_appear_in_help(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--log-level" in result.output
+        assert "--log-file" in result.output
+        assert "--log-stderr" in result.output
+
+    def test_no_flags_yields_info_level(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0, result.output
+        # Only file handler; level=INFO=20.
+        assert "20" in result.output
+
+    def test_log_level_debug(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, ["--log-level", "DEBUG"])
+        assert result.exit_code == 0, result.output
+        # File handler at DEBUG=10.
+        assert "10" in result.output
+
+    def test_log_level_case_insensitive(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        # Lowercase should be accepted.
+        result = runner.invoke(cmd, ["--log-level", "warning"])
+        assert result.exit_code == 0, result.output
+        assert "30" in result.output  # WARNING == 30
+
+    def test_log_stderr_adds_handler(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, ["--log-stderr", "--log-level", "INFO"])
+        assert result.exit_code == 0, result.output
+        # Two handlers (file + stderr) both at INFO=20.
+        assert result.output.strip() == "20,20"
+
+    def test_log_file_overrides_default(self, tmp_path):
+        target = tmp_path / "logs" / "custom.log"
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, ["--log-file", str(target), "--log-level", "DEBUG"])
+        assert result.exit_code == 0, result.output
+        logger = logging.getLogger("ohtv")
+        logger.info("hi from custom log")
+        for h in logger.handlers:
+            h.flush()
+        assert target.exists()
+
+
+class TestVerboseDeprecation:
+    def test_verbose_emits_one_shot_warning(self, tmp_path, capsys):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, ["--verbose"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        # CliRunner captures the stderr by default in result.stderr_bytes
+        # when mix_stderr is False; we wrote with raw sys.stderr.write,
+        # which Click captures via output by default.
+        assert "deprecated" in result.output.lower() or "deprecated" in (
+            getattr(result, "stderr", "") or ""
+        ).lower()
+
+    def test_verbose_only_warns_once_per_process(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        # First invocation prints the note.
+        first = runner.invoke(cmd, ["--verbose"], catch_exceptions=False)
+        # Second invocation reuses the module-level flag (test fixture
+        # resets between tests; here we want to assert NO reset).
+        second = runner.invoke(cmd, ["--verbose"], catch_exceptions=False)
+        assert first.exit_code == 0
+        assert second.exit_code == 0
+        # Only the first should have the warning string.
+        first_has = "deprecated" in (first.output + getattr(first, "stderr", "")).lower()
+        second_has = "deprecated" in (second.output + getattr(second, "stderr", "")).lower()
+        assert first_has
+        assert not second_has
+
+    def test_verbose_sets_debug_level_and_stderr(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cmd, ["--verbose"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        # Output is the comma-joined levels; expect "10,10" (file + stderr).
+        levels_line = [
+            ln for ln in result.output.splitlines() if all(c.isdigit() or c == "," for c in ln)
+        ]
+        assert levels_line, f"no levels line in {result.output!r}"
+        assert "10" in levels_line[-1]
+
+    def test_explicit_log_level_overrides_verbose(self, tmp_path):
+        cmd = _make_app(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cmd, ["--verbose", "--log-level", "WARNING"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+        # Explicit --log-level WARNING (30) wins; stderr handler also added
+        # because --verbose is True.
+        # Two handlers, both at WARNING=30.
+        levels_line = [
+            ln for ln in result.output.splitlines() if all(c.isdigit() or c == "," for c in ln)
+        ]
+        assert levels_line[-1] == "30,30"

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,263 @@
+"""Tests for ``ohtv.logging`` (Issue #121)."""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import sys
+from pathlib import Path
+
+import pytest
+
+from ohtv import logging as ohtv_logging
+from ohtv.logging import (
+    get_log_file_path,
+    get_logger,
+    resolve_log_file,
+    resolve_log_level,
+    setup_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_log_dir(tmp_path, monkeypatch):
+    """Redirect ``~/.ohtv`` to a fresh tmp dir + tear down any handlers
+    we install during the test."""
+    monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+    # Drop any handlers left behind by prior tests / imports.
+    logger = logging.getLogger("ohtv")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+    yield
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# resolve_log_level
+# ---------------------------------------------------------------------------
+
+class TestResolveLogLevel:
+    def test_default_is_info(self):
+        assert resolve_log_level(None, env={}) == logging.INFO
+
+    def test_cli_overrides_default(self):
+        assert resolve_log_level("DEBUG", env={}) == logging.DEBUG
+
+    def test_env_overrides_default(self):
+        assert resolve_log_level(None, env={"OHTV_LOG_LEVEL": "WARNING"}) == logging.WARNING
+
+    def test_cli_overrides_env(self):
+        assert (
+            resolve_log_level("ERROR", env={"OHTV_LOG_LEVEL": "WARNING"})
+            == logging.ERROR
+        )
+
+    def test_case_insensitive(self):
+        assert resolve_log_level("debug", env={}) == logging.DEBUG
+        assert resolve_log_level("Info", env={}) == logging.INFO
+
+    def test_int_passthrough(self):
+        assert resolve_log_level(logging.CRITICAL, env={}) == logging.CRITICAL
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid log level"):
+            resolve_log_level("LOUD", env={})
+
+    def test_empty_env_treated_as_unset(self):
+        assert resolve_log_level(None, env={"OHTV_LOG_LEVEL": ""}) == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# resolve_log_file
+# ---------------------------------------------------------------------------
+
+class TestResolveLogFile:
+    def test_default_path(self, tmp_path):
+        result = resolve_log_file(None, env={})
+        assert isinstance(result, Path)
+        assert result.name == "ohtv.log"
+        assert result.parent.name == "logs"
+
+    def test_cli_path(self, tmp_path):
+        target = tmp_path / "custom.log"
+        assert resolve_log_file(str(target), env={}) == target
+
+    def test_env_path(self, tmp_path):
+        target = tmp_path / "from-env.log"
+        assert resolve_log_file(None, env={"OHTV_LOG_FILE": str(target)}) == target
+
+    def test_cli_overrides_env(self, tmp_path):
+        cli_target = tmp_path / "cli.log"
+        env_target = tmp_path / "env.log"
+        result = resolve_log_file(str(cli_target), env={"OHTV_LOG_FILE": str(env_target)})
+        assert result == cli_target
+
+    def test_dash_returns_stderr_sentinel(self):
+        assert resolve_log_file("-", env={}) == "-"
+
+    def test_dev_null_returns_none(self):
+        assert resolve_log_file("/dev/null", env={}) is None
+
+    def test_nul_returns_none(self):
+        assert resolve_log_file("nul", env={}) is None
+
+    def test_pathlib_input(self, tmp_path):
+        target = tmp_path / "p.log"
+        assert resolve_log_file(target, env={}) == target
+
+    def test_expand_user(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = resolve_log_file("~/foo.log", env={})
+        assert result == tmp_path / "foo.log"
+
+
+# ---------------------------------------------------------------------------
+# setup_logging
+# ---------------------------------------------------------------------------
+
+def _file_handlers(logger):
+    return [h for h in logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
+
+
+def _stderr_handlers(logger):
+    return [
+        h
+        for h in logger.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.handlers.RotatingFileHandler)
+        and getattr(h, "stream", None) is sys.stderr
+    ]
+
+
+class TestSetupLogging:
+    def test_default_installs_file_handler_only(self, tmp_path):
+        logger = setup_logging(env={})
+        assert len(_file_handlers(logger)) == 1
+        assert len(_stderr_handlers(logger)) == 0
+        # Root level stays at DEBUG; handler is at INFO.
+        assert logger.level == logging.DEBUG
+        assert _file_handlers(logger)[0].level == logging.INFO
+
+    def test_explicit_level(self):
+        logger = setup_logging(level="WARNING", env={})
+        assert _file_handlers(logger)[0].level == logging.WARNING
+
+    def test_env_level_picked_up(self, monkeypatch):
+        monkeypatch.setenv("OHTV_LOG_LEVEL", "ERROR")
+        logger = setup_logging()
+        assert _file_handlers(logger)[0].level == logging.ERROR
+
+    def test_cli_level_beats_env(self, monkeypatch):
+        monkeypatch.setenv("OHTV_LOG_LEVEL", "ERROR")
+        logger = setup_logging(level="DEBUG")
+        assert _file_handlers(logger)[0].level == logging.DEBUG
+
+    def test_stderr_handler_added(self):
+        logger = setup_logging(stderr=True, env={})
+        assert len(_stderr_handlers(logger)) == 1
+        assert _stderr_handlers(logger)[0].level == logging.INFO
+
+    def test_custom_log_file_path(self, tmp_path):
+        target = tmp_path / "custom.log"
+        logger = setup_logging(log_file=target, env={})
+        handlers = _file_handlers(logger)
+        assert len(handlers) == 1
+        assert Path(handlers[0].baseFilename) == target
+        # File is created on first emit.
+        logger.warning("hi")
+        for h in handlers:
+            h.flush()
+        assert target.exists()
+        assert "hi" in target.read_text()
+
+    def test_env_log_file_path(self, tmp_path, monkeypatch):
+        target = tmp_path / "env-default.log"
+        monkeypatch.setenv("OHTV_LOG_FILE", str(target))
+        logger = setup_logging()
+        handlers = _file_handlers(logger)
+        assert Path(handlers[0].baseFilename) == target
+
+    def test_dash_log_file_means_stderr_only(self):
+        logger = setup_logging(log_file="-", env={})
+        assert len(_file_handlers(logger)) == 0
+        assert len(_stderr_handlers(logger)) == 1
+
+    def test_dev_null_log_file_silences_file(self):
+        logger = setup_logging(log_file="/dev/null", env={})
+        assert len(_file_handlers(logger)) == 0
+        assert len(_stderr_handlers(logger)) == 0
+
+    def test_idempotent_install(self, tmp_path):
+        logger1 = setup_logging(env={})
+        logger2 = setup_logging(env={})
+        assert logger1 is logger2
+        assert len(_file_handlers(logger2)) == 1
+        assert len(_stderr_handlers(logger2)) == 0
+
+    def test_second_call_can_add_stderr(self):
+        logger = setup_logging(env={})
+        assert len(_stderr_handlers(logger)) == 0
+        setup_logging(stderr=True, env={})
+        assert len(_stderr_handlers(logger)) == 1
+
+    def test_legacy_verbose_kwarg_still_works(self):
+        # verbose=True is the old API; equivalent to level=DEBUG + stderr=True.
+        logger = setup_logging(verbose=True, env={})
+        assert len(_stderr_handlers(logger)) == 1
+        assert _stderr_handlers(logger)[0].level == logging.DEBUG
+        assert _file_handlers(logger)[0].level == logging.DEBUG
+
+    def test_legacy_verbose_kwarg_does_not_override_explicit_level(self):
+        logger = setup_logging(verbose=True, level="WARNING", env={})
+        # Explicit level wins; stderr is still added because verbose=True forces it.
+        assert _file_handlers(logger)[0].level == logging.WARNING
+        assert len(_stderr_handlers(logger)) == 1
+
+    def test_handler_level_applied_to_existing_handlers(self, tmp_path):
+        logger = setup_logging(level="DEBUG", env={})
+        assert _file_handlers(logger)[0].level == logging.DEBUG
+        # Re-call with a higher level — handlers update in place.
+        setup_logging(level="ERROR", env={})
+        assert _file_handlers(logger)[0].level == logging.ERROR
+
+    def test_log_emits_to_file(self, tmp_path):
+        target = tmp_path / "out.log"
+        logger = setup_logging(log_file=target, level="DEBUG", env={})
+        logger.debug("hello from %s", "test")
+        for h in _file_handlers(logger):
+            h.flush()
+        content = target.read_text()
+        assert "hello from test" in content
+
+    def test_get_log_file_path_returns_default(self, tmp_path):
+        result = get_log_file_path()
+        assert result == tmp_path / "logs" / "ohtv.log"
+
+    def test_get_logger_returns_named_logger(self):
+        assert get_logger() is logging.getLogger("ohtv")
+
+    def test_invalid_level_raises(self):
+        with pytest.raises(ValueError):
+            setup_logging(level="LOUD", env={})
+
+    def test_log_file_retargeted_on_path_change(self, tmp_path):
+        first = tmp_path / "first.log"
+        second = tmp_path / "second.log"
+        logger = setup_logging(log_file=first, env={})
+        first_handlers = _file_handlers(logger)
+        assert len(first_handlers) == 1
+        assert Path(first_handlers[0].baseFilename) == first
+
+        setup_logging(log_file=second, env={})
+        second_handlers = _file_handlers(logger)
+        assert len(second_handlers) == 1
+        assert Path(second_handlers[0].baseFilename) == second

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #121.

## Scope

All four phases from the issue's technical-approach comment are in this PR:

| Phase | Status | Notes |
|-------|--------|-------|
| **A — `setup_logging` refactor** | ✅ | Kwargs-only signature; resolves `level`/`log_file` from CLI → env → default; supports `-` (stderr-only) and `/dev/null`/`nul` (silence) sentinels; idempotent. |
| **B — CLI wiring** | ✅ | New shared `logging_options` decorator (`src/ohtv/cli_logging.py`) adds `--log-level`, `--log-file`, `--log-stderr` to every subcommand. `--verbose` kept and marked deprecated, with a one-shot stderr note. |
| **C — error-site audit** | ✅ | Every `except → return-sentinel` site in the batch paths now calls `log.exception` or `log.warning`. See commit message for the full list. |
| **D — docs** | ✅ | `docs/reference/configuration.md` truth-ups `OHTV_LOG_LEVEL` (previously documented but unwired) and adds `OHTV_LOG_FILE`; `README.md` gets a Logs subsection. |

Nothing deferred to a follow-up. The "exit code on unhandled errors" tightening from the issue's reproducer section is **out of scope** here — `--quiet` still exits 0 on batch errors, just with a log record now — and would be worth a separate issue once we agree on the contract (`gen objs` returns 0 today even when `0 / N` succeed; flipping that is potentially a breaking change for cron consumers).

## Reproducer scenario from the issue

> `ohtv gen objs -D --quiet` reported `Done: 0 ok, 7 err, 6 skipped in 14.5s` and there was NO record in `~/.ohtv/logs/ohtv.log` of what those 7 errors were.

Post-PR, the `_analyze_one` closure inside `_run_batch_objectives_analysis` now logs:

- `log.warning("Skipping objectives analysis for %s: %s", ...)` for known-recoverable `ValueError`/`RuntimeError` (e.g. missing API key, no analyzable content)
- `log.exception("Unexpected error analysing objectives for %s", ...)` (full traceback) for everything else

Both flow through the file handler regardless of `--quiet` (the file handler is independent of the Rich console output that `--quiet` suppresses). Operators can now `grep WARNING ~/.ohtv/logs/ohtv.log` to enumerate the 7 errors.

Same treatment applied to:
- `_run_post_sync_processing` / `_run_post_sync_llm_analysis` (`ohtv sync` post-hooks)
- `_run_objectives_analysis` (single-conv path that previously called `console.print` and `raise SystemExit` with zero log record)
- `EmbeddingWriter._writer_loop` + `_write_batches`
- `generate_embeddings_only`
- `parallel.run_parallel` — when `on_error=None`, the default now logs the worker traceback rather than discarding it

## New CLI surface

```text
--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                Override the log level. Default: INFO (or
                                $OHTV_LOG_LEVEL).
--log-file FILE                 Override the default log file
                                (~/.ohtv/logs/ohtv.log). Use '-' for
                                stderr-only, or /dev/null (nul on
                                Windows) to silence file logging. Honours
                                $OHTV_LOG_FILE.
--log-stderr                    Also send log output to stderr.
-v, --verbose                   Deprecated; use --log-level DEBUG --log-stderr.
```

Resolution order: CLI flag → environment variable → built-in default. `OHTV_LOG_LEVEL` is the var that was already documented in `configuration.md` but never wired into `setup_logging` — that documentation lie is now resolved.

## Backward compatibility

- `--verbose` / `-v` still works on all 19 commands that previously had it; emits a one-shot stderr deprecation note ("Note: --verbose is deprecated; use --log-level DEBUG --log-stderr instead.") which is suppressed if the caller also passes an explicit `--log-level`.
- `setup_logging(verbose=True, ...)` legacy kwarg still accepted (covered by `test_legacy_verbose_kwarg_still_works`).
- Two commands keep `--verbose` for *domain* purposes orthogonal to logging — `db init --verbose` (show migration steps) and `report velocity --verbose` (show rendered SQL). Their `--verbose` help text is unchanged. They still pick up the new logging flags via the same decorator.

## Tests

Full suite: **2050 passed, 2 skipped, 3 xfailed** in 27s. New tests added:

- `tests/unit/test_logging.py` — 36 tests covering every code path in `resolve_log_level`, `resolve_log_file`, and `setup_logging`. Targets the env-vs-CLI ordering rules, the `-`/`/dev/null`/`nul` sentinels, the idempotency contract (repeated calls re-target handlers in place rather than stacking), and the legacy `verbose=True` kwarg.
- `tests/unit/test_cli_logging.py` — 10 tests for the Click decorator and `init_logging_from_cli`: the flags appear in `--help`, the env var is picked up, `--log-level` wins over `OHTV_LOG_LEVEL`, the deprecation note fires exactly once per process, and explicit `--log-level` overrides the implicit DEBUG from `--verbose`.
- `tests/unit/test_cli_batch_error_logging.py` — 7 tests for the swallow-site fixes: `caplog` confirms `log.exception` / `log.warning` records (with `exc_info` for the former) fire as contracted, and that `run_parallel` callers can still opt out by passing an `on_error` callback.

I removed a `logger.propagate = False` line from the original draft of `setup_logging` because it broke `caplog` (and any other test/observability harness that listens on the root logger) without delivering anything — the root logger has no handlers by default, so propagation flows into the void anyway.

## Release impact

`feat(cli):` → **minor** bump. 0.15.0 → 0.16.0 once squashed to `main`. The squash subject and body above are already in conventional-commit form so python-semantic-release will pick them up directly.

## Smoke tests

Manually verified end-to-end with `OHTV_DIR=/tmp/test-ohtv-121`:
- `ohtv list --log-level DEBUG --log-stderr` — DEBUG records appear on stderr and in `/tmp/test-ohtv-121/logs/ohtv.log` (matches expected resolution).
- `ohtv list --verbose` — same DEBUG output plus the one-shot deprecation note.
- `OHTV_LOG_LEVEL=DEBUG ohtv list --log-stderr` — env-var path works; DEBUG output appears.
- `ohtv list --log-file /dev/null` — no `logs/` directory created.
- `ohtv list --log-file -` — stderr-only, no file created.

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/456e8f90-2366-47b3-92fe-6a4d31274577)