### PR TITLE
fix(reports): aggregate weekly-counts at root grain (#123)

### DIFF
--- a/src/ohtv/reports/weekly_counts.py
+++ b/src/ohtv/reports/weekly_counts.py
@@ -58,15 +58,46 @@ _DB_SOURCE_CLOUD = "cloud"
 
 
 # Pure SQL — bucketing happens in Python (see module docstring).
+#
+# Root-grain filter (issue #123): ``id = root_conversation_id``
+# restricts the result set to root conversations only. Once
+# sub-conversations are synced (issue #108 / migration 019), each
+# agent-delegated sub becomes its own row in ``conversations``;
+# without this predicate the ``cloud`` column over-counts by the
+# delegation rate. The root's own ``created_at`` already equals
+# ``MIN(created_at)`` across the subtree by construction (a sub
+# cannot exist before its parent), so a direct predicate is both
+# simpler and cheaper than going through the
+# ``conversations_by_root`` view, which is needed only by reports
+# that roll up quantitative subtree fields. The column is indexed
+# by migration 020 (``idx_conversations_root``).
 _WEEKLY_COUNTS_SQL = """
 SELECT created_at, source
 FROM conversations
 WHERE created_at IS NOT NULL
+  AND id = root_conversation_id
   AND (:since   IS NULL OR created_at >= :since)
   AND (:until   IS NULL OR created_at <  :until)
   AND (:source  IS NULL OR source = :source)
 ORDER BY created_at
 """
+
+
+def _assert_root_column_present(conn: sqlite3.Connection) -> None:
+    """Guard against running on a pre-migration-020 schema.
+
+    The report's count is fundamentally wrong without
+    ``root_conversation_id`` (it would over-count by the agent
+    delegation rate). Silently falling back to the legacy
+    "every row counts" query would just reintroduce the bug
+    this issue (#123) fixes, so we fail loudly instead.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(conversations)")}
+    if "root_conversation_id" not in cols:
+        raise RuntimeError(
+            "report weekly-counts requires migration 020; "
+            "run 'ohtv db scan' to apply pending migrations"
+        )
 
 
 @dataclass
@@ -126,6 +157,7 @@ def fetch_rows(
     """
     if conn.row_factory is None:
         conn.row_factory = sqlite3.Row
+    _assert_root_column_present(conn)
     cursor = conn.execute(
         _WEEKLY_COUNTS_SQL,
         {

--- a/tests/unit/reports/test_cli_weekly_counts.py
+++ b/tests/unit/reports/test_cli_weekly_counts.py
@@ -45,17 +45,25 @@ def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _seed_two_weeks(db_path: Path) -> None:
-    """Seed two cloud conversations in adjacent ISO weeks."""
+    """Seed two cloud conversations in adjacent ISO weeks.
+
+    Each row sets ``root_conversation_id = id`` so it survives the
+    root-grain filter added in issue #123. ``ConversationStore``
+    does this automatically in production; raw-SQL test seeds
+    have to do it explicitly.
+    """
     conn = sqlite3.connect(db_path)
     conn.execute(
-        "INSERT INTO conversations (id, location, created_at, source) "
-        "VALUES (?, ?, ?, ?)",
-        ("c1", "/tmp/c1", "2024-03-05T12:00:00Z", "cloud"),  # W10
+        "INSERT INTO conversations "
+        "(id, location, created_at, source, root_conversation_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("c1", "/tmp/c1", "2024-03-05T12:00:00Z", "cloud", "c1"),  # W10
     )
     conn.execute(
-        "INSERT INTO conversations (id, location, created_at, source) "
-        "VALUES (?, ?, ?, ?)",
-        ("c2", "/tmp/c2", "2024-03-12T12:00:00Z", "local"),  # W11
+        "INSERT INTO conversations "
+        "(id, location, created_at, source, root_conversation_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("c2", "/tmp/c2", "2024-03-12T12:00:00Z", "local", "c2"),  # W11
     )
     conn.commit()
     conn.close()

--- a/tests/unit/reports/test_weekly_counts.py
+++ b/tests/unit/reports/test_weekly_counts.py
@@ -12,6 +12,8 @@ import io
 import sqlite3
 from datetime import date, datetime, timezone
 
+import pytest
+
 from ohtv.reports.weekly_counts import (
     CSV_HEADER,
     WeeklyCountsReport,
@@ -33,12 +35,32 @@ def _insert_conv(
     *,
     created_at: str | None,
     source: str = "cloud",
+    parent_conversation_id: str | None = None,
+    root_conversation_id: str | None = None,
 ) -> None:
-    """Minimal conversations insert covering the columns this report touches."""
+    """Minimal conversations insert covering the columns this report touches.
+
+    Issue #123: ``parent_conversation_id`` / ``root_conversation_id``
+    let tests seed sub-conversation trees. When ``root_conversation_id``
+    is not passed, it defaults to ``conv_id`` (i.e., this row is its own
+    root), which preserves the pre-#123 behaviour of every existing
+    test seeding only roots.
+    """
+    if root_conversation_id is None:
+        root_conversation_id = conv_id
     conn.execute(
-        "INSERT INTO conversations (id, location, created_at, source) "
-        "VALUES (?, ?, ?, ?)",
-        (conv_id, f"/tmp/{conv_id}", created_at, source),
+        "INSERT INTO conversations "
+        "(id, location, created_at, source, "
+        " parent_conversation_id, root_conversation_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            conv_id,
+            f"/tmp/{conv_id}",
+            created_at,
+            source,
+            parent_conversation_id,
+            root_conversation_id,
+        ),
     )
     conn.commit()
 
@@ -328,3 +350,164 @@ def test_format_csv_empty_rows_emits_header_only() -> None:
     buf = io.StringIO()
     format_csv([], buf)
     assert buf.getvalue().splitlines() == ["week,cloud,cli,total"]
+
+
+# ---------------------------------------------------------------------------
+# T-A — issue #123 — root + 2 subs in same week count as 1
+# ---------------------------------------------------------------------------
+
+
+def test_root_with_two_subs_same_week_counts_one(conn: sqlite3.Connection) -> None:
+    """A root plus two agent-delegated subs in the same week → cloud=1.
+
+    Pre-#123, the query counted every row in ``conversations``, so a
+    root with two subs produced ``cloud=3``. With the root-grain
+    predicate the subs are filtered out at the SQL layer.
+    """
+    _insert_conv(conn, "root1", created_at="2024-03-05T10:00:00Z", source="cloud")
+    _insert_conv(
+        conn,
+        "sub1",
+        created_at="2024-03-05T11:00:00Z",
+        source="cloud",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    _insert_conv(
+        conn,
+        "sub2",
+        created_at="2024-03-05T12:00:00Z",
+        source="cloud",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    row = _row(report, "2024-W10")
+    assert row.cloud == 1
+    assert row.cli == 0
+    assert row.total == 1
+
+
+# ---------------------------------------------------------------------------
+# T-B — issue #123 — sub in a later week than its root does not appear
+# ---------------------------------------------------------------------------
+
+
+def test_sub_in_later_week_does_not_count(conn: sqlite3.Connection) -> None:
+    """Root in week N, sub in week N+1 → week N+1 has cloud=0.
+
+    The sub's later ``created_at`` would have created a phantom
+    second week before #123. With the predicate, only the root's
+    own week shows up in sparse output; ``include_empty`` exposes
+    week N+1 as a zero-row.
+    """
+    _insert_conv(conn, "root1", created_at="2024-03-05T10:00:00Z", source="cloud")
+    _insert_conv(
+        conn,
+        "sub1",
+        created_at="2024-03-12T10:00:00Z",
+        source="cloud",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    report = _aggregate(conn)
+    # Sparse output → only the root's week.
+    assert [r.week_iso for r in report.rows] == ["2024-W10"]
+    assert _row(report, "2024-W10").cloud == 1
+    # With include_empty + an explicit ``until`` anchoring the
+    # zero-fill range, week N+1 shows up as a zero-row. The sub is
+    # filtered out at the SQL layer, so its ``created_at`` cannot
+    # drive the zero-fill range on its own — the caller's
+    # ``until`` is what makes the empty week visible.
+    rows = fetch_rows(conn)
+    report_full = aggregate_weekly_counts(
+        rows,
+        include_empty=True,
+        until=datetime(2024, 3, 13, tzinfo=timezone.utc),
+    )
+    weeks = [r.week_iso for r in report_full.rows]
+    assert "2024-W11" in weeks
+    assert _row(report_full, "2024-W11").cloud == 0
+    assert _row(report_full, "2024-W11").cli == 0
+    assert _row(report_full, "2024-W11").total == 0
+
+
+# ---------------------------------------------------------------------------
+# T-C — issue #123 — 2-deep chain (grand-child) still counts one root
+# ---------------------------------------------------------------------------
+
+
+def test_two_deep_chain_counts_one_root(conn: sqlite3.Connection) -> None:
+    """root → sub → grand-sub all in the same week → cloud=1.
+
+    Verifies N-level chains roll up correctly: depth handling lives
+    entirely in #122's ``root_conversation_id`` column. The report
+    just consumes the denormalized value.
+    """
+    _insert_conv(conn, "root1", created_at="2024-03-05T10:00:00Z", source="cloud")
+    _insert_conv(
+        conn,
+        "sub1",
+        created_at="2024-03-05T11:00:00Z",
+        source="cloud",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    _insert_conv(
+        conn,
+        "grand1",
+        created_at="2024-03-05T12:00:00Z",
+        source="cloud",
+        parent_conversation_id="sub1",
+        root_conversation_id="root1",
+    )
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    assert _row(report, "2024-W10").cloud == 1
+    assert _row(report, "2024-W10").total == 1
+
+
+# ---------------------------------------------------------------------------
+# T-D — issue #123 — missing ``root_conversation_id`` column raises
+# ---------------------------------------------------------------------------
+
+
+def test_missing_root_column_raises_clear_error() -> None:
+    """A schema without ``root_conversation_id`` is a hard error.
+
+    Silently falling back to the legacy SQL would just reintroduce
+    the over-count bug this issue fixes, so :func:`fetch_rows`
+    explicitly checks for the column and raises ``RuntimeError``
+    with an actionable message.
+    """
+    bare = sqlite3.connect(":memory:")
+    bare.row_factory = sqlite3.Row
+    bare.execute(
+        "CREATE TABLE conversations "
+        "(id TEXT PRIMARY KEY, created_at TEXT, source TEXT)"
+    )
+    try:
+        with pytest.raises(RuntimeError, match="migration 020"):
+            fetch_rows(bare)
+    finally:
+        bare.close()
+
+
+# ---------------------------------------------------------------------------
+# T-E — issue #123 — single conversation (no subs) is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_single_root_no_subs_legacy_path_unchanged(conn: sqlite3.Connection) -> None:
+    """A single root with no subs counts as 1 — no behaviour change.
+
+    Belt-and-braces regression on the legacy path: the addition of
+    the root-grain predicate must not alter the count when there
+    are no sub-conversations to filter out.
+    """
+    _insert_conv(conn, "root1", created_at="2024-03-05T10:00:00Z", source="cloud")
+    report = _aggregate(conn)
+    assert len(report.rows) == 1
+    assert _row(report, "2024-W10").cloud == 1
+    assert _row(report, "2024-W10").total == 1


### PR DESCRIPTION
Fixes #123.

## What

Once sub-conversation sync (#108) and the `root_conversation_id` column (#122 / migration 020) landed, `ohtv report weekly-counts` started over-counting the `cloud` column by the agent delegation rate: every delegated sub became its own row in `conversations` and the report had no way to distinguish them from roots.

This PR adds a single SQL predicate to `_WEEKLY_COUNTS_SQL`:

```sql
AND id = root_conversation_id
```

Plus a column-presence guard at `fetch_rows` entry that raises a clear `RuntimeError("report weekly-counts requires migration 020; run 'ohtv db scan' to apply pending migrations")` if migration 020 hasn't run.

## Why direct predicate vs `conversations_by_root` view?

The view's value-add is roll-up of quantitative subtree fields (`SUM(event_count)`, `MIN/MAX` timestamps). This report only needs `created_at` and `source`. The root's own `created_at` already equals `MIN(created_at)` across its tree by construction (a sub cannot exist before its parent), so the direct predicate is the minimal, index-friendly fix. Per the issue body's explicit choice, the view remains the right surface for #124 (velocity), which DOES roll up subtree sums.

## Acceptance criteria

| AC | Status |
|---|---|
| Default counts roots only — one row per root per ISO week | ✅ |
| CSV header unchanged: `week,cloud,cli,total` | ✅ |
| T-A: 1 cloud root + 2 cloud subs same week → `cloud=1` | ✅ |
| T-B: root in week N + sub in week N+1 → week N+1 `cloud=0` | ✅ |
| T-C: 2-deep chain (root → sub → grand-sub) → `cloud=1` | ✅ |
| Missing-column error path: clear `RuntimeError` | ✅ (T-D) |
| No `--include-subs` flag | ✅ (not added) |

Plus T-E (single root, no subs) — belt-and-braces regression that the legacy path is unchanged.

## Files changed

| File | Change | Lines |
|---|---|---|
| `src/ohtv/reports/weekly_counts.py` | Add SQL predicate + `_assert_root_column_present` guard | ~30 |
| `tests/unit/reports/test_weekly_counts.py` | Extend `_insert_conv` helper + 5 new tests (T-A through T-E) | ~165 |
| `tests/unit/reports/test_cli_weekly_counts.py` | Update `_seed_two_weeks` raw-SQL helper to set `root_conversation_id = id` (matching what `ConversationStore.upsert` does in production) | ~12 |

## Out of scope (untouched)

- `aggregate_weekly_counts`, `format_csv`, `WeeklyCountsRow`, `WeeklyCountsReport`, `CSV_HEADER` — unchanged.
- AGENTS.md — #122 carries the durable concept note; #123 is just the first consumer.
- `docs/reference/database.md` — schema docs belong to #122.
- CLI flags on `ohtv report weekly-counts` — no `--include-subs` per the issue's explicit decision.

## Tests

```
tests/unit/reports/test_weekly_counts.py ..................   18 passed
tests/unit/reports/test_cli_weekly_counts.py ...........       8 passed
```

Full unit suite: 2033 passed / 2 skipped / 3 xfailed.

## Cross-references

- Per AGENTS.md item #29 (CSV column naming): the `cli` header stays in the CSV emitter; DB stores `source='local'`. Translation happens in exactly one place — the aggregator. No rename anywhere else.
- Per AGENTS.md item #32 (root-grain foundation): this is the first consumer of `root_conversation_id`. The COALESCE-protected column is populated at write time by `ConversationStore.upsert` / `record_cloud_download` (no per-caller resolution needed).
- Per AGENTS.md item #14 (ID normalization): no change — IDs stay dashless.
- Per AGENTS.md item #5 (UTC bin caveat): preserved — `test_naive_timestamp_treated_as_utc` regression intact.

---

This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford.

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e93754b0-bfc9-47c7-945b-9ec985893d70)