### PR TITLE
ci: add enable-orchestrator workflow

### DIFF
--- a/.github/workflows/enable-orchestrator.yml
+++ b/.github/workflows/enable-orchestrator.yml
@@ -1,0 +1,35 @@
+name: Enable OHTV Orchestrator on New Issue or PR
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+  workflow_dispatch:
+
+jobs:
+  enable-orchestrator:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and enable orchestrator if disabled
+        env:
+          OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
+          AUTOMATION_ID: "c202ca20-60d5-4f5b-9d53-3d7308c1d95b"
+        run: |
+          # Check current status
+          STATUS=$(curl -s -H "Authorization: Bearer $OPENHANDS_API_KEY" \
+            "https://app.all-hands.dev/api/automation/v1/$AUTOMATION_ID" | jq -r '.enabled')
+
+          if [ "$STATUS" = "false" ]; then
+            echo "Orchestrator is disabled. Enabling..."
+            curl -s -X PATCH \
+              -H "Authorization: Bearer $OPENHANDS_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d '{"enabled": true}' \
+              "https://app.all-hands.dev/api/automation/v1/$AUTOMATION_ID"
+            echo "Orchestrator enabled!"
+          elif [ "$STATUS" = "true" ]; then
+            echo "Orchestrator already enabled. Nothing to do."
+          else
+            echo "Could not determine status: $STATUS"
+          fi

--- a/.github/workflows/enable-orchestrator.yml
+++ b/.github/workflows/enable-orchestrator.yml
@@ -16,20 +16,35 @@ jobs:
           OPENHANDS_API_KEY: ${{ secrets.OPENHANDS_API_KEY }}
           AUTOMATION_ID: "c202ca20-60d5-4f5b-9d53-3d7308c1d95b"
         run: |
-          # Check current status
-          STATUS=$(curl -s -H "Authorization: Bearer $OPENHANDS_API_KEY" \
-            "https://app.all-hands.dev/api/automation/v1/$AUTOMATION_ID" | jq -r '.enabled')
+          set -euo pipefail
+
+          # Check current status. `-f` makes curl exit non-zero on HTTP 4xx/5xx
+          # so a transient API failure surfaces as a workflow failure instead
+          # of producing an empty $STATUS that we silently swallow below.
+          STATUS=$(curl -sf -H "Authorization: Bearer $OPENHANDS_API_KEY" \
+            "https://app.all-hands.dev/api/automation/v1/$AUTOMATION_ID" | jq -r '.enabled') || {
+            echo "Error: Failed to read orchestrator status from automation API."
+            exit 1
+          }
 
           if [ "$STATUS" = "false" ]; then
             echo "Orchestrator is disabled. Enabling..."
-            curl -s -X PATCH \
+            if curl -sf -X PATCH \
               -H "Authorization: Bearer $OPENHANDS_API_KEY" \
               -H "Content-Type: application/json" \
               -d '{"enabled": true}' \
-              "https://app.all-hands.dev/api/automation/v1/$AUTOMATION_ID"
-            echo "Orchestrator enabled!"
+              "https://app.all-hands.dev/api/automation/v1/$AUTOMATION_ID" > /dev/null; then
+              echo "Orchestrator enabled!"
+            else
+              echo "Error: PATCH to enable orchestrator failed; it is still disabled."
+              exit 1
+            fi
           elif [ "$STATUS" = "true" ]; then
             echo "Orchestrator already enabled. Nothing to do."
           else
-            echo "Could not determine status: $STATUS"
+            # Unexpected payload (e.g. jq saw 'null' because the API returned
+            # an error object). Surface this as a failure rather than a 0-exit
+            # "could not determine status" log line that nobody reads.
+            echo "Error: Unexpected status from automation API: '$STATUS'"
+            exit 1
           fi


### PR DESCRIPTION
## What

Adds `.github/workflows/enable-orchestrator.yml`, mirroring the workflow already in [`jpshackelford/voice-relay`](https://github.com/jpshackelford/voice-relay/blob/main/.github/workflows/enable-orchestrator.yml).

## Why

The **OHTV Workflow Orchestrator** automation (`c202ca20-60d5-4f5b-9d53-3d7308c1d95b`) auto-disables itself after 2+ consecutive quiet cycles per the `/disable-automation` skill — sensible behavior to avoid wasted cron runs after the backlog drains.

But without an auto-enable bridge, new issues/PRs sit unworked until a human notices the toggle is off. That's exactly what happened this week:

| Event | Time (UTC) |
|---|---|
| Cluster #122 drained, orchestrator auto-disabled | 2026-05-30 19:18Z |
| Issue #160 filed (`ready, priority:medium`) | 2026-06-01 12:56Z |
| Issues #161, #162 filed (`priority:medium`, need expansion) | 2026-06-01 12:56–12:57Z |
| Issue #163 filed (`priority:medium`, needs expansion) | 2026-06-02 13:05Z |
| Orchestrator still disabled, queue idle | 2026-06-02 |

voice-relay has had this workflow for a while and avoids the same gap.

## How

```yaml
on:
  issues:        [opened]
  pull_request:  [opened, ready_for_review, reopened]
  workflow_dispatch:
```

The job `GET`s the automation, and if `enabled == false` issues a `PATCH` to re-enable it. No-op when already enabled.

## Requirements

- `OPENHANDS_API_KEY` repo secret — **already configured** ✅
- Automation ID hardcoded to `c202ca20-60d5-4f5b-9d53-3d7308c1d95b` (the OHTV Workflow Orchestrator)

## Verification

After merge, the workflow can be smoke-tested by running it via the **workflow_dispatch** button — it should log `Orchestrator already enabled. Nothing to do.` if the automation was flipped on prior, or `Orchestrator enabled!` if it was off.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/045be104-692c-4d6c-a6e3-9739a9a2e885)