### PR TITLE
fix(logging): suppress LiteLLM botocore pre-load warnings (#148)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,6 +16,7 @@ Environment variables, data directories, and logging.
 | `OHTV_EXTRA_CONVERSATION_PATHS` | Additional conversation directories (colon-separated paths) | None |
 | `OHTV_LOG_LEVEL` | Default log level (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`, case-insensitive). Overridden by `--log-level`. | `INFO` |
 | `OHTV_LOG_FILE` | Default log destination. Overridden by `--log-file`. Special values: `-` writes to stderr only; `/dev/null` (or `nul` on Windows) silences file logging. | `~/.ohtv/logs/ohtv.log` |
+| `LITELLM_LOG` | Log level for the upstream `LiteLLM` logger (set via `os.environ.setdefault` at `import ohtv` time, so it silences LiteLLM's eager Bedrock/SageMaker `botocore` pre-load warnings on every CLI invocation). Export `LITELLM_LOG=WARNING` (or `DEBUG`) to see them again when debugging LiteLLM behaviour. | `ERROR` |
 | `LLM_API_KEY` | API key for LLM provider | Required for `gen`, `search`, `ask` |
 | `LLM_MODEL` | Default LLM model for `ask` | `openai/gpt-4o-mini` |
 | `LLM_BASE_URL` | Custom LLM base URL | Provider default |

--- a/src/ohtv/__init__.py
+++ b/src/ohtv/__init__.py
@@ -1,3 +1,13 @@
 """OpenHands Trajectory Viewer - CLI for viewing conversation histories."""
 
+import os as _os
+
+# Silence LiteLLM's eager Bedrock/SageMaker pre-load warnings (Issue #148).
+# These fire at `import litellm` time via logging.getLogger("LiteLLM"),
+# *before* openhands-sdk has a chance to lower the LiteLLM logger level,
+# so we must set LITELLM_LOG via the env var that litellm._logging reads
+# at module init. setdefault() preserves any user-provided value
+# (e.g. LITELLM_LOG=DEBUG for debugging).
+_os.environ.setdefault("LITELLM_LOG", "ERROR")
+
 __version__ = "0.19.0"

--- a/tests/unit/test_litellm_log_suppression.py
+++ b/tests/unit/test_litellm_log_suppression.py
@@ -1,0 +1,70 @@
+"""Regression tests for Issue #148: LiteLLM botocore warning suppression.
+
+`import ohtv` must set ``LITELLM_LOG=ERROR`` via ``os.environ.setdefault``
+before any submodule triggers a transitive ``import litellm``. We test this
+in a subprocess because by the time the pytest test process gets here,
+sibling tests have almost certainly already imported ``litellm`` (and thus
+also imported ``litellm._logging``, which reads ``LITELLM_LOG`` once at
+module init). A subprocess gives us a fresh interpreter where neither
+``ohtv`` nor ``litellm`` has been imported yet.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Build a minimal env that still lets the child find the project's ohtv.
+
+    We forward PATH (so the system Python can find its stdlib loaders),
+    VIRTUAL_ENV (so `sys.executable` in a uv-managed venv resolves correctly),
+    and PYTHONPATH (so editable installs resolve). We deliberately do NOT
+    forward LITELLM_LOG unless the caller explicitly asks for it.
+    """
+    env: dict[str, str] = {}
+    for key in ("PATH", "VIRTUAL_ENV", "PYTHONPATH", "HOME"):
+        value = os.environ.get(key)
+        if value is not None:
+            env[key] = value
+    if extra:
+        env.update(extra)
+    return env
+
+
+def test_ohtv_sets_litellm_log_to_error_when_unset() -> None:
+    """`import ohtv` sets LITELLM_LOG=ERROR when the env var was unset."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; import ohtv; print(os.environ['LITELLM_LOG'])",
+        ],
+        env=_child_env(),  # no LITELLM_LOG forwarded
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "ERROR", (
+        f"expected ERROR, got stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_ohtv_preserves_litellm_log_when_set() -> None:
+    """`import ohtv` leaves a user-provided LITELLM_LOG untouched (setdefault contract)."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; import ohtv; print(os.environ['LITELLM_LOG'])",
+        ],
+        env=_child_env({"LITELLM_LOG": "DEBUG"}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "DEBUG", (
+        f"expected DEBUG (preserved), got stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.18.1"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Sets `LITELLM_LOG=ERROR` via `os.environ.setdefault` at package init so the eager `litellm` import in commands like `ohtv ask`/`ohtv gen objs` no longer leaks `could not pre-load <provider> response stream shape` warnings to stderr on `ohtv --help`, `ohtv prompts list`, `ohtv db status`, etc.

## What changed

- **`src/ohtv/__init__.py`** — Added `os.environ.setdefault("LITELLM_LOG", "ERROR")` (3-line block + explanatory comment) before any submodule pulls in `litellm` transitively. Runs once at first `import ohtv.*`.
- **`tests/unit/test_litellm_log_suppression.py`** (new) — Two subprocess-isolated regression tests covering the default path (`LITELLM_LOG` unset → becomes `ERROR`) and the preserve-user-set contract (`LITELLM_LOG=DEBUG` → stays `DEBUG`). Subprocess isolation is required because sibling tests in the same pytest process have already imported `litellm._logging`, which reads `LITELLM_LOG` exactly once at module init.
- **`docs/reference/configuration.md`** — Added a `LITELLM_LOG` row to the environment-variables table next to `OHTV_LOG_LEVEL`/`OHTV_LOG_FILE`.
- **`uv.lock`** — Refreshed version pin.

## Escape hatch

The `setdefault` *is* the escape hatch — `LITELLM_LOG=WARNING ohtv ask ...` (or `DEBUG`) brings warnings back when debugging LiteLLM behaviour. No separate flag needed.

## Verification

Manual test report on this PR rated all 5 acceptance criteria 🟢 GOOD against `55c56d03`:

1. ✅ `ohtv --help`, `ohtv prompts list`, `ohtv db status` produce zero `could not pre-load ... response stream shape` warnings on stderr.
2. ✅ `LITELLM_LOG=WARNING ohtv ...` restores the warnings (escape hatch verified).
3. ✅ Regression tests pass in isolation and in the full suite.
4. ✅ No regression in other LiteLLM-using commands (`ohtv ask`, `ohtv gen objs`).
5. ✅ Docs row renders correctly and matches the implementation.

Closes #148.

---

_This PR description was authored by an AI agent (OpenHands) on behalf of @jpshackelford._
