### PR TITLE
fix(reports): aggregate velocity at root grain (#124)

### DIFF
--- a/src/ohtv/reports/velocity.py
+++ b/src/ohtv/reports/velocity.py
@@ -65,9 +65,35 @@ from ohtv.analysis.periods import iterate_periods
 
 
 # Pure SQL query — Python performs ISO-week bucketing afterwards.
-# The DISTINCT sub-select collapses (created / pushed / merged) rows
-# for the same conversation against the same change_ref to one row,
-# which is the natural de-dup boundary the issue calls out.
+#
+# Root-grain dedup (issue #124): the DISTINCT sub-select is keyed on
+# ``(change_ref_id, root_conversation_id)`` — NOT
+# ``(change_ref_id, conversation_id)`` — and the outer
+# ``conversation_human_input`` join is keyed on the root's id, so
+# the human-input join only ever sees the root's row even when an
+# agent-delegated sub also contributed to the same PR.
+#
+# Why this matters: once sub-conversation sync (#108) + migration
+# 020 (#122) landed, a parent that delegates a sub task (e.g., the
+# sub runs ``git push`` against the parent's PR branch) produced two
+# ``conversation_contributions`` rows for one ``change_ref`` — one
+# for the root, one for the sub. Each one also had its own
+# ``conversation_human_input`` row. Pre-#124 the outer
+# ``GROUP BY cr.id`` summed both ``chi`` rows, inflating ``Words``
+# and ``Msgs`` by the sub's followup counts (the sub's
+# ``initial_prompt_words`` was already masked out by the
+# ``'automation'`` CASE branch, but ``followup_word_count`` and
+# ``followup_message_count`` slipped through).
+#
+# A ``WHERE`` predicate cannot fix this — the duplication is in the
+# join cardinality, not in the row set of ``conversations``. The
+# minimal fix is to substitute the join key from conversation grain
+# to root grain. Orphan contributions (a contributions row whose
+# ``conversation_id`` is not in ``conversations``) are dropped by
+# the ``INNER JOIN`` here, which matches the pre-#124 behaviour of
+# the outer ``LEFT JOIN`` returning NULL → 0 words for them.
+#
+# The column is indexed by migration 020 (``idx_conversations_root``).
 _VELOCITY_SQL = """
 SELECT
     cr.id           AS change_ref_id,
@@ -97,8 +123,11 @@ SELECT
 FROM change_refs cr
 JOIN repositories r ON r.id = cr.repo_id
 LEFT JOIN (
-    SELECT DISTINCT change_ref_id, conversation_id
-    FROM conversation_contributions
+    SELECT DISTINCT
+        cc.change_ref_id          AS change_ref_id,
+        c.root_conversation_id    AS conversation_id
+    FROM conversation_contributions cc
+    JOIN conversations c ON c.id = cc.conversation_id
 ) dcc ON dcc.change_ref_id = cr.id
 LEFT JOIN conversation_human_input chi
        ON chi.conversation_id = dcc.conversation_id
@@ -110,6 +139,24 @@ WHERE cr.status = 'merged'
 GROUP BY cr.id
 ORDER BY cr.merged_at
 """
+
+
+def _assert_root_column_present(conn: sqlite3.Connection) -> None:
+    """Guard against running on a pre-migration-020 schema.
+
+    The report's word/message counts are fundamentally wrong without
+    ``root_conversation_id`` (they would over-count by the agent
+    delegation rate — see issue #124). Silently falling back to the
+    legacy conversation-grain SQL would just reintroduce the bug
+    this issue fixes, so we fail loudly instead. Mirrors the guard
+    landed in :mod:`ohtv.reports.weekly_counts` (#123).
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(conversations)")}
+    if "root_conversation_id" not in cols:
+        raise RuntimeError(
+            "report velocity requires migration 020; "
+            "run 'ohtv db scan' to apply pending migrations"
+        )
 
 
 @dataclass
@@ -219,6 +266,7 @@ def fetch_raw_rows(
     # Bind on raw=None when the caller is dict-style only.
     if conn.row_factory is None:
         conn.row_factory = sqlite3.Row
+    _assert_root_column_present(conn)
     cursor = conn.execute(
         _VELOCITY_SQL,
         {"repo_id": repo_id, "since": since, "until": until},

--- a/tests/unit/reports/conftest.py
+++ b/tests/unit/reports/conftest.py
@@ -52,11 +52,33 @@ def seed_repo(
     return repo_id
 
 
-def seed_conversation(conn: sqlite3.Connection, conv_id: str) -> None:
-    """Insert a minimal conversations row."""
+def seed_conversation(
+    conn: sqlite3.Connection,
+    conv_id: str,
+    *,
+    parent_conversation_id: str | None = None,
+    root_conversation_id: str | None = None,
+) -> None:
+    """Insert a minimal conversations row.
+
+    Issue #124: ``parent_conversation_id`` / ``root_conversation_id``
+    let tests seed sub-conversation trees. When ``root_conversation_id``
+    is not passed, it defaults to ``conv_id`` (i.e., this row is its
+    own root), which preserves the pre-#124 behaviour of every
+    existing test seeding only roots.
+    """
+    if root_conversation_id is None:
+        root_conversation_id = conv_id
     conn.execute(
-        "INSERT INTO conversations (id, location) VALUES (?, ?)",
-        (conv_id, f"/tmp/{conv_id}"),
+        "INSERT INTO conversations "
+        "(id, location, parent_conversation_id, root_conversation_id) "
+        "VALUES (?, ?, ?, ?)",
+        (
+            conv_id,
+            f"/tmp/{conv_id}",
+            parent_conversation_id,
+            root_conversation_id,
+        ),
     )
     conn.commit()
 

--- a/tests/unit/reports/test_velocity.py
+++ b/tests/unit/reports/test_velocity.py
@@ -656,3 +656,333 @@ def test_aggregate_velocity_report_metadata(conn: sqlite3.Connection) -> None:
     assert report.metadata["raw_row_count"] == 1
     assert report.metadata["bucket_count"] == 1
     assert report.metadata["missing_loc_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #124 — root-grain dedup regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_root_plus_sub_same_pr_excludes_sub_words(conn: sqlite3.Connection) -> None:
+    """T-B — root + sub both contribute to same merged PR in the same week.
+
+    Pre-#124 the DISTINCT sub-select keyed on conversation grain, so the
+    outer ``GROUP BY cr.id`` summed both the root's and the sub's
+    ``conversation_human_input`` rows. The sub's
+    ``initial_prompt_words=80`` was masked by the ``'automation'`` CASE
+    branch, but ``followup_word_count=200`` and
+    ``followup_message_count=4`` slipped through, inflating ``Words``
+    to 250 and ``Msgs`` to 5. Post-#124 the DISTINCT sub-select keys on
+    root grain so only the root's ``chi`` row is joined, giving the
+    expected ``Words=50`` / ``Msgs=1``.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "root1")
+    seed_conversation(
+        conn,
+        "sub1",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=100,
+        lines_removed=20,
+    )
+    seed_contribution(conn, conversation_id="root1", change_ref_id=pr_id)
+    seed_contribution(conn, conversation_id="sub1", change_ref_id=pr_id)
+    seed_human_input(
+        conn,
+        conversation_id="root1",
+        initial_prompt_words=50,
+        initial_prompt_source="human",
+    )
+    seed_human_input(
+        conn,
+        conversation_id="sub1",
+        initial_prompt_words=80,
+        initial_prompt_source="automation",
+        followup_word_count=200,
+        followup_message_count=4,
+    )
+
+    report = aggregate_velocity(conn=conn)
+
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    # Words = root's only (50), NOT root + sub.followup_word_count (250).
+    assert row.human_words == 50
+    # Msgs = root's only (1), NOT root + sub.followup_message_count (5).
+    assert row.human_messages == 1
+    # LOC accounting is unchanged — the dedup is purely on the
+    # human-input join path.
+    assert row.lines_added == 100
+    assert row.lines_removed == 20
+    assert row.total_loc == 120
+    assert row.partial_loc is False
+    assert row.missing_loc_count == 0
+
+
+def test_root_plus_sub_cross_week_bucketed_by_merge(conn: sqlite3.Connection) -> None:
+    """T-C — root in week N, sub in week N+1, PR merged in week N+1.
+
+    Velocity buckets by ``merged_at`` (NOT by conversation
+    ``created_at``), so a sub created in a later week than the
+    root must NOT add a phantom second bucket. The single bucket
+    at week N+1 must hold the root's words exactly once.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "root1")
+    seed_conversation(
+        conn,
+        "sub1",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    # Merged in 2024-W11 (the sub's "week"); root's words count once.
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-12T12:00:00Z",  # ISO week 11 of 2024
+        lines_added=50,
+        lines_removed=10,
+    )
+    seed_contribution(conn, conversation_id="root1", change_ref_id=pr_id)
+    seed_contribution(conn, conversation_id="sub1", change_ref_id=pr_id)
+    seed_human_input(
+        conn,
+        conversation_id="root1",
+        initial_prompt_words=42,
+        initial_prompt_source="human",
+        followup_word_count=8,
+        followup_message_count=2,
+    )
+    seed_human_input(
+        conn,
+        conversation_id="sub1",
+        initial_prompt_words=300,
+        initial_prompt_source="automation",
+        followup_word_count=500,
+        followup_message_count=10,
+    )
+
+    report = aggregate_velocity(conn=conn)
+    assert [r.week for r in report.rows] == ["2024-W11"]
+    row = report.rows[0]
+    # Root only: 42 (initial) + 8 (followup).
+    assert row.human_words == 50
+    # Root only: 1 (initial) + 2 (followup).
+    assert row.human_messages == 3
+    # LOC unchanged.
+    assert row.lines_added == 50
+    assert row.lines_removed == 10
+
+
+def test_root_plus_sub_loc_accounting_unchanged(conn: sqlite3.Connection) -> None:
+    """T-D — LOC accounting (+Lines / -Lines / Total / partial_loc) is
+    unaffected by the root-grain dedup on the human-input join.
+
+    The fix is purely on the ``conversation_contributions`` ×
+    ``conversation_human_input`` join path. LOC is keyed off
+    ``change_refs`` and never touched the duplicated join, so we
+    explicitly assert it didn't move.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "root1")
+    seed_conversation(
+        conn,
+        "sub1",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    # Two merged PRs in the same week: one with LOC populated, one
+    # with LOC NULL → partial_loc must be True regardless of the
+    # human-input join shape.
+    pr1 = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=150,
+        lines_removed=30,
+    )
+    pr2 = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=2,
+        merged_at="2024-03-05T13:00:00Z",
+        lines_added=None,
+        lines_removed=None,
+    )
+    seed_contribution(conn, conversation_id="root1", change_ref_id=pr1)
+    seed_contribution(conn, conversation_id="sub1", change_ref_id=pr1)
+    seed_contribution(conn, conversation_id="root1", change_ref_id=pr2)
+    seed_human_input(
+        conn,
+        conversation_id="root1",
+        initial_prompt_words=10,
+        initial_prompt_source="human",
+    )
+    seed_human_input(
+        conn,
+        conversation_id="sub1",
+        initial_prompt_words=99,
+        initial_prompt_source="automation",
+        followup_word_count=99,
+        followup_message_count=9,
+    )
+
+    report = aggregate_velocity(conn=conn)
+    assert len(report.rows) == 1
+    row = report.rows[0]
+    # 2 merged PRs, only pr1 has LOC populated → partial_loc=True,
+    # missing_loc_count=1.
+    assert row.prs_merged == 2
+    assert row.lines_added == 150
+    assert row.lines_removed == 30
+    assert row.total_loc == 180
+    assert row.partial_loc is True
+    assert row.missing_loc_count == 1
+    # Sanity-check the words side too: root's input × 2 PRs (once
+    # per change_ref), sub excluded.
+    assert row.human_words == 20  # root counted on pr1 and pr2
+    assert row.human_messages == 2
+
+
+def test_two_deep_chain_excludes_both_subs(conn: sqlite3.Connection) -> None:
+    """T-E — root → sub1 → sub2 all contribute to same PR → root's words only.
+
+    Verifies N-level chains roll up correctly. Depth handling lives
+    entirely in #122's ``root_conversation_id`` denormalisation; the
+    velocity SQL just consumes the column.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "root1")
+    seed_conversation(
+        conn,
+        "sub1",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    seed_conversation(
+        conn,
+        "sub2",
+        parent_conversation_id="sub1",
+        root_conversation_id="root1",
+    )
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=200,
+        lines_removed=40,
+    )
+    seed_contribution(conn, conversation_id="root1", change_ref_id=pr_id)
+    seed_contribution(conn, conversation_id="sub1", change_ref_id=pr_id)
+    seed_contribution(conn, conversation_id="sub2", change_ref_id=pr_id)
+    seed_human_input(
+        conn,
+        conversation_id="root1",
+        initial_prompt_words=25,
+        initial_prompt_source="human",
+        followup_word_count=5,
+        followup_message_count=1,
+    )
+    seed_human_input(
+        conn,
+        conversation_id="sub1",
+        initial_prompt_words=100,
+        initial_prompt_source="automation",
+        followup_word_count=200,
+        followup_message_count=3,
+    )
+    seed_human_input(
+        conn,
+        conversation_id="sub2",
+        initial_prompt_words=100,
+        initial_prompt_source="automation",
+        followup_word_count=400,
+        followup_message_count=7,
+    )
+
+    report = aggregate_velocity(conn=conn)
+    row = report.rows[0]
+    # Root only: 25 + 5 = 30 words, 1 + 1 = 2 msgs.
+    assert row.human_words == 30
+    assert row.human_messages == 2
+    assert row.prs_merged == 1
+    assert row.lines_added == 200
+
+
+def test_sub_only_contribution_attributes_to_root(conn: sqlite3.Connection) -> None:
+    """Sub-only contribution path: only the sub appears in
+    ``conversation_contributions`` (the parent triggered the sub but
+    never pushed itself). Verify the root's words still attach to the
+    change_ref via the substituted join key.
+    """
+    repo_id = seed_repo(conn, canonical_url="https://github.com/x/y")
+    seed_conversation(conn, "root1")
+    seed_conversation(
+        conn,
+        "sub1",
+        parent_conversation_id="root1",
+        root_conversation_id="root1",
+    )
+    pr_id = seed_pr(
+        conn,
+        repo_id=repo_id,
+        pr_number=1,
+        merged_at="2024-03-05T12:00:00Z",
+        lines_added=80,
+        lines_removed=10,
+    )
+    # Only the sub contributes (e.g., the sub did the git push).
+    seed_contribution(conn, conversation_id="sub1", change_ref_id=pr_id)
+    seed_human_input(
+        conn,
+        conversation_id="root1",
+        initial_prompt_words=42,
+        initial_prompt_source="human",
+    )
+    seed_human_input(
+        conn,
+        conversation_id="sub1",
+        initial_prompt_words=999,
+        initial_prompt_source="automation",
+        followup_word_count=999,
+        followup_message_count=99,
+    )
+
+    report = aggregate_velocity(conn=conn)
+    row = report.rows[0]
+    # Sub's contribution gets mapped to the root, so the root's
+    # ``chi`` row is what the outer join picks up.
+    assert row.human_words == 42
+    assert row.human_messages == 1
+
+
+def test_missing_root_column_raises_clear_error() -> None:
+    """T-F — a schema without ``root_conversation_id`` is a hard error.
+
+    Silently falling back to the legacy conversation-grain SQL would
+    just reintroduce the over-count bug this issue fixes, so
+    :func:`fetch_raw_rows` explicitly checks for the column and
+    raises ``RuntimeError`` with an actionable message.
+    """
+    bare = sqlite3.connect(":memory:")
+    bare.row_factory = sqlite3.Row
+    # Minimal conversations table without ``root_conversation_id``.
+    bare.execute(
+        "CREATE TABLE conversations "
+        "(id TEXT PRIMARY KEY, created_at TEXT, source TEXT)"
+    )
+    try:
+        with pytest.raises(RuntimeError, match="migration 020"):
+            fetch_raw_rows(bare)
+    finally:
+        bare.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.15.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #124.

## Problem

After sub-conversation sync (#108) + migration 020 (#122) landed, `ohtv report velocity` double-counted human input when an agent-delegated sub contributed to the same merged PR as its parent.

The pre-#124 `_VELOCITY_SQL` `DISTINCT` sub-select keyed on `(change_ref_id, conversation_id)`. When the agent delegated a sub task and the sub also pushed to the parent's PR branch, root + sub each carried their own `conversation_human_input` row through the outer join. The sub's `initial_prompt_words` was masked by the `'automation'` CASE branch, but `followup_word_count` and `followup_message_count` slipped through, inflating `Words` and `Msgs` by the sub's contribution.

LOC accounting was **not** affected — LOC is keyed off `change_refs`, not conversations.

## Fix

A `WHERE` predicate (like #123 used for `weekly-counts`) cannot fix this — the duplication is in the join cardinality, not in the `conversations` row set. The minimal fix substitutes the DISTINCT key from conversation grain to root grain by `INNER JOIN`-ing `conversations` into the sub-select:

```sql
LEFT JOIN (
    SELECT DISTINCT
        cc.change_ref_id          AS change_ref_id,
        c.root_conversation_id    AS conversation_id
    FROM conversation_contributions cc
    JOIN conversations c ON c.id = cc.conversation_id
) dcc ON dcc.change_ref_id = cr.id
LEFT JOIN conversation_human_input chi
       ON chi.conversation_id = dcc.conversation_id
```

This collapses (root+sub, same PR) to one row per change_ref, and because `dcc.conversation_id` is now the root's id, the outer `LEFT JOIN` to `conversation_human_input` only ever sees the root's row even if the sub has its own.

Orphan contributions (a `conversation_contributions` row whose `conversation_id` is not in `conversations`) are dropped by the new `INNER JOIN`, matching the pre-#124 behaviour of the outer `LEFT JOIN` returning NULL → 0 words for them. No regression.

Also adds `_assert_root_column_present` guard at `fetch_raw_rows` entry that raises `RuntimeError("report velocity requires migration 020; run 'ohtv db scan' to apply pending migrations")` if migration 020 hasn't been applied. Mirrors the guard #123 landed for `weekly_counts`.

## Files

- `src/ohtv/reports/velocity.py` — rewrite the DISTINCT sub-select; add `_assert_root_column_present` guard.
- `tests/unit/reports/conftest.py` — extend `seed_conversation` helper with `parent_conversation_id` / `root_conversation_id` kwargs defaulting to self-root (matches #123's `_insert_conv` shape).
- `tests/unit/reports/test_velocity.py` — 6 new regression tests (T-A through T-F).

## Test coverage

| Test | Maps to AC |
|---|---|
| `test_root_plus_sub_same_pr_excludes_sub_words` | Words = root only; Msgs = root only; LOC unchanged |
| `test_root_plus_sub_cross_week_bucketed_by_merge` | Cross-week — bucket by merged_at, root's words once |
| `test_root_plus_sub_loc_accounting_unchanged` | LOC math + partial_loc unaffected by dedup |
| `test_two_deep_chain_excludes_both_subs` | 2-deep chain (root → sub1 → sub2) → root only |
| `test_sub_only_contribution_attributes_to_root` | Sub-only contribution maps to root's `chi` row |
| `test_missing_root_column_raises_clear_error` | Guard raises `RuntimeError("migration 020")` |

Existing 27 velocity tests + 81 total reports tests pass unchanged.

```
$ uv run python -m pytest tests/unit/reports/test_velocity.py -v
============================== 33 passed in 2.04s ==============================

$ uv run python -m pytest tests/unit -q
2039 passed, 2 skipped, 3 xfailed in 27.35s
```

## Acceptance criteria

- [x] `Words` and `Words/LOC` for a `change_ref` touched by root + sub = root only
- [x] `Msgs` de-duped by root
- [x] LOC accounting (`+Lines`, `-Lines`, `Total`, `partial_loc`) unchanged
- [x] Cross-week case: root in N, sub in N+1, merged in N+1 → words count toward N+1 once
- [x] Existing tests pass unchanged
- [x] New regression tests added
- [x] Guard raises clear error if migration 020 not applied

## Out of scope

- Per-conversation tables stay at conversation grain (no schema changes)
- LOC accounting & `partial_loc` semantics (#103)
- `initial_prompt_source = 'unknown'` policy (#83) — #124 is defense-in-depth against it
- A `--include-subs` debug flag for velocity (has no semantically coherent meaning here)

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2a022b37-e3ae-4d31-8c16-fcfd0ed02c09)