### PR TITLE
feat(rag): cite root_conversation_id in ask/search results (#128)

### DIFF
--- a/src/ohtv/analysis/rag.py
+++ b/src/ohtv/analysis/rag.py
@@ -96,8 +96,17 @@ class ConversationSource:
 
 @dataclass
 class ContextChunk:
-    """A chunk of context retrieved for RAG."""
+    """A chunk of context retrieved for RAG.
+
+    Issue #128: ``root_conversation_id`` is the per-#122 (migration 020)
+    root of the parent chain for this chunk's source conversation. For
+    standalone conversations it equals ``conversation_id``. The
+    render-layer citation pipeline groups by this field so users see
+    one citation per *user-intent unit* (root) instead of one per
+    delegated sub-conversation.
+    """
     conversation_id: str
+    root_conversation_id: str
     title: str
     embed_type: str
     source_text: str
@@ -220,6 +229,29 @@ def _get_conversation_source(
         return None
 
 
+def _assert_root_column_present(conn) -> None:
+    """Guard against running on a pre-migration-020 schema.
+
+    Issue #128: the RAG citation-dedup pipeline collapses chunks by
+    ``root_conversation_id`` (added in migration 020 — see #122).
+    Silently falling back to ``conversation_id`` here would reintroduce
+    the very bug this fix closes ("citations point at sub-conversation
+    IDs the user doesn't recognize"), so we fail loudly instead.
+
+    Called once at the entry of :meth:`RAGRetriever.retrieve` and
+    :meth:`RAGAnswerer.answer_question` — runtime, not import — so
+    ``import ohtv.analysis.rag`` stays cheap and DB-free for tests
+    that don't touch retrieval.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(conversations)")}
+    if "root_conversation_id" not in cols:
+        raise RuntimeError(
+            "RAG citation dedup requires migration 020 "
+            "(root_conversation_id column). Run 'ohtv' once to trigger "
+            "ensure_db_ready(), or 'ohtv db scan' to apply pending migrations."
+        )
+
+
 def _results_to_context_chunks(
     results,
     conv_store,
@@ -228,7 +260,14 @@ def _results_to_context_chunks(
     repo_store,
     cloud_base_url: str,
 ) -> list[ContextChunk]:
-    """Convert embedding search results to ContextChunk objects with full metadata."""
+    """Convert embedding search results to ContextChunk objects with full metadata.
+
+    Issue #128: populates ``root_conversation_id`` from
+    ``Conversation.root_conversation_id`` (migration 020). When the
+    column is NULL (FS-only fallback, or pre-backfill state) or the
+    conversation isn't in the DB, the field falls back to the chunk's
+    own ``conversation_id`` so standalone-conv semantics are preserved.
+    """
     chunks = []
     for r in results:
         conv = conv_store.get(r.conversation_id)
@@ -236,6 +275,15 @@ def _results_to_context_chunks(
         created_at = conv.created_at if conv else None
         summary = conv.summary if conv else None
         conv_source = conv.source if conv else "local"
+        # Issue #128: root id always populated. For standalones,
+        # migration 020's backfill sets root = id. For subs, it walks
+        # parent_conversation_id to the top. Falls back to self-id when
+        # the DB row is missing or the column is NULL (defensive).
+        root_id = (
+            conv.root_conversation_id
+            if conv and conv.root_conversation_id
+            else r.conversation_id
+        )
         source = _get_conversation_source(
             r.conversation_id, conv_store, link_store, ref_store, repo_store, cloud_base_url
         )
@@ -243,6 +291,7 @@ def _results_to_context_chunks(
 
         chunks.append(ContextChunk(
             conversation_id=r.conversation_id,
+            root_conversation_id=root_id,
             title=title,
             embed_type=r.embed_type,
             source_text=r.source_text,
@@ -307,6 +356,9 @@ class RAGRetriever:
         import time
         from ohtv.analysis.embeddings import get_embedding
 
+        # Issue #128: fail loudly if the schema is pre-migration-020.
+        _assert_root_column_present(self.conv_store.conn)
+
         # Extract temporal filter if enabled and no explicit dates provided
         temporal_applied = False
         search_query = question
@@ -370,7 +422,10 @@ class RAGRetriever:
         # Sort chunks: group by conversation, then by embed_type, then by chunk_index
         context_chunks.sort(key=lambda c: (c.conversation_id, c.embed_type, c.chunk_index))
 
-        source_ids = {c.conversation_id for c in context_chunks}
+        # Issue #128: source IDs are roots, not raw conversation IDs.
+        # Sub-conversations roll up to their root so the caller sees one
+        # citation per user-intent unit.
+        source_ids = {c.root_conversation_id for c in context_chunks}
 
         return RAGRetrievalResult(
             context_chunks=context_chunks,
@@ -469,7 +524,10 @@ class RAGAnswerer:
             ValueError: If no relevant context is found
         """
         import time
-        
+
+        # Issue #128: fail loudly if the schema is pre-migration-020.
+        _assert_root_column_present(self.conv_store.conn)
+
         # Extract temporal filter if enabled and no explicit dates provided
         temporal_applied = False
         search_query = question
@@ -514,8 +572,9 @@ class RAGAnswerer:
         answer, context_tokens, total_tokens, cost = self._generate_answer(question, context_chunks)
         gen_time = time.perf_counter() - gen_start
         
-        source_ids = {c.conversation_id for c in context_chunks}
-        
+        # Issue #128: source IDs are roots, not raw conversation IDs.
+        source_ids = {c.root_conversation_id for c in context_chunks}
+
         # Aggregate refs from all source conversations
         all_repos: dict[str, RepoInfo] = {}
         all_prs: dict[str, RefInfo] = {}
@@ -631,12 +690,21 @@ class RAGAnswerer:
         return "\n".join(context_parts)
     
     def _format_chunk_header(self, chunk: ContextChunk, index: int) -> str:
-        """Format the header line for a context chunk."""
+        """Format the header line for a context chunk.
+
+        Issue #128: cites the **root** conversation ID as the canonical
+        ``Conversation ID:`` so the LLM cites root IDs in its answer
+        text (the user's mental model). When the chunk came from a
+        delegated sub, append a ``(via sub: <hex8>)`` annotation so the
+        chunk-grain truth is still visible.
+        """
         header = f"[Source {index}: {chunk.title}"
         if chunk.created_at:
             header += f" ({self._format_age(chunk.created_at)})"
         header += f" - relevance: {chunk.score:.0%}]"
-        header += f"\nConversation ID: {chunk.conversation_id}"
+        header += f"\nConversation ID: {chunk.root_conversation_id}"
+        if chunk.conversation_id != chunk.root_conversation_id:
+            header += f" (via sub: {chunk.conversation_id[:8]})"
         if chunk.display_url:
             header += f"\nURL: {chunk.display_url}"
         return header

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -2918,16 +2918,19 @@ def search(
         start_time = time.perf_counter()
         
         if exact:
-            # FTS5 keyword search
-            raw_results = embed_store.search_fts(query, limit=limit)
-            # Convert to have consistent interface
+            # FTS5 keyword search.
+            # Issue #128: over-fetch so the root-dedup below has
+            # headroom (same rationale as the semantic path).
+            raw_results = embed_store.search_fts(query, limit=limit * 3)
+            # Convert to a mutable-attr surface so the dedup helper
+            # can rewrite ``conversation_id`` and ``rank`` in place.
             results = [
-                type("Result", (), {
-                    "conversation_id": r.conversation_id,
-                    "score": r.score,
-                    "rank": r.rank,
-                    "best_match_type": "keyword",
-                })()
+                _SearchResultRow(
+                    conversation_id=r.conversation_id,
+                    score=r.score,
+                    rank=r.rank,
+                    best_match_type="keyword",
+                )
                 for r in raw_results
             ]
             search_type = "keyword"
@@ -2942,16 +2945,19 @@ def search(
                 console.print("[dim]Make sure LLM_API_KEY is set.[/dim]")
                 raise SystemExit(1)
             
-            # Use aggregated search (best match per conversation)
+            # Use aggregated search (best match per conversation).
+            # Issue #128: over-fetch so the post-aggregation root-dedup
+            # below has headroom to collapse subtree siblings while
+            # still hitting the requested ``limit`` after dedup.
             results = embed_store.search_conversations(
                 query_embedding,
-                limit=limit,
+                limit=limit * 3,
                 min_score=min_score,
             )
             search_type = "semantic"
-        
+
         search_time = time.perf_counter() - start_time
-        
+
         # Filter by date if specified
         if since_date:
             since = _parse_date_option(since_date)
@@ -2962,8 +2968,19 @@ def search(
                     if conv and conv.created_at and conv.created_at >= since:
                         filtered_results.append(r)
                 results = filtered_results
-        
-        # Load conversation metadata for display
+
+        # Issue #128: dedup the ranked result list by root_conversation_id
+        # so users see one row per user-intent unit, not per
+        # delegated sub. Score / source-text are the MAX-scoring
+        # chunk's (preserved by walking the pre-sorted list and
+        # keeping first occurrence per root). Displayed ID + title are
+        # rewritten to the root's via ``conv_store.get(root_id)``.
+        results = _dedup_search_results_by_root(results, conv_store, limit)
+
+        # Load conversation metadata for display.
+        # After dedup, results' ``conversation_id`` is already the root id
+        # (rewritten by ``_dedup_search_results_by_root``), so this lookup
+        # surfaces the root's title and date.
         conv_metadata = {}
         for r in results:
             conv = conv_store.get(r.conversation_id)
@@ -2974,6 +2991,71 @@ def search(
             _print_search_json(results, conv_metadata, search_time, search_type)
         else:
             _print_search_results(results, conv_metadata, search_time, search_type, query)
+
+
+@dataclass
+class _SearchResultRow:
+    """Mutable surface for a single ``ohtv search`` row.
+
+    Issue #128: the FTS5 path previously produced anonymous ``type(...)``
+    instances; the new root-dedup helper needs to rewrite
+    ``conversation_id`` (sub → root) and ``rank`` (after collapse), so
+    we use a proper dataclass for both paths.
+    """
+    conversation_id: str
+    score: float
+    rank: int
+    best_match_type: str
+    best_match_chunk: int = 0
+    source_text: str | None = None
+
+
+def _dedup_search_results_by_root(
+    results: list,
+    conv_store,
+    limit: int,
+) -> list:
+    """Collapse a ranked search-result list to one entry per root.
+
+    Issue #128: the embeddings table is keyed by ``conversation_id``,
+    so ``search_conversations`` / ``search_fts`` return rows that may
+    point at delegated sub-conversations the user doesn't recognize.
+    This helper walks the **pre-sorted** input (score desc), keeps the
+    first occurrence per root (which is the max-scoring chunk in that
+    subtree, by the input ordering — the explicit MAX-aggregation
+    policy from the issue body), rewrites the displayed ``conversation_id``
+    to the root id, re-numbers ``rank`` from 1, and truncates to
+    ``limit``.
+
+    Standalone conversations pass through unchanged (their root_id ==
+    their id). Unknown IDs (FS-only fallback) pass through too.
+
+    The mutation strategy avoids requiring a specific result type —
+    duck typing on ``.conversation_id`` / ``.rank`` is enough.
+    """
+    if not results:
+        return results
+    from ohtv.filters import map_to_roots
+    ids = [r.conversation_id for r in results]
+    root_map = map_to_roots(conv_store.conn, ids)
+    deduped = []
+    seen_roots: set[str] = set()
+    for r in results:
+        root_id = root_map.get(r.conversation_id, r.conversation_id)
+        if root_id in seen_roots:
+            continue
+        seen_roots.add(root_id)
+        # Rewrite the displayed id to the root so downstream rendering
+        # surfaces a familiar id. The snippet / score / best_match_type
+        # stay at the max-scoring chunk's values (MAX policy).
+        r.conversation_id = root_id
+        deduped.append(r)
+        if len(deduped) >= limit:
+            break
+    # Re-number ranks 1..N after collapse.
+    for i, r in enumerate(deduped, 1):
+        r.rank = i
+    return deduped
 
 
 def _format_time_ago(dt: datetime) -> str:
@@ -3101,11 +3183,27 @@ def _display_retrieval_breakdown(
         else:
             return f"[dim]📅 {label}: until {end.strftime('%Y-%m-%d')}[/dim]"
 
-    # Count unique conversations
+    # Issue #128: report both grains side-by-side. ``len(conv_ids)`` is
+    # the chunk-grain unique-conversation count (matches the breakdown
+    # rows below); ``len(root_ids)`` is the rolled-up citation count
+    # the user actually sees in ``ohtv ask``'s Sources table.
     conv_ids = {c.conversation_id for c in chunks}
+    root_ids = {
+        getattr(c, "root_conversation_id", c.conversation_id) for c in chunks
+    }
 
     console.print(f"\n[bold]Query:[/bold] {question}")
-    console.print(f"[dim]Retrieved {len(chunks)} chunks from {len(conv_ids)} conversations[/dim]")
+    if len(root_ids) != len(conv_ids):
+        # At least one chunk came from a delegated sub — surface both
+        # grains so the rolled-up citation count is auditable.
+        console.print(
+            f"[dim]Retrieved {len(chunks)} chunks from {len(conv_ids)} conversations "
+            f"({len(root_ids)} roots)[/dim]"
+        )
+    else:
+        console.print(
+            f"[dim]Retrieved {len(chunks)} chunks from {len(conv_ids)} conversations[/dim]"
+        )
 
     # Show temporal filter info
     if temporal_applied and date_range:
@@ -3119,7 +3217,12 @@ def _display_retrieval_breakdown(
 
     console.print()
 
-    # Group chunks by conversation_id, then by embed_type
+    # Group chunks by conversation_id, then by embed_type.
+    # Issue #128: grouping STAYS at chunk grain (conversation_id, not
+    # root_conversation_id) — that's the whole point of ``--explain``:
+    # show chunk-level truth for debugging. The root annotation is
+    # added per-conv header below when a chunk's root differs from
+    # its own id.
     conv_chunks: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
     conv_metadata: dict[str, dict] = {}
 
@@ -3133,6 +3236,7 @@ def _display_retrieval_breakdown(
                 "title": chunk.title,
                 "created_at": chunk.created_at,
                 "summary": chunk.summary,
+                "root_id": getattr(chunk, "root_conversation_id", conv_id),
             }
 
     # Sort conversations by max score (highest first)
@@ -3161,7 +3265,22 @@ def _display_retrieval_breakdown(
         if len(title) > max_title_len:
             title = title[:max_title_len-3] + "..."
 
-        console.print(f"[cyan]{conv_id_short}[/cyan] ({date_str}) [dim]\"{title}\"[/dim]")
+        # Issue #128: when the chunk came from a delegated sub, surface
+        # both grains — the chunk-level ``conversation_id`` (for
+        # debugging) AND the rolled-up ``root_conversation_id`` (the
+        # citation target the user will see in ``ohtv ask``).
+        root_id = metadata.get("root_id") or conv_id
+        if root_id != conv_id:
+            root_id_short = root_id.replace("-", "")[:8]
+            console.print(
+                f"[cyan]{conv_id_short}[/cyan] "
+                f"(root: [cyan]{root_id_short}[/cyan]) "
+                f"({date_str}) [dim]\"{title}\"[/dim]"
+            )
+        else:
+            console.print(
+                f"[cyan]{conv_id_short}[/cyan] ({date_str}) [dim]\"{title}\"[/dim]"
+            )
 
         # Show breakdown by embed type
         types_by_conv = conv_chunks[conv_id]
@@ -3487,28 +3606,83 @@ def ask(
         console.print(f"\n[dim]─────────────────────────────────────────────────[/dim]")
         console.print(f"[bold]Sources ({len(result.source_conversation_ids)} conversations):[/bold]")
         
-        # Group chunks by conversation and count them
+        # Issue #128: group chunks by **root** id so the Sources table
+        # shows one citation per user-intent unit. Chunks from delegated
+        # sub-conversations roll up to their root; the displayed ID,
+        # title, date, and cloud URL come from the root via
+        # ``conv_store.get(root_id)``. A ``[via sub: <hex8>]`` annotation
+        # is appended below when at least one chunk in the group came
+        # from a sub, preserving chunk-grain visibility.
         conv_chunks: dict[str, list] = {}
         for chunk in result.context_chunks:
-            if chunk.conversation_id not in conv_chunks:
-                conv_chunks[chunk.conversation_id] = []
-            conv_chunks[chunk.conversation_id].append(chunk)
-        
+            root_id = chunk.root_conversation_id
+            if root_id not in conv_chunks:
+                conv_chunks[root_id] = []
+            conv_chunks[root_id].append(chunk)
+
         # Build source info list and sort by date (newest first)
         source_infos = []
-        for conv_id, chunks in conv_chunks.items():
-            first_chunk = chunks[0]
+        for root_id, chunks in conv_chunks.items():
             scores = [c.score for c in chunks]
+            # Resolve display metadata from the **root** (not the
+            # first chunk's sub conv) so users see a familiar title
+            # and the cloud URL points at the root they'd find in
+            # ``ohtv list`` / the cloud UI.
+            root_conv = conv_store.get(root_id)
+            if root_conv:
+                created_at = root_conv.created_at
+                summary = root_conv.summary
+                conv_source = root_conv.source or "local"
+            else:
+                # Fall back to the first chunk's metadata if the root
+                # row is missing (shouldn't happen post-migration 020,
+                # but be defensive).
+                first_chunk = chunks[0]
+                created_at = first_chunk.created_at
+                summary = first_chunk.summary
+                conv_source = first_chunk.conv_source
+
+            # The cloud URL is per-conv; build it for the root so the
+            # citation points at the user-facing unit (sub URLs are not
+            # what the user copy-pastes from ``ohtv list``).
+            from ohtv.analysis.rag import _get_cloud_url
+            cloud_url = _get_cloud_url(cloud_base_url, root_id)
+            # Re-evaluate cloud-URL validity at the root grain using
+            # the existing 14-day retention check on
+            # ``ConversationSource``.
+            display_url = None
+            if conv_source == "cloud" and created_at:
+                from ohtv.analysis.rag import ConversationSource
+                root_source = ConversationSource(
+                    conversation_id=root_id,
+                    title=root_conv.title if root_conv else "",
+                    source="cloud",
+                    cloud_url=cloud_url,
+                    created_at=created_at,
+                )
+                if root_source.is_cloud_url_valid():
+                    display_url = cloud_url
+
+            # Issue #128: collect the sub-id 8-char prefixes that
+            # contributed to this root. Only annotate when at least one
+            # chunk was from a sub (root_id != chunk.conversation_id).
+            via_sub_ids = sorted({
+                c.conversation_id[:8]
+                for c in chunks
+                if c.conversation_id != root_id
+            })
+
             source_infos.append({
-                "conv_id": conv_id,
-                "created_at": first_chunk.created_at,
-                "summary": first_chunk.summary,
-                "cloud_url": first_chunk.cloud_url if first_chunk.conv_source == "cloud" else None,
-                "display_url": first_chunk.display_url,
-                "conv_source": first_chunk.conv_source,
+                "conv_id": root_id,
+                "created_at": created_at,
+                "summary": summary,
+                "cloud_url": cloud_url if conv_source == "cloud" else None,
+                "display_url": display_url,
+                "conv_source": conv_source,
                 "chunk_count": len(chunks),
                 "score_min": min(scores),
                 "score_max": max(scores),
+                "via_sub_ids": via_sub_ids,
             })
         
         # Sort by date descending (newest first), None dates at the end
@@ -3552,6 +3726,20 @@ def ask(
                 summary_parts.append(info["summary"])
             else:
                 summary_parts.append("[dim]—[/dim]")
+            # Issue #128: when delegated sub-conversations contributed
+            # chunks to this root, annotate so the user knows the
+            # citation rolled up agent-delegated work.
+            via_sub_ids = info.get("via_sub_ids", [])
+            if via_sub_ids:
+                if len(via_sub_ids) == 1:
+                    summary_parts.append(
+                        f"[dim][via sub: {via_sub_ids[0]}][/dim]"
+                    )
+                else:
+                    summary_parts.append(
+                        f"[dim][via {len(via_sub_ids)} subs: "
+                        f"{', '.join(via_sub_ids)}][/dim]"
+                    )
             if info["display_url"]:
                 # No styling on URL - keeps Terminal.app auto-detection working
                 # OSC 8 link markup for modern terminals (iTerm2, Windows Terminal, etc)

--- a/src/ohtv/filters.py
+++ b/src/ohtv/filters.py
@@ -579,3 +579,67 @@ def expand_to_roots(conn, conv_ids: set[str]) -> set[str]:
         if cid not in seen_ids:
             roots.add(cid)
     return roots
+
+
+def map_to_roots(conn, conv_ids: list[str]) -> dict[str, str]:
+    """Map conversation IDs to their root IDs, preserving rank order.
+
+    Issue #128: list-shaped companion to :func:`expand_to_roots`. The
+    RAG ``ohtv search`` pipeline returns a *ranked* list of
+    ``ConversationSearchResult`` (max-scoring chunk per conversation,
+    sorted score-desc). To dedup that list to one row per root while
+    preserving the existing rank order, callers walk the list and look
+    up each id's root via ``mapping[id]`` — the dict form is the
+    natural shape (set-based expansion would lose rank).
+
+    Like :func:`expand_to_roots`, this helper:
+
+    * normalizes IDs (strips dashes) per AGENTS.md item #14 so dashed
+      inputs find their dashless DB rows;
+    * falls back to ``id`` itself when ``root_conversation_id`` is NULL
+      (defensive — migration 020 backfills, but mid-rescan races exist);
+    * passes unknown IDs through unchanged (mapping them to themselves)
+      so FS-only conversations don't disappear from search results.
+
+    The returned dict is keyed by **caller-provided** (possibly dashed)
+    IDs so callers can use ``mapping[orig_id]`` directly without
+    re-normalizing on their side.
+
+    Args:
+        conn: Open sqlite3 connection.
+        conv_ids: Conversation IDs (any format) to map. Duplicates are
+            allowed; the dict naturally collapses them.
+
+    Returns:
+        ``{caller_id: root_id}`` for every input id. Unknown IDs map
+        to themselves (normalized form). Empty input yields ``{}``.
+
+    Raises:
+        sqlite3.OperationalError: If ``root_conversation_id`` column is
+            absent. Callers that hit this path should have already
+            checked for migration 020 — the typical RAG entry-point
+            guard fires before this helper runs.
+    """
+    if not conv_ids:
+        return {}
+    # Map original (possibly dashed) → normalized form. Preserves the
+    # caller-provided keys in the result dict so callers don't have to
+    # re-normalize.
+    orig_to_normalized = {cid: normalize_conversation_id(cid) for cid in conv_ids}
+    normalized_unique = set(orig_to_normalized.values())
+    placeholders = ",".join("?" * len(normalized_unique))
+    cursor = conn.execute(
+        f"SELECT id, root_conversation_id FROM conversations "
+        f"WHERE id IN ({placeholders})",
+        tuple(normalized_unique),
+    )
+    # Defensive: NULL root_conversation_id (shouldn't happen after
+    # migration 020, but be safe) → self-root.
+    normalized_to_root = {
+        row[0]: (row[1] if row[1] else row[0]) for row in cursor.fetchall()
+    }
+    # IDs not in the DB pass through (mapped to their normalized self).
+    return {
+        orig: normalized_to_root.get(norm, norm)
+        for orig, norm in orig_to_normalized.items()
+    }

--- a/tests/unit/analysis/test_rag_retriever.py
+++ b/tests/unit/analysis/test_rag_retriever.py
@@ -7,6 +7,35 @@ from unittest.mock import MagicMock, patch
 from ohtv.analysis.rag import RAGRetriever, RAGRetrievalResult, ContextChunk
 
 
+def _mock_conv_store_with_root_column(
+    *, root_conversation_id: str | None = None
+) -> MagicMock:
+    """Build a ``conv_store`` MagicMock that satisfies the #128 guard.
+
+    The guard calls ``conv_store.conn.execute("PRAGMA table_info(...)")``
+    and walks rows looking for column index [1] == ``root_conversation_id``.
+    We stub that one row so existing tests don't need a real DB.
+
+    When ``root_conversation_id`` is set, ``conv_store.get(...)`` returns
+    a Conversation-like mock with that field set (so the chunk's root
+    field gets populated correctly). Tests that don't override
+    ``conv_store.get`` themselves use this default.
+    """
+    conv_store = MagicMock()
+    # One PRAGMA row per column; only the second column (name) is
+    # consulted by the guard. ``id`` and ``root_conversation_id`` rows
+    # are enough.
+    conv_store.conn.execute.return_value = [
+        (0, "id", "TEXT", 0, None, 1),
+        (1, "root_conversation_id", "TEXT", 0, None, 0),
+    ]
+    if root_conversation_id is not None:
+        mock_conv = MagicMock()
+        mock_conv.root_conversation_id = root_conversation_id
+        conv_store.get.return_value = mock_conv
+    return conv_store
+
+
 class TestRAGRetrievalResult:
     """Tests for RAGRetrievalResult dataclass."""
 
@@ -150,10 +179,10 @@ class TestRAGRetrieverRetrieve:
         """Test basic retrieval without temporal filter."""
         # Setup mocks
         mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
-        
+
         embed_store = MagicMock()
-        conv_store = MagicMock()
-        
+        conv_store = _mock_conv_store_with_root_column()
+
         # Mock embedding search results
         mock_result = MagicMock()
         mock_result.conversation_id = "abc123"
@@ -162,38 +191,43 @@ class TestRAGRetrieverRetrieve:
         mock_result.score = 0.85
         mock_result.chunk_index = 0
         embed_store.get_context_for_rag.return_value = [mock_result]
-        
+
         # Mock conversation
         mock_conv = MagicMock()
         mock_conv.title = "Test Conversation"
         mock_conv.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
         mock_conv.summary = None
         mock_conv.source = "local"
+        # Issue #128: standalone conv → root == id.
+        mock_conv.root_conversation_id = "abc123"
         conv_store.get.return_value = mock_conv
-        
+
         retriever = RAGRetriever(
             embed_store, conv_store,
             enable_temporal_filter=False,
         )
-        
+
         result = retriever.retrieve("test query", max_context_chunks=5)
-        
+
         assert len(result.context_chunks) == 1
         assert result.source_conversation_ids == {"abc123"}
         assert result.temporal_filter_applied is False
         assert result.context_chunks[0].title == "Test Conversation"
         assert result.context_chunks[0].score == 0.85
+        # Issue #128: root field populated; for a standalone it equals
+        # the chunk's conversation_id.
+        assert result.context_chunks[0].root_conversation_id == "abc123"
 
     @patch("ohtv.analysis.embeddings.get_embedding")
     def test_retrieve_with_no_results(self, mock_get_embedding):
         """Test retrieval when no results found."""
         mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
-        
+
         embed_store = MagicMock()
         embed_store.get_context_for_rag.return_value = []
-        
+
         retriever = RAGRetriever(
-            embed_store, MagicMock(),
+            embed_store, _mock_conv_store_with_root_column(),
             enable_temporal_filter=False,
         )
         
@@ -217,8 +251,8 @@ class TestRAGRetrieverRetrieve:
         mock_extract.return_value = mock_temporal
         
         embed_store = MagicMock()
-        conv_store = MagicMock()
-        
+        conv_store = _mock_conv_store_with_root_column()
+
         # Mock embedding search results
         mock_result = MagicMock()
         mock_result.conversation_id = "abc123"
@@ -227,12 +261,13 @@ class TestRAGRetrieverRetrieve:
         mock_result.score = 0.75
         mock_result.chunk_index = 0
         embed_store.get_context_for_rag.return_value = [mock_result]
-        
+
         mock_conv = MagicMock()
         mock_conv.title = "Test"
         mock_conv.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
         mock_conv.summary = None
         mock_conv.source = "cloud"
+        mock_conv.root_conversation_id = "abc123"
         conv_store.get.return_value = mock_conv
         
         retriever = RAGRetriever(
@@ -252,12 +287,12 @@ class TestRAGRetrieverRetrieve:
         
         embed_store = MagicMock()
         embed_store.get_context_for_rag.return_value = []
-        
+
         retriever = RAGRetriever(
-            embed_store, MagicMock(),
+            embed_store, _mock_conv_store_with_root_column(),
             enable_temporal_filter=False,
         )
-        
+
         retriever.retrieve("test", min_score=0.6)
         
         embed_store.get_context_for_rag.assert_called_once()
@@ -268,9 +303,9 @@ class TestRAGRetrieverRetrieve:
     def test_retrieve_sorts_chunks(self, mock_get_embedding):
         """Test that chunks are sorted by conversation, type, index."""
         mock_get_embedding.return_value = MagicMock(embedding=[0.1] * 1536)
-        
+
         embed_store = MagicMock()
-        conv_store = MagicMock()
+        conv_store = _mock_conv_store_with_root_column()
         
         # Create unsorted results
         results = [
@@ -354,6 +389,7 @@ class TestDisplayRetrievalBreakdown:
         chunks = [
             MagicMock(
                 conversation_id="abc123",
+                root_conversation_id="abc123",
                 embed_type="analysis",
                 title="Test Conversation",
                 created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
@@ -362,6 +398,7 @@ class TestDisplayRetrievalBreakdown:
             ),
             MagicMock(
                 conversation_id="abc123",
+                root_conversation_id="abc123",
                 embed_type="summary",
                 title="Test Conversation",
                 created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
@@ -398,6 +435,7 @@ class TestDisplayRetrievalBreakdown:
         chunks = [
             MagicMock(
                 conversation_id="abc123",
+                root_conversation_id="abc123",
                 embed_type="analysis",
                 title="Test",
                 created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
@@ -430,6 +468,7 @@ class TestDisplayRetrievalBreakdown:
         chunks = [
             MagicMock(
                 conversation_id="abc123",
+                root_conversation_id="abc123",
                 embed_type="summary",
                 title="Test",
                 created_at=datetime(2024, 2, 15, tzinfo=timezone.utc),

--- a/tests/unit/analysis/test_rag_root_dedup.py
+++ b/tests/unit/analysis/test_rag_root_dedup.py
@@ -1,0 +1,386 @@
+"""Tests for Issue #128 — RAG citation root-dedup.
+
+The render-layer citation pipeline collapses chunks from delegated
+sub-conversations to their **root** so users see one citation per
+user-intent unit (the unit they recognise from ``ohtv list`` and the
+cloud UI), without changing the chunk-grain retrieval contract.
+
+Coverage:
+
+* ``_results_to_context_chunks`` populates ``root_conversation_id``
+  from the DB (standalone, sub, root paths).
+* ``RAGRetrievalResult.source_conversation_ids`` is a set of **roots**.
+* ``_assert_root_column_present`` runtime guard fires when migration
+  020 is missing.
+* ``_build_context_text`` / ``_format_chunk_header`` cite the root
+  and append ``(via sub: ...)`` only when the chunk's source ≠ root.
+* The closing-AC regression: 1 root + 2 subs + 1 standalone →
+  exactly 2 citations after dedup.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from ohtv.analysis.rag import (
+    ContextChunk,
+    RAGAnswerer,
+    RAGRetriever,
+    _assert_root_column_present,
+    _results_to_context_chunks,
+)
+
+
+def _make_pragma_rows() -> list[tuple]:
+    """PRAGMA rows that satisfy the migration-020 guard."""
+    return [
+        (0, "id", "TEXT", 0, None, 1),
+        (1, "root_conversation_id", "TEXT", 0, None, 0),
+    ]
+
+
+def _make_conv(
+    conv_id: str,
+    *,
+    root_id: str | None = None,
+    title: str = "Conv title",
+    summary: str | None = None,
+    source: str = "local",
+    created_at: datetime | None = None,
+) -> MagicMock:
+    """Build a ``conv_store.get`` return value for one conversation."""
+    m = MagicMock()
+    m.title = title
+    m.summary = summary
+    m.source = source
+    m.created_at = created_at
+    # Default: standalone (root == self).
+    m.root_conversation_id = root_id if root_id is not None else conv_id
+    return m
+
+
+def _make_chunk_result(
+    conv_id: str,
+    *,
+    score: float = 0.8,
+    embed_type: str = "analysis",
+    chunk_index: int = 0,
+    source_text: str = "test text",
+) -> MagicMock:
+    """Build a chunk-search result row (duck-typed)."""
+    r = MagicMock()
+    r.conversation_id = conv_id
+    r.embed_type = embed_type
+    r.source_text = source_text
+    r.score = score
+    r.chunk_index = chunk_index
+    return r
+
+
+# ---------------------------------------------------------------------------
+# _results_to_context_chunks — root population
+# ---------------------------------------------------------------------------
+
+
+class TestResultsToContextChunksRootPopulation:
+    """``_results_to_context_chunks`` reads ``Conversation.root_conversation_id``
+    so every chunk carries a root id (== own id for standalones)."""
+
+    def test_standalone_conv_root_equals_id(self):
+        """For a conv with ``root_conversation_id = id``, the chunk
+        carries the same value (no surprise re-mapping)."""
+        results = [_make_chunk_result("aaa111")]
+        conv_store = MagicMock()
+        conv_store.get.return_value = _make_conv("aaa111")
+        chunks = _results_to_context_chunks(
+            results, conv_store, None, None, None, "https://example.invalid"
+        )
+        assert len(chunks) == 1
+        assert chunks[0].conversation_id == "aaa111"
+        assert chunks[0].root_conversation_id == "aaa111"
+
+    def test_sub_conv_uses_root_from_db(self):
+        """For a sub, the chunk's ``root_conversation_id`` is the
+        DB-populated root, not the chunk's own conv id."""
+        results = [_make_chunk_result("sub222")]
+        conv_store = MagicMock()
+        conv_store.get.return_value = _make_conv("sub222", root_id="root111")
+        chunks = _results_to_context_chunks(
+            results, conv_store, None, None, None, "https://example.invalid"
+        )
+        assert chunks[0].conversation_id == "sub222"
+        assert chunks[0].root_conversation_id == "root111"
+
+    def test_missing_conv_falls_back_to_self_id(self):
+        """If the conv isn't in the DB (FS-only fallback), the chunk
+        gets ``root_conversation_id = conversation_id`` so downstream
+        dedup treats it as a standalone."""
+        results = [_make_chunk_result("ghost1")]
+        conv_store = MagicMock()
+        conv_store.get.return_value = None
+        chunks = _results_to_context_chunks(
+            results, conv_store, None, None, None, "https://example.invalid"
+        )
+        assert chunks[0].root_conversation_id == "ghost1"
+
+    def test_null_root_falls_back_to_self_id(self):
+        """If the DB row is present but ``root_conversation_id`` is
+        NULL (pre-backfill race), we self-root rather than crash."""
+        results = [_make_chunk_result("orphan")]
+        conv_store = MagicMock()
+        # ``None`` root via direct attribute set.
+        conv = MagicMock()
+        conv.title = "Orphan"
+        conv.summary = None
+        conv.source = "local"
+        conv.created_at = None
+        conv.root_conversation_id = None
+        conv_store.get.return_value = conv
+        chunks = _results_to_context_chunks(
+            results, conv_store, None, None, None, "https://example.invalid"
+        )
+        assert chunks[0].root_conversation_id == "orphan"
+
+
+# ---------------------------------------------------------------------------
+# source_conversation_ids — root grain (AC2)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceConversationIdsAreRoots:
+    """``RAGRetrievalResult.source_conversation_ids`` is the rolled-up
+    set of roots, not the chunk-level conv ids."""
+
+    @pytest.fixture
+    def retriever_with_dummy_store(self):
+        """Build a retriever whose ``conv_store.conn`` satisfies the
+        migration-020 guard."""
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        conv_store.conn.execute.return_value = _make_pragma_rows()
+        return retriever_with_dummy_store_helper(embed_store, conv_store)
+
+    def test_one_root_two_subs_collapses_to_one_id(self, monkeypatch):
+        """1 root + 2 subs (all under same root) → 1 source id."""
+        monkeypatch.setattr(
+            "ohtv.analysis.embeddings.get_embedding",
+            lambda q: MagicMock(embedding=[0.1] * 1536),
+        )
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        conv_store.conn.execute.return_value = _make_pragma_rows()
+
+        # Three chunks under one root R.
+        embed_store.get_context_for_rag.return_value = [
+            _make_chunk_result("R", score=0.9),
+            _make_chunk_result("SUB1", score=0.7),
+            _make_chunk_result("SUB2", score=0.6),
+        ]
+        # Every conv → root R.
+        def fake_get(cid):
+            return _make_conv(cid, root_id="R")
+        conv_store.get.side_effect = fake_get
+
+        retriever = RAGRetriever(embed_store, conv_store, enable_temporal_filter=False)
+        result = retriever.retrieve("q")
+
+        assert result.source_conversation_ids == {"R"}
+        # AC closing-checkbox: chunk-grain truth preserved.
+        assert len(result.context_chunks) == 3
+
+    def test_one_root_two_subs_plus_one_standalone(self, monkeypatch):
+        """1 root + 2 subs (same root) + 1 standalone → 2 source ids."""
+        monkeypatch.setattr(
+            "ohtv.analysis.embeddings.get_embedding",
+            lambda q: MagicMock(embedding=[0.1] * 1536),
+        )
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        conv_store.conn.execute.return_value = _make_pragma_rows()
+
+        embed_store.get_context_for_rag.return_value = [
+            _make_chunk_result("R", score=0.9),
+            _make_chunk_result("SUB1", score=0.8),
+            _make_chunk_result("SUB2", score=0.7),
+            _make_chunk_result("Y", score=0.6),
+        ]
+
+        # Sub-tree convs root to R; standalone Y roots to itself.
+        def fake_get(cid):
+            if cid in ("R", "SUB1", "SUB2"):
+                return _make_conv(cid, root_id="R")
+            return _make_conv(cid)
+        conv_store.get.side_effect = fake_get
+
+        retriever = RAGRetriever(embed_store, conv_store, enable_temporal_filter=False)
+        result = retriever.retrieve("q")
+
+        # AC closing-checkbox: len == 2 (1 root + 1 standalone).
+        assert result.source_conversation_ids == {"R", "Y"}
+        # All 4 chunks survive — no pre-aggregation.
+        assert len(result.context_chunks) == 4
+
+
+def retriever_with_dummy_store_helper(embed_store, conv_store):
+    """Sliver around ``RAGRetriever`` to keep fixtures terse."""
+    return RAGRetriever(embed_store, conv_store, enable_temporal_filter=False)
+
+
+# ---------------------------------------------------------------------------
+# Migration-020 guard
+# ---------------------------------------------------------------------------
+
+
+class TestAssertRootColumnPresent:
+    """``_assert_root_column_present`` fires when the column is missing,
+    and stays silent when it's there."""
+
+    def test_passes_when_column_present(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE conversations (id TEXT, root_conversation_id TEXT)"
+        )
+        _assert_root_column_present(conn)  # should not raise
+
+    def test_raises_when_column_missing(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE conversations (id TEXT)")
+        with pytest.raises(RuntimeError) as excinfo:
+            _assert_root_column_present(conn)
+        # Cite migration 020 explicitly (sibling-PR contract).
+        assert "020" in str(excinfo.value)
+        assert "root_conversation_id" in str(excinfo.value)
+
+    def test_retrieve_raises_when_column_missing(self, monkeypatch):
+        """Issue #128 closing AC: a connection without
+        ``root_conversation_id`` raises at first retrieval — runtime,
+        not at import."""
+        monkeypatch.setattr(
+            "ohtv.analysis.embeddings.get_embedding",
+            lambda q: MagicMock(embedding=[0.1] * 1536),
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE conversations (id TEXT)")
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        conv_store.conn = conn
+
+        retriever = RAGRetriever(embed_store, conv_store, enable_temporal_filter=False)
+        # The guard fires before any DB / LLM call.
+        with pytest.raises(RuntimeError, match="020"):
+            retriever.retrieve("q")
+
+
+# ---------------------------------------------------------------------------
+# _format_chunk_header / _build_context_text — root + via-sub annotation
+# ---------------------------------------------------------------------------
+
+
+class TestFormatChunkHeader:
+    """The LLM prompt header cites the **root** id and annotates
+    ``(via sub: ...)`` when the chunk came from a delegated sub."""
+
+    @pytest.fixture
+    def answerer(self, monkeypatch):
+        """Build a ``RAGAnswerer`` without exercising the LLM API key
+        check (mocking ``LLM`` is overkill — we only call format helpers)."""
+        # Avoid needing LLM_API_KEY.
+        monkeypatch.setenv("LLM_API_KEY", "test-key-not-used")
+        embed_store = MagicMock()
+        conv_store = MagicMock()
+        conv_store.conn.execute.return_value = _make_pragma_rows()
+        return RAGAnswerer(embed_store, conv_store)
+
+    def test_header_for_standalone_conv_omits_via_sub(self, answerer):
+        chunk = ContextChunk(
+            conversation_id="self123",
+            root_conversation_id="self123",
+            title="Standalone",
+            embed_type="analysis",
+            source_text="...",
+            score=0.9,
+        )
+        header = answerer._format_chunk_header(chunk, index=1)
+        assert "Conversation ID: self123" in header
+        assert "via sub" not in header
+
+    def test_header_for_sub_includes_via_sub_annotation(self, answerer):
+        chunk = ContextChunk(
+            conversation_id="subdeadbeef00",
+            root_conversation_id="rootcafebabe11",
+            title="Delegated",
+            embed_type="analysis",
+            source_text="...",
+            score=0.85,
+        )
+        header = answerer._format_chunk_header(chunk, index=2)
+        # Root is the canonical citation.
+        assert "Conversation ID: rootcafebabe11" in header
+        # Sub-grain truth is preserved in the parenthetical.
+        assert "(via sub: subdeadb" in header
+
+    def test_build_context_text_routes_through_root(self, answerer):
+        """The full LLM prompt builder concatenates root-cited
+        headers (so the LLM cites root ids in its answer text)."""
+        chunks = [
+            ContextChunk(
+                conversation_id="sub00000001",
+                root_conversation_id="rootABCDEF",
+                title="A",
+                embed_type="analysis",
+                source_text="alpha",
+                score=0.9,
+            ),
+            ContextChunk(
+                conversation_id="standalone1",
+                root_conversation_id="standalone1",
+                title="B",
+                embed_type="analysis",
+                source_text="beta",
+                score=0.8,
+            ),
+        ]
+        text = answerer._build_context_text(chunks)
+        # Root id appears as the canonical citation for the sub-sourced
+        # chunk; via-sub annotation present.
+        assert "Conversation ID: rootABCDEF" in text
+        assert "(via sub: sub00000" in text
+        # Standalone has no via-sub annotation.
+        assert "Conversation ID: standalone1" in text
+        standalone_block = text.split("[Source 2:")[-1]
+        assert "via sub" not in standalone_block
+
+
+# ---------------------------------------------------------------------------
+# ContextChunk dataclass shape
+# ---------------------------------------------------------------------------
+
+
+class TestContextChunkDataclass:
+    def test_root_field_required(self):
+        """``root_conversation_id`` is a required field — must be
+        passed explicitly to construction."""
+        with pytest.raises(TypeError):
+            ContextChunk(
+                conversation_id="abc",  # type: ignore[call-arg]
+                title="t",
+                embed_type="analysis",
+                source_text="s",
+                score=0.5,
+            )
+
+    def test_can_construct_with_all_fields(self):
+        chunk = ContextChunk(
+            conversation_id="cid",
+            root_conversation_id="rid",
+            title="t",
+            embed_type="analysis",
+            source_text="s",
+            score=0.5,
+        )
+        assert chunk.conversation_id == "cid"
+        assert chunk.root_conversation_id == "rid"

--- a/tests/unit/test_cli_ask_search_root_dedup.py
+++ b/tests/unit/test_cli_ask_search_root_dedup.py
@@ -1,0 +1,271 @@
+"""Issue #128 — ``ohtv ask`` / ``ohtv search`` citation root-dedup.
+
+The render-layer dedup collapses chunks from delegated sub-conversations
+to their root so users see one citation per user-intent unit. These
+tests cover:
+
+* ``_dedup_search_results_by_root`` (CLI helper): MAX-score policy,
+  rank re-numbering, limit truncation, no backfill, standalone
+  passthrough.
+* ``_display_retrieval_breakdown``: shows both grains (chunk-level
+  conv id + rolled-up root id) when chunks come from delegated subs.
+
+Tests use an in-memory SQLite DB seeded with rows matching migration
+020 (every row carries ``root_conversation_id``). The DB is wrapped in
+a lightweight ``conv_store`` stand-in that only exposes ``.conn``,
+which is all the helper needs.
+
+Cross-references:
+* Helper: :func:`ohtv.cli._dedup_search_results_by_root`
+* AC closing checkbox: 1 root + 2 subs + 1 standalone → 2 rendered rows.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from ohtv.cli import (
+    _SearchResultRow,
+    _dedup_search_results_by_root,
+    _display_retrieval_breakdown,
+)
+from ohtv.db import migrate
+
+
+@pytest.fixture
+def db_conn():
+    """In-memory DB with the full ohtv schema (incl. migration 020)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrate(conn)
+    return conn
+
+
+def _seed_tree(db_conn, root_id: str, sub_ids: list[str]) -> None:
+    """Seed a (root, *subs) tree in ``conversations``."""
+    db_conn.execute(
+        "INSERT INTO conversations (id, location, source, root_conversation_id) "
+        "VALUES (?, ?, 'cloud', ?)",
+        (root_id, f"/tmp/{root_id}", root_id),
+    )
+    for sub_id in sub_ids:
+        db_conn.execute(
+            "INSERT INTO conversations "
+            "(id, location, source, parent_conversation_id, root_conversation_id) "
+            "VALUES (?, ?, 'cloud', ?, ?)",
+            (sub_id, f"/tmp/{sub_id}", root_id, root_id),
+        )
+    db_conn.commit()
+
+
+def _seed_standalone(db_conn, conv_id: str) -> None:
+    """Seed a standalone (self-rooted) conversation."""
+    db_conn.execute(
+        "INSERT INTO conversations (id, location, source, root_conversation_id) "
+        "VALUES (?, ?, 'cloud', ?)",
+        (conv_id, f"/tmp/{conv_id}", conv_id),
+    )
+    db_conn.commit()
+
+
+def _make_conv_store(db_conn):
+    """Wrap a sqlite conn as a minimal conv_store surface."""
+    store = MagicMock()
+    store.conn = db_conn
+    return store
+
+
+# ---------------------------------------------------------------------------
+# _dedup_search_results_by_root
+# ---------------------------------------------------------------------------
+
+
+class TestDedupSearchResultsByRoot:
+    """The CLI search-result dedup helper. Walks pre-sorted input,
+    keeps first-occurrence per root (MAX policy), rewrites
+    conversation_id to root id, re-ranks, truncates to limit."""
+
+    def test_empty_input_returns_empty(self, db_conn):
+        store = _make_conv_store(db_conn)
+        assert _dedup_search_results_by_root([], store, limit=10) == []
+
+    def test_standalone_passes_through(self, db_conn):
+        """Standalone conversations are returned unchanged (root == id)."""
+        _seed_standalone(db_conn, "stand1")
+        results = [
+            _SearchResultRow(conversation_id="stand1", score=0.9, rank=1, best_match_type="analysis"),
+        ]
+        out = _dedup_search_results_by_root(results, _make_conv_store(db_conn), limit=10)
+        assert len(out) == 1
+        assert out[0].conversation_id == "stand1"
+        assert out[0].rank == 1
+        assert out[0].score == 0.9
+
+    def test_subtree_collapses_to_one_row_max_score(self, db_conn):
+        """1 root + 2 subs (sorted score desc) → 1 row with MAX score."""
+        _seed_tree(db_conn, "rootA", ["subA1", "subA2"])
+        # Input sorted by score desc.
+        results = [
+            _SearchResultRow(conversation_id="subA1", score=0.95, rank=1, best_match_type="analysis"),
+            _SearchResultRow(conversation_id="rootA", score=0.85, rank=2, best_match_type="summary"),
+            _SearchResultRow(conversation_id="subA2", score=0.72, rank=3, best_match_type="content"),
+        ]
+        out = _dedup_search_results_by_root(results, _make_conv_store(db_conn), limit=10)
+        assert len(out) == 1
+        # ID is rewritten to the root (so display shows familiar id).
+        assert out[0].conversation_id == "rootA"
+        # MAX score wins (first occurrence by virtue of pre-sorted input).
+        assert out[0].score == 0.95
+        # Source-text / best_match_type stay at max-scoring chunk's
+        # values — the snippet under that chunk is what gets shown.
+        assert out[0].best_match_type == "analysis"
+        assert out[0].rank == 1
+
+    def test_two_distinct_subtrees(self, db_conn):
+        """5 chunks from 1 root + 2 chunks from 1 standalone → 2 rows."""
+        _seed_tree(db_conn, "rootA", ["subA1", "subA2"])
+        _seed_standalone(db_conn, "standB")
+        results = [
+            _SearchResultRow(conversation_id="rootA", score=0.95, rank=1, best_match_type="analysis"),
+            _SearchResultRow(conversation_id="subA1", score=0.92, rank=2, best_match_type="summary"),
+            _SearchResultRow(conversation_id="standB", score=0.88, rank=3, best_match_type="analysis"),
+            _SearchResultRow(conversation_id="subA2", score=0.81, rank=4, best_match_type="content"),
+            _SearchResultRow(conversation_id="rootA", score=0.78, rank=5, best_match_type="content"),
+        ]
+        out = _dedup_search_results_by_root(results, _make_conv_store(db_conn), limit=10)
+        assert len(out) == 2
+        # Order preserved: rootA first (max score 0.95), then standB.
+        assert [r.conversation_id for r in out] == ["rootA", "standB"]
+        # Ranks renumbered 1..N after collapse.
+        assert [r.rank for r in out] == [1, 2]
+
+    def test_no_backfill_preserves_limit(self, db_conn):
+        """If dedup leaves fewer rows than ``limit``, we do NOT
+        backfill — preserves the explicit AC4 contract."""
+        _seed_tree(db_conn, "rootA", ["subA1", "subA2", "subA3"])
+        # All 4 chunks from the same root.
+        results = [
+            _SearchResultRow(conversation_id=cid, score=0.9 - i * 0.05, rank=i + 1, best_match_type="analysis")
+            for i, cid in enumerate(["rootA", "subA1", "subA2", "subA3"])
+        ]
+        out = _dedup_search_results_by_root(results, _make_conv_store(db_conn), limit=10)
+        # Even though limit=10 and we had 4 input rows, dedup leaves 1.
+        # No backfill from elsewhere.
+        assert len(out) == 1
+
+    def test_limit_truncates_after_dedup(self, db_conn):
+        """``limit`` is applied **after** dedup, so it's a roots-cap."""
+        # Three standalone trees.
+        for cid in ("conv1", "conv2", "conv3"):
+            _seed_standalone(db_conn, cid)
+        results = [
+            _SearchResultRow(conversation_id="conv1", score=0.9, rank=1, best_match_type="analysis"),
+            _SearchResultRow(conversation_id="conv2", score=0.8, rank=2, best_match_type="analysis"),
+            _SearchResultRow(conversation_id="conv3", score=0.7, rank=3, best_match_type="analysis"),
+        ]
+        out = _dedup_search_results_by_root(results, _make_conv_store(db_conn), limit=2)
+        assert len(out) == 2
+        assert [r.conversation_id for r in out] == ["conv1", "conv2"]
+
+    def test_unknown_id_passes_through_unchanged(self, db_conn):
+        """An id not in the DB falls back to self-root (FS-only conv)."""
+        results = [
+            _SearchResultRow(conversation_id="ghost1", score=0.5, rank=1, best_match_type="analysis"),
+        ]
+        out = _dedup_search_results_by_root(results, _make_conv_store(db_conn), limit=10)
+        assert len(out) == 1
+        assert out[0].conversation_id == "ghost1"
+
+
+# ---------------------------------------------------------------------------
+# _display_retrieval_breakdown — both grains
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayRetrievalBreakdownBothGrains:
+    """The ``--explain`` retrieval breakdown shows both the chunk-level
+    ``conversation_id`` and the rolled-up ``root_conversation_id`` so
+    users can audit dedup decisions."""
+
+    def _chunk(self, conv_id: str, root_id: str, score: float = 0.8):
+        m = MagicMock()
+        m.conversation_id = conv_id
+        m.root_conversation_id = root_id
+        m.embed_type = "analysis"
+        m.title = "Test"
+        m.created_at = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        m.summary = None
+        m.score = score
+        return m
+
+    def test_only_standalone_chunks_no_root_annotation(self, capsys):
+        """When every chunk has root == id, the header doesn't include
+        the ``(root: ...)`` parenthetical — keeps the breakdown clean
+        for the common case."""
+        chunks = [self._chunk("standabcdef", "standabcdef")]
+        _display_retrieval_breakdown(
+            question="q",
+            chunks=chunks,
+            search_time=0.1,
+            temporal_applied=False,
+            date_range=None,
+            explicit_start=None,
+            explicit_end=None,
+        )
+        out = capsys.readouterr().out
+        assert "root:" not in out
+        # The conv-grain count is shown without the rolled-up count.
+        assert "Retrieved 1 chunks from 1 conversations" in out
+        assert "roots" not in out
+
+    def test_sub_chunk_shows_both_grains(self, capsys):
+        """A chunk from a delegated sub shows both its own id AND the
+        rolled-up root id in the per-conv header."""
+        chunks = [self._chunk("sub12345678", "rootabcdef00")]
+        _display_retrieval_breakdown(
+            question="q",
+            chunks=chunks,
+            search_time=0.1,
+            temporal_applied=False,
+            date_range=None,
+            explicit_start=None,
+            explicit_end=None,
+        )
+        out = capsys.readouterr().out
+        # Both ids appear (8-char prefixes).
+        assert "sub12345" in out
+        assert "rootabcd" in out
+        # The "root:" parenthetical is present in the per-conv header.
+        assert "root:" in out
+        # Single chunk under a single sub still reports 1 conv (its
+        # own id) and the summary line does NOT append "(N roots)"
+        # because the conv-count and root-count happen to coincide.
+        # The chunk-level "(root: ...)" annotation remains the source
+        # of truth here.
+        assert "Retrieved 1 chunks from 1 conversations" in out
+
+    def test_summary_line_when_chunk_count_differs_from_root_count(self, capsys):
+        """When chunks split across multiple subs but collapse to one
+        root, the summary line shows ``(N roots)``."""
+        chunks = [
+            self._chunk("sub11111111", "rootcafe00", score=0.9),
+            self._chunk("sub22222222", "rootcafe00", score=0.8),
+            self._chunk("standalone1", "standalone1", score=0.7),
+        ]
+        _display_retrieval_breakdown(
+            question="q",
+            chunks=chunks,
+            search_time=0.1,
+            temporal_applied=False,
+            date_range=None,
+            explicit_start=None,
+            explicit_end=None,
+        )
+        out = capsys.readouterr().out
+        # 3 chunks across 3 distinct conv ids → 2 roots.
+        assert "3 chunks from 3 conversations" in out
+        assert "(2 roots)" in out

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -327,3 +327,125 @@ class TestExpandToRoots:
         result = expand_to_roots(db_conn, {"orphan1"})
 
         assert result == {"orphan1"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #128 — map_to_roots helper (list-shaped companion)
+# ---------------------------------------------------------------------------
+
+
+class TestMapToRoots:
+    """``map_to_roots`` is the list-shaped companion to
+    :func:`expand_to_roots`. The RAG ``ohtv search`` pipeline returns a
+    *ranked* list, so the dedup helper needs a mapping (not a set) to
+    preserve rank order via ``mapping[id]`` lookups.
+    """
+
+    def _seed_tree(self, db_conn, root_id: str, sub_ids: list[str]) -> None:
+        db_conn.execute(
+            "INSERT INTO conversations (id, location, source, root_conversation_id) "
+            "VALUES (?, ?, 'cloud', ?)",
+            (root_id, f"/tmp/{root_id}", root_id),
+        )
+        for sub_id in sub_ids:
+            db_conn.execute(
+                "INSERT INTO conversations "
+                "(id, location, source, parent_conversation_id, root_conversation_id) "
+                "VALUES (?, ?, 'cloud', ?, ?)",
+                (sub_id, f"/tmp/{sub_id}", root_id, root_id),
+            )
+        db_conn.commit()
+
+    def test_empty_input(self, db_conn):
+        from ohtv.filters import map_to_roots
+
+        assert map_to_roots(db_conn, []) == {}
+
+    def test_all_roots_self_map(self, db_conn):
+        """A list of roots maps each id to itself."""
+        from ohtv.filters import map_to_roots
+
+        self._seed_tree(db_conn, "r0001", [])
+        self._seed_tree(db_conn, "r0002", [])
+
+        result = map_to_roots(db_conn, ["r0001", "r0002"])
+
+        assert result == {"r0001": "r0001", "r0002": "r0002"}
+
+    def test_all_subs_map_to_root(self, db_conn):
+        """A list of subs all under the same root all map to the same root."""
+        from ohtv.filters import map_to_roots
+
+        self._seed_tree(db_conn, "r0001", ["s0001", "s0002", "s0003"])
+
+        result = map_to_roots(db_conn, ["s0001", "s0002", "s0003"])
+
+        assert result == {"s0001": "r0001", "s0002": "r0001", "s0003": "r0001"}
+
+    def test_mixed_subs_and_roots(self, db_conn):
+        """A mixed list: roots map to self, subs map to their root."""
+        from ohtv.filters import map_to_roots
+
+        self._seed_tree(db_conn, "raaa1", ["saaa1"])
+        self._seed_tree(db_conn, "rbbb1", ["sbbb1", "sbbb2"])
+
+        result = map_to_roots(db_conn, ["raaa1", "saaa1", "sbbb1", "sbbb2"])
+
+        assert result == {
+            "raaa1": "raaa1",
+            "saaa1": "raaa1",
+            "sbbb1": "rbbb1",
+            "sbbb2": "rbbb1",
+        }
+
+    def test_unknown_ids_pass_through(self, db_conn):
+        """IDs not in the DB map to themselves (normalized form) so
+        FS-only conversations don't vanish from the result."""
+        from ohtv.filters import map_to_roots
+
+        result = map_to_roots(db_conn, ["unknown1", "unknown2"])
+
+        assert result == {"unknown1": "unknown1", "unknown2": "unknown2"}
+
+    def test_preserves_caller_keys_for_dashed_input(self, db_conn):
+        """When the caller passes dashed ids, the dict is keyed by the
+        **caller-provided** id so ``mapping[orig]`` works without
+        re-normalizing."""
+        from ohtv.filters import map_to_roots
+
+        root_dashless = "abcd1234567890abcdef1234567890ab"
+        sub_dashless = "12345678aabbccdd1122334455667788"
+        self._seed_tree(db_conn, root_dashless, [sub_dashless])
+
+        dashed_sub = "12345678-aabb-ccdd-1122-334455667788"
+        result = map_to_roots(db_conn, [dashed_sub])
+
+        # Caller's original (dashed) id is the dict key; value is the
+        # normalized root id (DB-form).
+        assert result == {dashed_sub: root_dashless}
+
+    def test_duplicates_in_input_collapse_in_dict(self, db_conn):
+        """A list with duplicates yields a dict (duplicates merge)."""
+        from ohtv.filters import map_to_roots
+
+        self._seed_tree(db_conn, "r0001", ["s0001"])
+
+        result = map_to_roots(db_conn, ["s0001", "s0001", "r0001"])
+
+        assert result == {"s0001": "r0001", "r0001": "r0001"}
+
+    def test_null_root_falls_back_to_self(self, db_conn):
+        """A row whose ``root_conversation_id`` is NULL (pre-backfill
+        race) maps to its own id rather than ``None``."""
+        from ohtv.filters import map_to_roots
+
+        db_conn.execute(
+            "INSERT INTO conversations (id, location, source, root_conversation_id) "
+            "VALUES (?, ?, 'cloud', NULL)",
+            ("nullroot", "/tmp/nullroot"),
+        )
+        db_conn.commit()
+
+        result = map_to_roots(db_conn, ["nullroot"])
+
+        assert result == {"nullroot": "nullroot"}


### PR DESCRIPTION
# Summary

`ohtv ask` and `ohtv search` now cite **root conversations** instead of leaking sub-conversation IDs the user doesn't recognise from `ohtv list` or the cloud UI. Retrieval continues at chunk grain (sub-conversation content is often the highest-signal evidence), but the citation-rendering pipeline collapses sub-sourced chunks to their root via the migration-020 `root_conversation_id` column.

Fixes #128. Closing member of the #122 root-grain aggregation cluster (siblings #123 → #150, #124 → #153, #125 → #154, #127 → #155 already merged).

## Implementation Notes

This PR is a **render-layer-only** fix. The chunk-grain retrieval contract is explicitly preserved (per the closing AC and the #122 cluster's per-conv-data rule):

- **`embedding_store.search` / `search_conversations` / `get_context_for_rag` are untouched.** The `JOIN ON e.conversation_id = c.id` is not modified. `git diff main -- src/ohtv/db/stores/embedding_store.py` is empty.
- **No new migration.** This PR depends on **migration 020** (the `root_conversation_id` column + index added by #122 — *not* migration 019, which is #108's `parent_conversation_id` column). Every guard message, docstring, and PR comment in this branch cites 020 explicitly, mirroring sibling PRs #152 and #155.
- **No `--include-sub-conversations` flag** on `ohtv ask` / `ohtv search`. Unlike sibling #125 (which has a legitimate "analyse a sub independently" workflow), citation dedup has no legitimate opt-out — the bug is "users don't recognise sub IDs". Chunk-grain visibility is preserved via the existing `--show-context` and `--explain` / `--explain-only` flags.
- **No backfill to N citations.** If top-5 retrieved chunks include 3 from root R and 2 from independent conv Y, the citation list shows 2 entries. Preserves `min_score` / `max_chunks` semantics (AC4).
- **Score aggregation policy: MAX.** When N chunks from a subtree collapse into one citation, the displayed score is `max(chunk.score for chunk in subtree_chunks)`. Implementation walks the pre-sorted (score-desc) input and keeps first-occurrence per root, which is the max-scoring chunk by construction.

### Helper added

`map_to_roots(conn, ids: list[str]) -> dict[str, str]` in `src/ohtv/filters.py` — the list-shaped companion to #127's set-shaped `expand_to_roots(conn, set)`. The dict form preserves rank order via `mapping[id]` lookups (a set would lose the input ordering). Both helpers share the same ID-normalisation / NULL-root-fallback / unknown-id-passthrough semantics.

### Runtime guardrail

`_assert_root_column_present(conn)` in `src/ohtv/analysis/rag.py` does a `PRAGMA table_info(conversations)` check at the **entry** of `RAGRetriever.retrieve` and `RAGAnswerer.answer_question`. The guard runs at runtime (not at import) so `import ohtv.analysis.rag` stays cheap and DB-free for tests that don't touch retrieval. The error message cites **migration 020** explicitly and points the user at `ohtv` (triggers `ensure_db_ready()`) or `ohtv db scan`. Pattern mirrors `_assert_root_column_present` in `src/ohtv/reports/weekly_counts.py` (PR #152) and the equivalent guard in `src/ohtv/cli.py` from PR #155.

### Sub-conversation behaviour under `--agent` (investigator mode)

Per the issue's "Out of Scope" section: investigator inherits the dedup for free via `RAGAnswer.context_chunks` (which now carry `root_conversation_id`). The investigator's `final_answer` is generated from the same chunks, so when it cites a source, it cites the root. No per-investigator changes needed.

## Acceptance Criteria coverage

- [x] `ContextChunk` gains a `root_conversation_id` field populated via `Conversation.root_conversation_id`. Standalone conversations have `root_conversation_id == conversation_id`. — `tests/unit/analysis/test_rag_root_dedup.py::TestResultsToContextChunksRootPopulation`
- [x] `RAGRetrievalResult.source_conversation_ids` and `RAGAnswer.source_conversation_ids` are sets of **root** IDs. — `TestSourceConversationIdsAreRoots`
- [x] `ohtv ask` Sources table displays the root ID (`hex8`) and root title; a `[via sub: <hex8>]` annotation appears when the citation's max-scoring chunk came from a sub. The cited cloud URL points to the root. — `src/ohtv/cli.py` ask command (lines ~3609–3686, ~3729–3742)
- [x] `ohtv search` table output dedupes to one row per root; rank/score/snippet reflect the max-scoring chunk in the subtree; displayed ID + title are the root's. — `tests/unit/test_cli_ask_search_root_dedup.py::TestDedupSearchResultsByRoot`
- [x] LLM-prompt chunk headers (`_build_context_text` / `_format_chunk_header`) cite the root ID with `(via sub: ...)` annotation when applicable. — `TestFormatChunkHeader`
- [x] `--explain` and `--explain-only` retrieval breakdowns show **both** grains: per-chunk `conversation_id` and rolled-up `root_conversation_id` (#35 alignment). — `TestDisplayRetrievalBreakdownBothGrains`
- [x] **No-pre-aggregation guarantee:** `embeddings` table is unchanged; no rollup writes; `embedding_store.search` / `search_conversations` / `get_context_for_rag` remain at chunk grain. — `git diff main -- src/ohtv/db/stores/embedding_store.py` is empty.
- [x] **Regression test (closing AC):** 1 root + 2 subs + 1 standalone → `len(source_conversation_ids) == 2`, with `--show-context` still showing 4 chunk-grain texts. — `TestSourceConversationIdsAreRoots::test_one_root_two_subs_plus_one_standalone`
- [x] **Runtime guardrail:** `PRAGMA table_info(conversations)` check for `root_conversation_id` at the `rag.py` cut site; `RuntimeError` raised at runtime (not import) when migration 020 hasn't run. — `TestAssertRootColumnPresent::test_retrieve_raises_when_column_missing`

## Test Coverage

- **New file** `tests/unit/analysis/test_rag_root_dedup.py` — 14 tests covering `_results_to_context_chunks` root-population, `source_conversation_ids` root-grain, the migration-020 guard, `_format_chunk_header` / `_build_context_text` annotations, and the `ContextChunk` dataclass shape.
- **New file** `tests/unit/test_cli_ask_search_root_dedup.py` — 10 tests covering `_dedup_search_results_by_root` (MAX-score, rank renumbering, limit truncation, no backfill, unknown-id passthrough, standalone passthrough) and `_display_retrieval_breakdown` both-grains rendering.
- **Extension** to `tests/unit/test_filters.py` — 8 tests for `map_to_roots` (empty input, all-roots, all-subs, mixed, unknown-id passthrough, dashed-caller-key preservation, duplicate collapse, NULL-root fallback).
- **Minor patches** to `tests/unit/analysis/test_rag_retriever.py` — existing 5 retrieve tests use a shared `_mock_conv_store_with_root_column` helper that stubs `PRAGMA table_info` so the migration-020 guard passes; existing 3 display-breakdown tests get `root_conversation_id` set explicitly on their MagicMock chunks.

Full unit suite: **2114 passed, 2 skipped, 3 xfailed** in 28s.

## Commits

- `feat(rag):` plumb `root_conversation_id` through `ContextChunk` and citations + guard
- `feat(filters):` add `map_to_roots(conn, list)` list-shaped companion
- `feat(cli):` root-dedup `ohtv ask` sources, `ohtv search` results, and `--explain` breakdown
- `test:` cover RAG root-dedup, `map_to_roots`, and migration-020 guard

Fixes #128.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/517c1b1b-95c6-4dc0-bc20-c7fdd2082b5b)