### PR TITLE
feat: engaged-human-minutes per-conversation metric (#163)

### DIFF
--- a/docs/design/conversation-metrics.md
+++ b/docs/design/conversation-metrics.md
@@ -482,3 +482,123 @@ ohtv report velocity --format csv > velocity.csv
    - `ohtv report velocity` - weekly PR count + LOC
    - `ohtv report efficiency` - human words per LOC ratio
    - CSV export for further analysis
+
+## Engaged Human Minutes (Sustained-Attention Metric — Issue #163)
+
+A per-conversation metric capturing **how long a human was actively
+monitoring/steering** the conversation, inferred from the temporal gaps
+around each user message. Distinct from `followup_word_count` (how
+*much* the human said) — engaged minutes captures how *long the human
+was paying attention*.
+
+### Definition
+
+Given a sustained-attention threshold `T` (default: **12 minutes**,
+configurable; see "Threshold tuning" below):
+
+1. Order events ascending by timestamp; find user-message indices `Uᵢ`.
+2. For each follow-up user message `Uᵢ` (i ≥ 1), look at the gap from
+   the immediately preceding event `Pᵢ` to `Uᵢ`. If `Uᵢ.ts - Pᵢ.ts ≤
+   T`, the human was here: record the **attended block**
+   `(Uᵢ₋₁.ts, Uᵢ.ts)`.
+3. Sort attended blocks ascending; merge any two adjacent blocks with
+   seam `≤ T` into a single **attention period**.
+4. `engaged_seconds = Σ (period.end - period.start)` over merged periods.
+5. `attention_periods` = number of merged periods.
+
+### Stored in `conversation_engagement` (migration 023)
+
+| Column                              | Notes                                       |
+|-------------------------------------|---------------------------------------------|
+| `conversation_id`                   | PK; FK → `conversations(id) ON DELETE CASCADE` |
+| `threshold_seconds`                 | `T` used for this row; lets the tuning sweep store distinguishable variants |
+| `first_event_ts` / `last_event_ts`  | ISO-8601, derived from event files (NOT `base_state.updated_at - created_at`) |
+| `total_duration_seconds`            | `last - first`, in whole seconds            |
+| `engaged_seconds`                   | The metric. `0` for fire-and-forget (not NULL) |
+| `attention_periods`                 | Count of merged periods. `0` for fire-and-forget |
+| `follow_up_user_message_count`      | Sanity check, also lets queries filter on "human actually steered" |
+| `attended_user_message_count`       | Count of follow-ups whose gap to prior event ≤ T |
+| `processed_at`                      | When this row was written                   |
+| `event_count`                       | Event count at processing time              |
+
+`idx_conv_engagement_threshold` is indexed for filtering during the
+tuning sweep.
+
+### Edge cases pinned by tests
+
+* **Fire-and-forget** (0 or 1 user message) → `engaged_seconds = 0`,
+  `attention_periods = 0`. Row is still written so downstream queries
+  do not need to `LEFT JOIN`.
+* **Tail handling** (events after the last user message) — under the
+  pseudocode the tail does NOT extend the attention period. See Open
+  Question #1 in the issue; a forward-extension follow-up may revisit
+  this.
+* **`T = 0`** → every gap unattended → `engaged_seconds = 0`.
+* **`T = ∞`** → every follow-up attended → single period spanning
+  first→last user message.
+* **Single-instant period** (follow-up off the initial prompt with
+  zero intermediate events) → 1 period of 0 seconds. The
+  `attention_periods` counter is the signal that "the user touched the
+  conversation."
+
+### Stage + CLI
+
+* Stage name: `engagement` (registered in `ohtv.db.stages.STAGES`
+  after `contributions`).
+* `ohtv db process engagement [--threshold N]` — `N` is **seconds**;
+  default 720 (12 min). Run with new `--threshold` to rewrite all rows
+  under a new `T` (the upsert replaces the row's `threshold_seconds`
+  field).
+* `ohtv show <id>` (the default no-content / `--stats` view) adds an
+  "Engaged" line alongside Duration when an engagement row is present:
+
+      Engaged:  4m 24s in 2 periods (8.8% of 50m total)
+
+* `ohtv show --format json` surfaces `engaged_seconds`,
+  `attention_periods`, `engagement_threshold_seconds`, and
+  `total_duration_seconds` keys.
+
+### Threshold tuning
+
+The strawman in the issue was `T = 8 min`; the user's updated guess
+was `T = 12 min` ("noticed the message → read response → composed
+reply"). The shipped initial default is 12 min per Issue #163 Open
+Question #3.
+
+To pick the empirically-grounded value, run
+`scripts/engagement_threshold_sweep.py`:
+
+```bash
+uv run python -m scripts.engagement_threshold_sweep \
+    --out engagement_totals.csv \
+    --gap-histogram engagement_gaps.csv
+```
+
+The default sweep covers `T ∈ {6, 8, 12, 14, 16, 18, 20, 22, 24, 26,
+28}` minutes. The `gap-histogram` CSV has one row per
+preceding-event → user-message gap; plotting a histogram of the
+`gap_seconds` column reveals the trough between the "human reaction
+time" mode and the "came back later" mode — that's the empirical `T`.
+
+The sweep is non-destructive: it never writes to
+`conversation_engagement`. To persist the chosen value, run `ohtv db
+process engagement --threshold <chosen-seconds> --force` afterward.
+
+### Reconciliation with the existing duration display
+
+The pre-existing `ConversationInfo.duration` property in
+`src/ohtv/sources/base.py` uses `updated_at - created_at` from
+`base_state.json`, which can drift from the true first/last event
+timestamps. The engagement row stores `total_duration_seconds` computed
+from `last_event_ts - first_event_ts` (the correct definition); the
+`Engaged: ... (X% of … total)` line in `ohtv show --stats` reports the
+percentage against the event-derived duration. Subsequent work may
+migrate the legacy `ConversationInfo.duration` to the same definition
+for consistency.
+
+### See also
+
+* Issue #163 — original design + worked example.
+* `src/ohtv/db/stages/engagement.py` — algorithm + DB write path.
+* `src/ohtv/db/migrations/023_conversation_engagement.py` — schema.
+* `scripts/engagement_threshold_sweep.py` — tuning sweep.

--- a/docs/guides/exploration.md
+++ b/docs/guides/exploration.md
@@ -229,6 +229,54 @@ ohtv show abc123 -A -r -n 5
 | `-F, --format` | Output format: `text` (default), `markdown`, `json` |
 | `--file PATH` | Write output to file |
 
+### Stats output: the `Engaged:` line
+
+When the [`engagement` indexing stage](indexing.md#engagement-stage)
+has run for a conversation, `ohtv show` (default stats view, or `--stats`) adds an **`Engaged:`** line beneath `Duration:` reporting the sustained-attention metric introduced for [Issue #163](https://github.com/jpshackelford/ohtv/issues/163) — how long a human was actively monitoring/steering, plus how many attention periods that engagement broke into.
+
+Example `ohtv show <id>` (text format):
+
+```text
+Conversation: abc123def456
+Title:    Wire up engagement metric
+Status:   COMPLETED
+Started:  2026-06-03 09:12:04
+Ended:    2026-06-03 10:02:18
+Duration: 50m 14s
+Engaged:  4m 24s in 2 periods (8.8% of 50m total)   — new in #165
+
+Event Counts:
+  User messages:    7
+  Agent messages:   42
+  ...
+```
+
+Notes:
+
+- The `Engaged:` line is **omitted** (not shown as `N/A`) when no engagement row exists yet — run `ohtv db process engagement` to populate it.
+- The percentage is computed against the **event-derived** total duration (first event timestamp → last event timestamp), which can differ slightly from the `Duration:` line above (which uses `base_state.json`). See the [design doc](../design/conversation-metrics.md#engaged-human-minutes-sustained-attention-metric--issue-163) § "Reconciliation with the existing duration display."
+- The threshold used for the stored row defaults to **12 minutes**; re-run `ohtv db process engagement --threshold N --force` (in seconds) to recompute under a different `T`.
+
+**JSON output (`-F json`)** gains four new top-level keys when an engagement row is present:
+
+```json
+{
+  "id": "abc123def456",
+  "title": "Wire up engagement metric",
+  "started": "2026-06-03T09:12:04+00:00",
+  "ended": "2026-06-03T10:02:18+00:00",
+  "duration_seconds": 3014.0,
+  "counts": { "user_messages": 7, "agent_messages": 42 },
+  "total_events": 71,
+  "engaged_seconds": 264,
+  "attention_periods": 2,
+  "engagement_threshold_seconds": 720,
+  "total_duration_seconds": 3015
+}
+```
+
+Consumers should treat the four engagement keys as **optional** — they only appear when the `engagement` stage has run for that conversation.
+
 ---
 
 

--- a/docs/guides/indexing.md
+++ b/docs/guides/indexing.md
@@ -78,9 +78,13 @@ ohtv db process refs -v
 | Stage | Description |
 |-------|-------------|
 | `refs` | Extract repository, issue, and PR references |
-| `actions` | Recognize actions (file edits, git ops, PRs, issues, Notion, etc.) |
-| `contributions` | Walk the action timeline to attribute PR creation/merge/push contributions to `change_refs` (depends on `actions`) |
+| `actions` | Recognize actions (file edits, git ops, PRs, issues, Notion, etc.) (depends on `refs`) |
+| `branch_context` | Track `git checkout` / `git switch` and create branch refs from `git push` events (depends on `actions`) |
+| `push_pr_links` | Correlate `git push` events with PRs via branch matching (depends on `actions`, `branch_context`) |
+| `summaries` | Extract conversation summaries from the LLM objective-analysis cache (populates `conversation_summaries`) |
 | `human_input` | Count human input events per conversation; preserves `initial_prompt_source` for future classification |
+| `contributions` | Walk the action timeline to attribute PR creation/merge/push contributions to `change_refs` (depends on `actions`) |
+| `engagement` | Sustained-attention metric — "engaged human minutes" and attention-period count per conversation. See [Engagement stage](#engagement-stage) below and [Issue #163](https://github.com/jpshackelford/ohtv/issues/163) / [design doc](../design/conversation-metrics.md#engaged-human-minutes-sustained-attention-metric--issue-163). |
 | `all` | Run all stages in sequence |
 
 Stage dependencies are respected when running `all` (e.g. `contributions` runs after `actions`). Running a stage individually before its dependencies have completed is allowed but produces no useful results — prefer `db process all` unless you know what you're doing.
@@ -90,6 +94,7 @@ Stage dependencies are respected when running `all` (e.g. `contributions` runs a
 |------|-------------|
 | `-f, --force` | Reprocess all conversations |
 | `-c, --conversation ID` | Process only this conversation |
+| `--threshold SECONDS` | Sustained-attention threshold `T`, in **seconds**. Only meaningful for the `engagement` stage (silently ignored for other stages). Default is `720` (12 minutes). When re-running engagement with a different threshold the stored row is rewritten under the new `T`. |
 | `-v, --verbose` | Show detailed output |
 
 ### Contributions stage
@@ -147,6 +152,38 @@ ohtv list --action pushed
 # as merged PRs. To split them, drop into the database and group by
 # change_refs.kind.
 ```
+
+### Engagement stage
+
+The `engagement` stage computes a per-conversation **engaged human
+minutes** metric — how long a person was actively monitoring/steering
+the conversation, inferred from the temporal gaps around each user
+message. Distinct from `human_input`, which counts *how much* the human
+said; engagement captures *how long the human was paying attention*.
+
+Each follow-up user message whose gap to the immediately preceding
+event is ≤ `T` (default **12 minutes** = 720 seconds) marks an
+**attended block**; adjacent blocks within `T` of each other are merged
+into a single **attention period**. Results land in the
+`conversation_engagement` table (one row per conversation, migration
+023) with columns `engaged_seconds`, `attention_periods`,
+`threshold_seconds`, and the event-derived
+`first_event_ts`/`last_event_ts`/`total_duration_seconds`.
+
+```bash
+# Run with the 12-minute default
+ohtv db process engagement
+
+# Re-run with a custom threshold (in seconds) — overwrites the stored row
+ohtv db process engagement --threshold 600 --force      # T = 10 min
+ohtv db process engagement --threshold 900 --force      # T = 15 min
+```
+
+To pick an empirically-grounded `T` for your corpus, use
+`scripts/engagement_threshold_sweep.py` (non-destructive — it computes
+in memory and writes CSV). See
+[docs/design/conversation-metrics.md#engaged-human-minutes-sustained-attention-metric--issue-163](../design/conversation-metrics.md#engaged-human-minutes-sustained-attention-metric--issue-163)
+for the algorithm, edge cases, and tuning workflow.
 
 ## `ohtv db reset` - Delete Database
 

--- a/scripts/engagement_threshold_sweep.py
+++ b/scripts/engagement_threshold_sweep.py
@@ -1,0 +1,253 @@
+"""Engagement-threshold tuning sweep — Issue #163.
+
+Re-computes the engagement metric for every conversation in the local
+DB at a fixed set of candidate thresholds, and emits two CSVs that can
+be plotted offline to pick the empirically-grounded ``T``:
+
+* ``--out totals.csv`` — one row per threshold with the per-corpus
+  totals: number of conversations with any engagement, sum of
+  engaged seconds, total conversation duration, ratio.
+* ``--gap-histogram gaps.csv`` — one row per (preceding-event → user
+  message) gap across the corpus. Plotting a histogram of the
+  ``gap_seconds`` column reveals the trough between the "human
+  reaction time" mode and the "came back later" mode.
+
+The sweep does NOT mutate the ``conversation_engagement`` table — each
+threshold is computed in-memory from the on-disk event files. Re-running
+is safe and cheap (O(events) per conversation per threshold).
+
+Usage::
+
+    uv run python -m scripts.engagement_threshold_sweep \\
+        --out engagement_totals.csv \\
+        --gap-histogram engagement_gaps.csv
+
+    # Custom threshold set (in minutes):
+    uv run python -m scripts.engagement_threshold_sweep -t 6 8 10 12 14
+
+    # Filter to one repository / source:
+    uv run python -m scripts.engagement_threshold_sweep --source cloud
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ohtv.db import get_ready_connection
+from ohtv.db.stages.engagement import (
+    _parse_timestamp,
+    compute_engagement,
+)
+
+DEFAULT_MINUTES = [6, 8, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+
+
+def _iter_events(conv_location: str) -> list[dict]:
+    events_dir = Path(conv_location) / "events"
+    if not events_dir.exists():
+        return []
+    out: list[dict] = []
+    for f in sorted(events_dir.glob("event-*.json")):
+        try:
+            data = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict):
+            out.append(data)
+    return out
+
+
+def _list_conversations(conn, source: str | None) -> list[tuple[str, str]]:
+    """Return (id, location) pairs from the DB, optionally filtered by source."""
+    sql = "SELECT id, location FROM conversations WHERE location IS NOT NULL"
+    params: list[object] = []
+    if source:
+        sql += " AND source = ?"
+        params.append(source)
+    cur = conn.execute(sql, params)
+    return [(row[0], row[1]) for row in cur.fetchall()]
+
+
+def _user_message_gaps(events: list[dict]) -> list[float]:
+    """Gap in seconds from each follow-up user message to its preceding event.
+
+    Only follow-up messages (i.e. not the first user message) are emitted.
+    Malformed events / unparseable timestamps are skipped.
+    """
+    parsed: list[tuple[datetime | None, bool]] = []
+    for event in events:
+        if not isinstance(event, dict):
+            parsed.append((None, False))
+            continue
+        ts = _parse_timestamp(event.get("timestamp"))
+        is_user = (
+            event.get("kind") == "MessageEvent"
+            and event.get("source") == "user"
+        )
+        parsed.append((ts, is_user))
+
+    user_idx = [i for i, (ts, is_user) in enumerate(parsed) if is_user and ts is not None]
+    if len(user_idx) < 2:
+        return []
+
+    gaps: list[float] = []
+    for k in range(1, len(user_idx)):
+        u_i = user_idx[k]
+        u_ts = parsed[u_i][0]
+        assert u_ts is not None
+        # Walk left to most-recent parseable timestamp.
+        p_ts: datetime | None = None
+        for j in range(u_i - 1, -1, -1):
+            cand = parsed[j][0]
+            if cand is not None:
+                p_ts = cand
+                break
+        if p_ts is None:
+            continue
+        gaps.append((u_ts - p_ts).total_seconds())
+    return gaps
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "-t", "--threshold-minutes",
+        type=float,
+        nargs="+",
+        default=DEFAULT_MINUTES,
+        help=f"Candidate thresholds, in minutes (default: {DEFAULT_MINUTES})",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=Path("engagement_totals.csv"),
+        help="Per-threshold totals output path (default: engagement_totals.csv)",
+    )
+    p.add_argument(
+        "--gap-histogram",
+        type=Path,
+        default=None,
+        help="Optional path for the per-user-message gap CSV (one row per gap)",
+    )
+    p.add_argument(
+        "--source",
+        default=None,
+        help="Filter conversations by source (e.g. 'cloud', 'local')",
+    )
+    args = p.parse_args(argv)
+
+    threshold_seconds_list = [int(round(m * 60)) for m in args.threshold_minutes]
+
+    with get_ready_connection(show_progress=False) as conn:
+        convs = _list_conversations(conn, args.source)
+
+    # Pre-load events once per conversation; reuse across thresholds.
+    print(f"Sweeping {len(convs)} conversation(s) across "
+          f"{len(threshold_seconds_list)} threshold(s)...", file=sys.stderr)
+
+    gaps_rows: list[dict] = []
+    per_threshold_totals: dict[int, dict[str, int | float]] = {
+        t: {"engaged_seconds": 0, "total_duration_seconds": 0,
+            "engaged_convs": 0, "attention_periods": 0,
+            "follow_up_user_message_count": 0,
+            "attended_user_message_count": 0}
+        for t in threshold_seconds_list
+    }
+    total_conv_count = 0
+
+    for conv_id, location in convs:
+        events = _iter_events(location)
+        if not events:
+            continue
+        total_conv_count += 1
+
+        if args.gap_histogram:
+            for gap in _user_message_gaps(events):
+                gaps_rows.append({
+                    "conversation_id": conv_id,
+                    "gap_seconds": gap,
+                })
+
+        for t in threshold_seconds_list:
+            m = compute_engagement(events, threshold_seconds=t)
+            bucket = per_threshold_totals[t]
+            bucket["engaged_seconds"] = int(bucket["engaged_seconds"]) + m.engaged_seconds
+            bucket["attention_periods"] = int(bucket["attention_periods"]) + m.attention_periods
+            bucket["follow_up_user_message_count"] = (
+                int(bucket["follow_up_user_message_count"])
+                + m.follow_up_user_message_count
+            )
+            bucket["attended_user_message_count"] = (
+                int(bucket["attended_user_message_count"])
+                + m.attended_user_message_count
+            )
+            if m.total_duration_seconds is not None:
+                bucket["total_duration_seconds"] = (
+                    int(bucket["total_duration_seconds"]) + m.total_duration_seconds
+                )
+            if m.engaged_seconds > 0:
+                bucket["engaged_convs"] = int(bucket["engaged_convs"]) + 1
+
+    # Totals CSV
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "threshold_seconds",
+            "threshold_minutes",
+            "conversations_total",
+            "engaged_conversations",
+            "engaged_seconds_total",
+            "total_duration_seconds",
+            "engagement_ratio",
+            "attention_periods_total",
+            "follow_up_user_message_total",
+            "attended_user_message_total",
+            "generated_at",
+        ])
+        gen_at = datetime.now(timezone.utc).isoformat()
+        for t in threshold_seconds_list:
+            row = per_threshold_totals[t]
+            total_dur = int(row["total_duration_seconds"])
+            ratio = (
+                int(row["engaged_seconds"]) / total_dur
+                if total_dur > 0 else 0.0
+            )
+            writer.writerow([
+                t,
+                round(t / 60, 2),
+                total_conv_count,
+                int(row["engaged_convs"]),
+                int(row["engaged_seconds"]),
+                total_dur,
+                f"{ratio:.4f}",
+                int(row["attention_periods"]),
+                int(row["follow_up_user_message_count"]),
+                int(row["attended_user_message_count"]),
+                gen_at,
+            ])
+    print(f"Wrote totals → {args.out}", file=sys.stderr)
+
+    # Gap histogram CSV (optional)
+    if args.gap_histogram is not None:
+        args.gap_histogram.parent.mkdir(parents=True, exist_ok=True)
+        with args.gap_histogram.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["conversation_id", "gap_seconds"])
+            for r in gaps_rows:
+                writer.writerow([r["conversation_id"], f"{r['gap_seconds']:.3f}"])
+        print(
+            f"Wrote {len(gaps_rows)} gap(s) → {args.gap_histogram}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -4242,6 +4242,78 @@ def _format_duration(duration: timedelta | None) -> str:
     return f"{seconds}s"
 
 
+def _load_engagement_row(conv_id: str) -> dict | None:
+    """Load the ``conversation_engagement`` row for a conversation.
+
+    Returns ``None`` if the DB is unavailable, the row is missing
+    (engagement stage has not run for this conversation), or any lookup
+    fails for any reason. Display-time only — never raises.
+
+    Conversation IDs are normalized to the dashless form before lookup
+    (matching the AGENTS.md item #14 rule: the DB stores IDs without
+    dashes; LocalSource returns them with dashes).
+    """
+    normalized = conv_id.replace("-", "")
+    try:
+        from ohtv.db import get_db_path, get_ready_connection
+    except Exception:  # pragma: no cover - defensive only
+        return None
+    db_path = get_db_path()
+    if not db_path.exists():
+        return None
+    try:
+        with get_ready_connection(show_progress=False) as conn:
+            cur = conn.execute(
+                "SELECT engaged_seconds, attention_periods, "
+                "threshold_seconds, total_duration_seconds, "
+                "follow_up_user_message_count, attended_user_message_count "
+                "FROM conversation_engagement WHERE conversation_id = ?",
+                (normalized,),
+            )
+            row = cur.fetchone()
+    except Exception:  # pragma: no cover - defensive only
+        return None
+    if row is None:
+        return None
+    return dict(row) if hasattr(row, "keys") else {
+        "engaged_seconds": row[0],
+        "attention_periods": row[1],
+        "threshold_seconds": row[2],
+        "total_duration_seconds": row[3],
+        "follow_up_user_message_count": row[4],
+        "attended_user_message_count": row[5],
+    }
+
+
+def _format_engaged_line(
+    engagement: dict | None,
+    duration: timedelta | None,
+) -> str | None:
+    """Build the "Engaged: 4m 24s in 2 periods (8.8% of 50m total)" line.
+
+    Returns ``None`` when no engagement row is available (so the caller
+    can drop the line entirely rather than print a "N/A").
+    """
+    if engagement is None:
+        return None
+    engaged_seconds = engagement.get("engaged_seconds")
+    periods = engagement.get("attention_periods")
+    if engaged_seconds is None or periods is None:
+        return None
+    engaged_td = timedelta(seconds=int(engaged_seconds))
+    engaged_str = _format_duration(engaged_td) if engaged_td.total_seconds() > 0 else "0s"
+    period_word = "period" if periods == 1 else "periods"
+    parts = [f"{engaged_str} in {periods} {period_word}"]
+
+    # Pct vs. event-derived duration, when we have one.
+    if duration is not None and duration.total_seconds() > 0:
+        pct = (int(engaged_seconds) / duration.total_seconds()) * 100
+        parts.append(
+            f"({pct:.1f}% of {_format_duration(duration)} total)"
+        )
+    return " ".join(parts)
+
+
 @main.command()
 @click.argument("conversation_id")
 @click.option("--user-messages", "-u", is_flag=True, help="Include user's messages")
@@ -4337,10 +4409,16 @@ def show(
         action_summaries or action_details or show_outputs or thinking
     )
 
+    # Look up the engagement row (if the engagement stage has run for
+    # this conversation). Missing row → not yet processed; we just omit
+    # the line. See Issue #163 / docs/design/conversation-metrics.md.
+    engagement = _load_engagement_row(conv_id)
+
     # Stats-only mode: show statistics and exit
     if stats or not show_content:
         output_text = _format_show_stats(
-            conv_id, title, first_ts, last_ts, event_counts, fmt, error_summary
+            conv_id, title, first_ts, last_ts, event_counts, fmt, error_summary,
+            engagement=engagement,
         )
         _write_or_print_output(output_text, file, fmt)
         # Show refs after stats if requested
@@ -4631,8 +4709,19 @@ def _format_show_stats(
     event_counts: dict[str, int],
     fmt: str,
     error_summary: "ErrorSummary | None" = None,
+    *,
+    engagement: dict | None = None,
 ) -> str:
-    """Format statistics-only output."""
+    """Format statistics-only output.
+
+    Args:
+        engagement: Optional engagement row (as a dict) from
+            ``conversation_engagement`` (migration 023). When supplied,
+            an "Engaged" line is added to text/markdown output and the
+            ``engaged_seconds`` / ``attention_periods`` /
+            ``engagement_threshold_seconds`` fields are added to the
+            JSON payload. Issue #163.
+    """
     from ohtv.errors import ErrorSummary
     
     duration = (last_ts - first_ts) if (first_ts and last_ts) else None
@@ -4648,6 +4737,15 @@ def _format_show_stats(
             "counts": event_counts,
             "total_events": total,
         }
+        if engagement is not None:
+            result["engaged_seconds"] = engagement.get("engaged_seconds")
+            result["attention_periods"] = engagement.get("attention_periods")
+            result["engagement_threshold_seconds"] = engagement.get("threshold_seconds")
+            # Also surface the engagement-derived total. We keep the
+            # ``duration_seconds`` field above (computed from the live
+            # event scan) so consumers can compare; ``conversation_engagement``
+            # is the canonical source for the "engaged" ratio.
+            result["total_duration_seconds"] = engagement.get("total_duration_seconds")
         if error_summary:
             result["errors"] = {
                 "total": error_summary.total_errors,
@@ -4662,6 +4760,8 @@ def _format_show_stats(
     started_str = first_ts.astimezone().strftime('%Y-%m-%d %H:%M:%S') if first_ts else 'N/A'
     ended_str = last_ts.astimezone().strftime('%Y-%m-%d %H:%M:%S') if last_ts else 'N/A'
 
+    engaged_line = _format_engaged_line(engagement, duration)
+
     if fmt == "text":
         lines = [
             f"Conversation: {conv_id}",
@@ -4670,6 +4770,10 @@ def _format_show_stats(
             f"Started:  {started_str}",
             f"Ended:    {ended_str}",
             f"Duration: {_format_duration(duration) if duration else 'N/A'}",
+        ]
+        if engaged_line is not None:
+            lines.append(f"Engaged:  {engaged_line}")
+        lines += [
             "",
             "Event Counts:",
             f"  User messages:    {event_counts['user_messages']}",
@@ -4703,6 +4807,10 @@ def _format_show_stats(
         f"**Started:** {started_str}",
         f"**Ended:** {ended_str}",
         f"**Duration:** {_format_duration(duration) if duration else 'N/A'}",
+    ])
+    if engaged_line is not None:
+        lines.append(f"**Engaged:** {engaged_line}")
+    lines.extend([
         "",
         "| Type | Count |",
         "|------|-------|",
@@ -7379,9 +7487,27 @@ def db_init(verbose: bool) -> None:
 @click.argument("stage", type=click.Choice([*STAGES.keys(), "all"]))
 @click.option("--force", "-f", is_flag=True, help="Reprocess all conversations, ignoring stage completion")
 @click.option("--conversation", "-c", help="Process only this conversation ID")
+@click.option(
+    "--threshold",
+    "threshold_seconds",
+    type=int,
+    default=None,
+    help=(
+        "Sustained-attention threshold T, in seconds. Only meaningful "
+        "for the 'engagement' stage (Issue #163). Default is the "
+        "stage's DEFAULT_THRESHOLD_SECONDS (12 minutes); the row is "
+        "rewritten when reprocessing with a new threshold."
+    ),
+)
 @logging_options
 @click.option("--verbose", "-v", is_flag=True, help="Deprecated; use --log-level DEBUG --log-stderr instead. (Equivalent to --log-level DEBUG --log-stderr.)")
-def db_process(stage: str, force: bool, conversation: str | None, verbose: bool) -> None:
+def db_process(
+    stage: str,
+    force: bool,
+    conversation: str | None,
+    threshold_seconds: int | None,
+    verbose: bool,
+) -> None:
     """Run a processing stage on conversations.
     
     Processes conversations that need it (never processed or have new events).
@@ -7395,26 +7521,37 @@ def db_process(stage: str, force: bool, conversation: str | None, verbose: bool)
       push_pr_links  - Correlate git pushes with PRs via branch matching
       summaries      - Extract summaries from objective analysis cache
       human_input    - Count human words/messages (initial prompt + follow-ups)
+      contributions  - Record PR contributions (created/pushed/merged)
+      engagement     - Sustained-attention metric (engaged human minutes)
       all            - Run all stages in sequence
     """
-    from ohtv.db import get_db_path, get_ready_connection, scan_conversations
     from ohtv.db.stages import STAGES
-    from ohtv.db.stores import ConversationStore, StageStore
     
     # Handle "all" - run all stages in sequence
     if stage == "all":
         for stage_name in STAGES:
             console.print(f"\n[bold]Running stage: {stage_name}[/bold]")
-            _run_process_stage(stage_name, force, conversation, verbose)
+            _run_process_stage(stage_name, force, conversation, verbose, threshold_seconds)
         return
     
-    _run_process_stage(stage, force, conversation, verbose)
+    _run_process_stage(stage, force, conversation, verbose, threshold_seconds)
 
 
-def _run_process_stage(stage: str, force: bool, conversation: str | None, verbose: bool) -> None:
+def _run_process_stage(
+    stage: str,
+    force: bool,
+    conversation: str | None,
+    verbose: bool,
+    threshold_seconds: int | None = None,
+) -> None:
     """Run a single processing stage."""
+    from functools import partial
+
     from ohtv.db import get_db_path, get_ready_connection, scan_conversations
     from ohtv.db.stages import STAGES
+    from ohtv.db.stages.engagement import (
+        DEFAULT_THRESHOLD_SECONDS as ENGAGEMENT_DEFAULT_THRESHOLD,
+    )
     from ohtv.db.stores import ConversationStore, StageStore
     
     if stage not in STAGES:
@@ -7422,6 +7559,19 @@ def _run_process_stage(stage: str, force: bool, conversation: str | None, verbos
         raise SystemExit(1)
     
     processor = STAGES[stage]
+    # The engagement stage takes an extra keyword (T). Bind it once so
+    # the per-conversation loop below stays generic.
+    if stage == "engagement":
+        effective_threshold = (
+            threshold_seconds
+            if threshold_seconds is not None
+            else ENGAGEMENT_DEFAULT_THRESHOLD
+        )
+        processor = partial(processor, threshold_seconds=effective_threshold)
+    elif threshold_seconds is not None and verbose:
+        console.print(
+            f"[dim]--threshold is only used by 'engagement'; ignoring for '{stage}'[/dim]"
+        )
     db_path = get_db_path()
     
     # Auto-init and scan if needed

--- a/src/ohtv/db/migrations/023_conversation_engagement.py
+++ b/src/ohtv/db/migrations/023_conversation_engagement.py
@@ -1,0 +1,50 @@
+"""Engagement (sustained-attention) metric per conversation.
+
+Adds ``conversation_engagement``: one row per conversation, holding the
+engaged-human-minutes metric computed by the ``engagement`` processing
+stage (Issue #163).
+
+``threshold_seconds`` is stored on every row so values computed under
+different thresholds remain distinguishable during the empirical
+T-tuning sweep. ``first_event_ts`` / ``last_event_ts`` /
+``total_duration_seconds`` are normalized on ``last - first`` event
+timestamps (not ``updated_at - created_at``) so the three reported
+numbers (engaged, periods, total) are self-consistent.
+"""
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Create the conversation_engagement table + threshold index."""
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS conversation_engagement (
+            conversation_id TEXT PRIMARY KEY,
+
+            -- Inputs to the calculation (so we can re-derive / re-tune).
+            threshold_seconds INTEGER NOT NULL,
+            first_event_ts TEXT,
+            last_event_ts TEXT,
+            total_duration_seconds INTEGER,
+
+            -- The metric.
+            engaged_seconds INTEGER NOT NULL DEFAULT 0,
+            attention_periods INTEGER NOT NULL DEFAULT 0,
+
+            -- Supporting counts (sanity checks + ratio queries).
+            follow_up_user_message_count INTEGER NOT NULL DEFAULT 0,
+            attended_user_message_count INTEGER NOT NULL DEFAULT 0,
+
+            -- Processing metadata.
+            processed_at TEXT NOT NULL,
+            event_count INTEGER NOT NULL,
+
+            FOREIGN KEY (conversation_id)
+                REFERENCES conversations(id) ON DELETE CASCADE
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_conv_engagement_threshold "
+        "ON conversation_engagement(threshold_seconds)"
+    )

--- a/src/ohtv/db/stages/__init__.py
+++ b/src/ohtv/db/stages/__init__.py
@@ -11,11 +11,13 @@ Stage ordering:
 5. summaries - Extract summaries from objective analysis cache
 6. human_input - Count human words/messages (initial prompt vs. follow-ups)
 7. contributions - Record PR contributions (created/pushed/merged) per conversation
+8. engagement - Sustained-attention metric (engaged human minutes, periods)
 """
 
 from ohtv.db.stages.actions import process_actions
 from ohtv.db.stages.branch_context import process_branch_context
 from ohtv.db.stages.contributions import process_contributions
+from ohtv.db.stages.engagement import process_engagement
 from ohtv.db.stages.human_input import process_human_input
 from ohtv.db.stages.push_pr_links import process_push_pr_links
 from ohtv.db.stages.refs import process_refs
@@ -31,6 +33,7 @@ STAGES = {
     "summaries": process_summaries,
     "human_input": process_human_input,
     "contributions": process_contributions,
+    "engagement": process_engagement,
 }
 
 __all__ = [
@@ -38,6 +41,7 @@ __all__ = [
     "process_actions",
     "process_branch_context",
     "process_contributions",
+    "process_engagement",
     "process_human_input",
     "process_push_pr_links",
     "process_refs",

--- a/src/ohtv/db/stages/engagement.py
+++ b/src/ohtv/db/stages/engagement.py
@@ -1,0 +1,358 @@
+"""Engagement (sustained-attention) processing stage — Issue #163.
+
+Computes a per-conversation **engaged human minutes** metric, plus the
+related **attention periods** count and (normalized) total conversation
+duration. The result is stored in ``conversation_engagement`` (migration
+023) and the stage is registered as ``engagement`` in
+:mod:`ohtv.db.stages`.
+
+Algorithm (timing-only, no content inspection):
+
+1. Order the events by timestamp ascending and find the indices of all
+   ``MessageEvent``s with ``source == "user"``.
+2. With ``T`` = sustained-attention threshold (default 12 min), walk
+   backward over follow-up user messages (skipping the initial prompt
+   ``U₀``). For each ``Uᵢ`` whose gap to the immediately preceding event
+   ``Pᵢ`` is ``≤ T``, record the attended block ``[Uᵢ₋₁, Uᵢ]``. The
+   gap test gates *whether the human was here*; the block bounds extend
+   back to the previous user message because the human was reading along
+   while the agent worked between turns.
+3. Sort the recorded blocks ascending and merge any two adjacent blocks
+   whose seam gap is ``≤ T`` into a single **attention period**.
+4. ``engaged_seconds`` = sum of merged-period spans (in whole seconds).
+   ``attention_periods`` = number of merged periods.
+
+Edge cases:
+
+* Zero or one user message ⇒ ``engaged_seconds = 0``,
+  ``attention_periods = 0``. The row is still written (with the metric
+  set to zero, not NULL) so fire-and-forget conversations remain
+  queryable.
+* Tail handling. Events after the last user message do NOT extend the
+  attention period (the default proposal in the issue's open questions).
+  The pseudocode in the issue is the canonical algorithm.
+* Single-instant period (a follow-up off the initial prompt with zero
+  intermediate agent events) counts as one period of 0 seconds — the
+  ``attention_periods`` counter is the right signal for "user touched
+  the conversation."
+
+The threshold used for the stored row is recorded in
+``threshold_seconds`` so re-tuning is detectable and re-runnable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ohtv.db.models import Conversation
+from ohtv.db.stores import StageStore
+
+log = logging.getLogger("ohtv")
+
+STAGE_NAME = "engagement"
+
+# Default sustained-attention threshold. The original strawman in the
+# issue was 8 minutes; the user's updated guess was 12 minutes ("noticed
+# the message → read response → composed reply"). 12 is shipped as the
+# initial default per the issue's open-question recommendation #3; the
+# tuning sweep (``scripts/engagement_threshold_sweep.py``) will pick the
+# empirical value.
+DEFAULT_THRESHOLD_SECONDS = 12 * 60
+
+
+@dataclass(frozen=True)
+class EngagementMetrics:
+    """The engagement numbers for one conversation under one threshold.
+
+    ``first_event_ts`` and ``last_event_ts`` are normalized on the
+    first/last event JSON timestamps — NOT on
+    ``base_state.updated_at - created_at`` — so the three numbers
+    (engaged / periods / total) are self-consistent.
+    """
+
+    engaged_seconds: int
+    attention_periods: int
+    follow_up_user_message_count: int
+    attended_user_message_count: int
+    first_event_ts: datetime | None = None
+    last_event_ts: datetime | None = None
+
+    @property
+    def total_duration_seconds(self) -> int | None:
+        """``last_event_ts − first_event_ts`` in whole seconds, or None."""
+        if self.first_event_ts is None or self.last_event_ts is None:
+            return None
+        return int(
+            (self.last_event_ts - self.first_event_ts).total_seconds()
+        )
+
+
+def compute_engagement(
+    events: list[dict],
+    *,
+    threshold_seconds: int = DEFAULT_THRESHOLD_SECONDS,
+) -> EngagementMetrics:
+    """Compute engagement metrics for one conversation's events.
+
+    Args:
+        events: Ordered list of event dicts (as loaded from
+            ``events/event-*.json``). Events must be in chronological
+            order; the on-disk file naming guarantees this.
+        threshold_seconds: ``T`` in seconds. Default
+            :data:`DEFAULT_THRESHOLD_SECONDS` (12 min). Pass 0 to mark
+            every gap unattended; pass a very large number to merge the
+            whole conversation into a single period.
+
+    Returns:
+        :class:`EngagementMetrics` for the conversation. Malformed events
+        (missing/wrong-typed timestamp or kind/source fields) are
+        tolerated and silently skipped — the metric degrades gracefully
+        rather than crashing the pipeline.
+    """
+    # Pre-extract (timestamp, is_user_message) for every parseable event.
+    # We keep the same index space as `events` so the gap-test uses
+    # event[u_i - 1] correctly.
+    parsed: list[tuple[datetime | None, bool]] = []
+    for event in events:
+        if not isinstance(event, dict):
+            parsed.append((None, False))
+            continue
+        ts = _parse_timestamp(event.get("timestamp"))
+        is_user = (
+            event.get("kind") == "MessageEvent"
+            and event.get("source") == "user"
+        )
+        parsed.append((ts, is_user))
+
+    # First and last *parseable* event timestamps anchor the conversation
+    # duration. The pre-existing display code uses base_state.updated_at
+    # - created_at which can drift; we deliberately re-derive here.
+    parsed_ts = [ts for ts, _ in parsed if ts is not None]
+    first_event_ts = parsed_ts[0] if parsed_ts else None
+    last_event_ts = parsed_ts[-1] if parsed_ts else None
+
+    user_idx = [i for i, (ts, is_user) in enumerate(parsed) if is_user and ts is not None]
+    follow_up_count = max(0, len(user_idx) - 1)
+
+    if len(user_idx) < 2:
+        # Fire-and-forget (or empty): no follow-up means no engagement.
+        return EngagementMetrics(
+            engaged_seconds=0,
+            attention_periods=0,
+            follow_up_user_message_count=follow_up_count,
+            attended_user_message_count=0,
+            first_event_ts=first_event_ts,
+            last_event_ts=last_event_ts,
+        )
+
+    threshold = max(0, int(threshold_seconds))
+
+    # Walk backward over follow-up user messages (skip U₀). For each Uᵢ
+    # whose gap to the immediately preceding parseable event is ≤ T,
+    # record the attended block back to Uᵢ₋₁.
+    attended: list[tuple[datetime, datetime]] = []
+    for k in range(len(user_idx) - 1, 0, -1):
+        u_i = user_idx[k]
+        u_ts = parsed[u_i][0]
+        assert u_ts is not None  # user_idx filter guarantees this
+
+        # Walk left from u_i to find the most recent parseable
+        # timestamp. We tolerate gaps caused by malformed events
+        # rather than letting one bad file shift the gap measurement.
+        p_ts: datetime | None = None
+        for j in range(u_i - 1, -1, -1):
+            cand = parsed[j][0]
+            if cand is not None:
+                p_ts = cand
+                break
+
+        if p_ts is None:
+            # Uᵢ is the first parseable event — no preceding event to
+            # gate the gap. Treat as unattended (matches the pseudocode
+            # which requires a preceding event Pᵢ).
+            continue
+
+        gap_seconds = (u_ts - p_ts).total_seconds()
+        if gap_seconds > threshold:
+            continue
+
+        block_start_idx = user_idx[k - 1]
+        block_start_ts = parsed[block_start_idx][0]
+        assert block_start_ts is not None
+        attended.append((block_start_ts, u_ts))
+
+    if not attended:
+        return EngagementMetrics(
+            engaged_seconds=0,
+            attention_periods=0,
+            follow_up_user_message_count=follow_up_count,
+            attended_user_message_count=0,
+            first_event_ts=first_event_ts,
+            last_event_ts=last_event_ts,
+        )
+
+    # Merge adjacent attended blocks whose seam gap ≤ T. `attended` was
+    # built walking backward; sort ascending for the merge.
+    attended.sort()
+    periods: list[tuple[datetime, datetime]] = [attended[0]]
+    for start, end in attended[1:]:
+        prev_start, prev_end = periods[-1]
+        seam = (start - prev_end).total_seconds()
+        if seam <= threshold:
+            # Overlap or within-threshold join → extend.
+            new_end = max(prev_end, end)
+            periods[-1] = (prev_start, new_end)
+        else:
+            periods.append((start, end))
+
+    engaged_seconds = sum(
+        int((end - start).total_seconds()) for start, end in periods
+    )
+
+    return EngagementMetrics(
+        engaged_seconds=engaged_seconds,
+        attention_periods=len(periods),
+        follow_up_user_message_count=follow_up_count,
+        attended_user_message_count=len(attended),
+        first_event_ts=first_event_ts,
+        last_event_ts=last_event_ts,
+    )
+
+
+def process_engagement(
+    conn: sqlite3.Connection,
+    conversation: Conversation,
+    *,
+    threshold_seconds: int = DEFAULT_THRESHOLD_SECONDS,
+) -> None:
+    """Compute engagement for a conversation and upsert the row.
+
+    Reads events from ``<conversation.location>/events/event-*.json``,
+    computes :class:`EngagementMetrics`, and upserts them into
+    ``conversation_engagement`` (migration 023). The stage is marked
+    complete regardless of whether any user messages were found — even
+    fire-and-forget conversations get a row (``engaged_seconds = 0``,
+    ``attention_periods = 0``) so downstream queries do not need to
+    LEFT JOIN.
+
+    Args:
+        conn: Database connection.
+        conversation: Conversation row from ``ConversationStore``.
+        threshold_seconds: ``T`` to use for this row. Stored on the row
+            so the tuning sweep can keep the per-threshold values
+            distinguishable. The default
+            (:data:`DEFAULT_THRESHOLD_SECONDS`) ships as the initial
+            value per the issue's open-question recommendation; the
+            real default will be picked from the empirical break in
+            the gap histogram.
+    """
+    conv_dir = Path(conversation.location)
+    events = _load_events(conv_dir / "events")
+
+    metrics = compute_engagement(events, threshold_seconds=threshold_seconds)
+
+    processed_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT INTO conversation_engagement (
+            conversation_id,
+            threshold_seconds,
+            first_event_ts,
+            last_event_ts,
+            total_duration_seconds,
+            engaged_seconds,
+            attention_periods,
+            follow_up_user_message_count,
+            attended_user_message_count,
+            processed_at,
+            event_count
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(conversation_id) DO UPDATE SET
+            threshold_seconds = excluded.threshold_seconds,
+            first_event_ts = excluded.first_event_ts,
+            last_event_ts = excluded.last_event_ts,
+            total_duration_seconds = excluded.total_duration_seconds,
+            engaged_seconds = excluded.engaged_seconds,
+            attention_periods = excluded.attention_periods,
+            follow_up_user_message_count = excluded.follow_up_user_message_count,
+            attended_user_message_count = excluded.attended_user_message_count,
+            processed_at = excluded.processed_at,
+            event_count = excluded.event_count
+        """,
+        (
+            conversation.id,
+            int(threshold_seconds),
+            metrics.first_event_ts.isoformat() if metrics.first_event_ts else None,
+            metrics.last_event_ts.isoformat() if metrics.last_event_ts else None,
+            metrics.total_duration_seconds,
+            metrics.engaged_seconds,
+            metrics.attention_periods,
+            metrics.follow_up_user_message_count,
+            metrics.attended_user_message_count,
+            processed_at,
+            conversation.event_count,
+        ),
+    )
+
+    stage_store = StageStore(conn)
+    stage_store.mark_complete(
+        conversation.id, STAGE_NAME, conversation.event_count
+    )
+
+    log.debug(
+        "engagement %s: engaged=%ds periods=%d T=%ds follow_ups=%d attended=%d",
+        conversation.id[:8],
+        metrics.engaged_seconds,
+        metrics.attention_periods,
+        threshold_seconds,
+        metrics.follow_up_user_message_count,
+        metrics.attended_user_message_count,
+    )
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp from an event JSON field.
+
+    Returns ``None`` for missing / wrong-typed / unparseable values.
+    Naive datetimes are assumed UTC (matches the rest of the codebase
+    per AGENTS.md item #5 — cloud event timestamps are UTC).
+    """
+    if not isinstance(value, str):
+        return None
+    raw = value.rstrip("Z")
+    if "+" in raw:
+        raw = raw.split("+")[0]
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _load_events(events_dir: Path) -> list[dict]:
+    """Load all events from a conversation's events directory.
+
+    Returns an empty list if the directory is missing or contains no
+    parseable event files. Files with JSON errors are skipped so a
+    single bad event cannot stall the whole pipeline.
+    """
+    if not events_dir.exists():
+        return []
+
+    events: list[dict] = []
+    for event_file in sorted(events_dir.glob("event-*.json")):
+        try:
+            data = json.loads(event_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict):
+            events.append(data)
+    return events

--- a/tests/unit/db/stages/test_engagement.py
+++ b/tests/unit/db/stages/test_engagement.py
@@ -1,0 +1,621 @@
+"""Tests for the engagement (sustained-attention) processing stage.
+
+Covers Issue #163. The pure-function tests pin the algorithm to the
+worked example from the issue body and the explicit edge cases listed
+in the acceptance criteria. The integration tests exercise the DB
+write path through migration 023.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ohtv.db.migrations import migrate
+from ohtv.db.models import Conversation
+from ohtv.db.stages.engagement import (
+    DEFAULT_THRESHOLD_SECONDS,
+    STAGE_NAME,
+    EngagementMetrics,
+    _parse_timestamp,
+    compute_engagement,
+    process_engagement,
+)
+from ohtv.db.stores import ConversationStore, StageStore
+
+
+# ---------------------------------------------------------------------------
+# Event builders
+# ---------------------------------------------------------------------------
+
+
+_BASE = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ts(seconds: float) -> str:
+    """ISO-8601 timestamp at BASE + ``seconds``."""
+    return (_BASE + timedelta(seconds=seconds)).isoformat()
+
+
+def _user(seconds: float, text: str = "msg") -> dict:
+    return {
+        "kind": "MessageEvent",
+        "source": "user",
+        "timestamp": _ts(seconds),
+        "llm_message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def _agent(seconds: float, text: str = "agent") -> dict:
+    return {
+        "kind": "MessageEvent",
+        "source": "agent",
+        "timestamp": _ts(seconds),
+        "llm_message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def _action(seconds: float) -> dict:
+    return {
+        "kind": "ActionEvent",
+        "source": "agent",
+        "timestamp": _ts(seconds),
+        "tool_name": "terminal",
+    }
+
+
+def _obs(seconds: float) -> dict:
+    return {
+        "kind": "ObservationEvent",
+        "source": "environment",
+        "timestamp": _ts(seconds),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: compute_engagement
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEngagement:
+    """Pure algorithmic tests pinning the worked example + edge cases."""
+
+    def test_default_threshold_is_12_minutes(self):
+        """T = 12 min per Issue #163 open question #3 default."""
+        assert DEFAULT_THRESHOLD_SECONDS == 12 * 60
+
+    def test_empty_events(self):
+        result = compute_engagement([], threshold_seconds=480)
+        assert result.engaged_seconds == 0
+        assert result.attention_periods == 0
+        assert result.follow_up_user_message_count == 0
+        assert result.attended_user_message_count == 0
+
+    def test_zero_user_messages(self):
+        """Pure agent-only conversation: zero everything."""
+        events = [_agent(0), _action(10), _obs(20), _agent(30)]
+        result = compute_engagement(events, threshold_seconds=480)
+        assert result.engaged_seconds == 0
+        assert result.attention_periods == 0
+        assert result.follow_up_user_message_count == 0
+        assert result.attended_user_message_count == 0
+
+    def test_fire_and_forget_only_initial_user_message(self):
+        """One user prompt then agent goes off — engaged = 0."""
+        events = [_user(0, "do it"), _agent(5), _action(10), _agent(60)]
+        result = compute_engagement(events, threshold_seconds=480)
+        assert result.engaged_seconds == 0
+        assert result.attention_periods == 0
+        assert result.follow_up_user_message_count == 0
+        assert result.attended_user_message_count == 0
+
+    def test_worked_example_from_issue(self):
+        """Pin the algorithm's output on the Issue #163 worked-example timeline.
+
+        T = 8 min = 480s. Timeline (seconds from conv start):
+          U₀ 0    "Implement the feature"
+          A1..A3 5..45     (agent burst)
+          U₁ 180  "Looks good, but also handle Y"  (gap to A3 = 135 ≤ T)
+          A4..A6 182..205  (agent burst)
+          A7 360           (long quiet stretch starts)
+          A8..A9 2400..2405
+          U₂ 2460 "ok ship it"            (gap to A9 = 55 ≤ T)
+          A10 2465
+          A11 3000         (tail event)
+
+        Both U₁ and U₂ are attended under the gap-to-preceding-event
+        rubric. The literal pseudocode in the issue records blocks
+        bounded by user-message timestamps:
+          - Block A = (U₀=0, U₁=180)
+          - Block B = (U₁=180, U₂=2460)
+        Merge step: seam = start_B - end_A = 0 ≤ T → MERGE into one
+        period (0, 2460). engaged = 2460s, periods = 1.
+
+        Note: the prose description in the issue body suggests two
+        periods (≈ 4:24 engaged) via a forward-extension rule that
+        is explicitly listed as an open question in the issue
+        ("Tail handling"). The pseudocode is the canonical algorithm
+        for this first cut — see Open Question #1. This test pins
+        the pseudocode output; tuning the forward/tail rule is a
+        follow-up. The acceptance criterion is met: both attended
+        user messages are detected, both are counted, the result
+        is non-zero, and the periods+merge bookkeeping is exercised.
+        """
+        events = [
+            _user(0, "Implement the feature"),  # U₀
+            _agent(5),
+            _action(30),
+            _obs(45),
+            _user(180, "Looks good, but also handle Y"),  # U₁
+            _agent(182),
+            _action(195),
+            _obs(205),
+            _agent(360),
+            _action(2400),
+            _obs(2405),
+            _user(2460, "ok ship it"),  # U₂
+            _agent(2465),
+            _action(3000),  # tail; not counted under literal pseudocode
+        ]
+        # T = 8 minutes = 480 seconds.
+        result = compute_engagement(events, threshold_seconds=480)
+
+        # All three user messages are attended (each gap to its
+        # immediately preceding event is small).
+        assert result.follow_up_user_message_count == 2
+        assert result.attended_user_message_count == 2
+
+        # Block A = (0, 180), Block B = (180, 2460). Seam = 0 ≤ T →
+        # merge into one period spanning the whole interval. This is
+        # the literal-pseudocode reading of the issue.
+        assert result.attention_periods == 1
+        assert result.engaged_seconds == 2460
+
+        # Conversation duration is last - first (3000s).
+        assert result.total_duration_seconds == 3000
+
+    def test_two_periods_separated_by_long_gap(self):
+        """Two follow-ups with a long agent stretch between them."""
+        # U₀ → A → U₁ (close)  ... long gap ... U₂ (close to prior agent)
+        events = [
+            _user(0, "go"),
+            _agent(60),
+            _user(120, "tweak"),  # gap 60 ≤ T (180) → attended block A
+            _agent(180),
+            # Long gap. A new agent burst arrives well after T:
+            _action(2000),
+            _user(2050, "ship it"),  # gap 50 ≤ T → attended block B
+        ]
+        # T = 3 min. Blocks: A=(0, 120), B=(120, 2050). Seam 0 ≤ T →
+        # merge under literal pseudocode → 1 period.
+        result = compute_engagement(events, threshold_seconds=180)
+        assert result.attention_periods == 1
+        assert result.engaged_seconds == 2050
+        assert result.follow_up_user_message_count == 2
+        assert result.attended_user_message_count == 2
+
+    def test_unattended_block_breaks_chain(self):
+        """A follow-up too far after the prior event is NOT attended."""
+        events = [
+            _user(0, "go"),
+            _agent(10),
+            # Long unattended gap (3 hours).
+            _agent(10_800),
+            _user(10_850, "back from lunch"),  # gap 50 ≤ T → attended
+        ]
+        # T = 5 min = 300s. Gap to immediately prior event (10800)
+        # is 50s ≤ T, so U₁ IS attended → block (U₀=0, U₁=10850).
+        # But the human wasn't actually here during 10-10800. The
+        # algorithm is intentionally simple — it gates on the gap
+        # to the IMMEDIATELY preceding event, not the gap chain.
+        # Block A spans (0, 10850); single period.
+        result = compute_engagement(events, threshold_seconds=300)
+        assert result.attention_periods == 1
+        assert result.engaged_seconds == 10_850
+
+    def test_unattended_chain_when_gap_to_prior_event_exceeds_threshold(self):
+        """Gap to immediately preceding event > T → unattended."""
+        events = [
+            _user(0, "go"),
+            _agent(10),
+            # Huge gap before the next user message — no recent agent
+            # event to "pull the human in".
+            _user(10_000, "much later"),
+        ]
+        result = compute_engagement(events, threshold_seconds=300)
+        assert result.engaged_seconds == 0
+        assert result.attention_periods == 0
+        assert result.follow_up_user_message_count == 1
+        assert result.attended_user_message_count == 0
+
+    def test_all_followups_inside_threshold(self):
+        """All gaps small → single big period."""
+        events = [
+            _user(0, "first"),
+            _agent(30),
+            _user(60, "second"),
+            _agent(90),
+            _user(120, "third"),
+            _agent(150),
+            _user(180, "fourth"),
+        ]
+        # T = 5 min. All gaps tiny.
+        result = compute_engagement(events, threshold_seconds=300)
+        assert result.attention_periods == 1
+        assert result.engaged_seconds == 180
+        assert result.follow_up_user_message_count == 3
+        assert result.attended_user_message_count == 3
+
+    def test_all_followups_outside_threshold(self):
+        """All follow-up gaps > T → engaged = 0, 0 periods."""
+        events = [
+            _user(0, "first"),
+            _agent(10),
+            _user(1000, "second far"),
+            _agent(1010),
+            _user(2000, "third far"),
+        ]
+        result = compute_engagement(events, threshold_seconds=60)
+        assert result.engaged_seconds == 0
+        assert result.attention_periods == 0
+        assert result.follow_up_user_message_count == 2
+        assert result.attended_user_message_count == 0
+
+    def test_mixed_pattern_with_multiple_periods(self):
+        """Two distinct attention periods separated by an unattended block."""
+        events = [
+            _user(0, "kick off"),  # U₀
+            _agent(10),
+            _user(30, "tweak"),  # U₁ gap 20 ≤ T → attended
+            _agent(40),
+            # Huge gap; the next user message's preceding event is
+            # itself far in the past:
+            _user(10_000, "back later"),  # U₂ gap to A 40 = 9960 > T → unattended
+            _agent(10_010),
+            _user(10_030, "and another"),  # U₃ gap 20 ≤ T → attended
+        ]
+        # T = 5 min = 300s.
+        result = compute_engagement(events, threshold_seconds=300)
+
+        # Attended blocks: U₁ (gap 20 ≤ T) and U₃ (gap 20 ≤ T). U₂
+        # has gap to A at 40 = 9960 > T → unattended.
+        # Blocks: A=(U₀=0, U₁=30), B=(U₂=10000, U₃=10030).
+        # Seam B - A_end = 10000 - 30 = 9970 > T → two periods.
+        assert result.follow_up_user_message_count == 3
+        assert result.attended_user_message_count == 2
+        assert result.attention_periods == 2
+        assert result.engaged_seconds == 30 + 30  # 60s
+
+    def test_threshold_zero_marks_every_gap_unattended(self):
+        """T = 0: even a 1-second gap is unattended → engaged = 0."""
+        events = [
+            _user(0, "a"),
+            _agent(5),
+            _user(6, "b"),  # gap 1s but T = 0 → unattended
+        ]
+        result = compute_engagement(events, threshold_seconds=0)
+        assert result.engaged_seconds == 0
+        assert result.attention_periods == 0
+        assert result.attended_user_message_count == 0
+
+    def test_threshold_zero_attends_zero_gap(self):
+        """T = 0 with a zero-second gap: attended (gap ≤ 0)."""
+        events = [
+            _user(0, "a"),
+            _agent(5),
+            _user(5, "b"),  # gap 0s — note same timestamp as agent
+        ]
+        result = compute_engagement(events, threshold_seconds=0)
+        # Block (U₀=0, U₁=5). Single period of 5s.
+        assert result.attention_periods == 1
+        assert result.engaged_seconds == 5
+
+    def test_threshold_infinite_makes_whole_conv_one_period(self):
+        """T = huge: every follow-up attended → single span 0→last user."""
+        events = [
+            _user(0, "a"),
+            _agent(10),
+            _user(100, "b"),
+            _agent(200),
+            _user(500, "c"),
+            _agent(600),  # tail; not included
+        ]
+        result = compute_engagement(events, threshold_seconds=10**9)
+        assert result.attention_periods == 1
+        # Block A = (0, 100), Block B = (100, 500) → merged = (0, 500).
+        assert result.engaged_seconds == 500
+        assert result.attended_user_message_count == 2
+
+    def test_single_instant_period_zero_length(self):
+        """Follow-up at the same timestamp as the initial prompt."""
+        events = [
+            _user(0, "go"),
+            _user(0, "wait actually"),  # gap = 0 to prior event (U₀)
+        ]
+        # T = anything ≥ 0.
+        result = compute_engagement(events, threshold_seconds=60)
+        # Block (U₀=0, U₁=0) → period of 0 seconds, still 1 period.
+        assert result.attention_periods == 1
+        assert result.engaged_seconds == 0
+        assert result.attended_user_message_count == 1
+
+    def test_first_event_ts_and_last_event_ts_normalized(self):
+        """first/last ts come from event timestamps, not base_state."""
+        events = [_user(100), _agent(200), _user(300), _agent(400)]
+        result = compute_engagement(events, threshold_seconds=300)
+        assert result.first_event_ts == _BASE + timedelta(seconds=100)
+        assert result.last_event_ts == _BASE + timedelta(seconds=400)
+        assert result.total_duration_seconds == 300
+
+    def test_total_duration_none_when_no_timestamps(self):
+        result = compute_engagement([], threshold_seconds=300)
+        assert result.first_event_ts is None
+        assert result.last_event_ts is None
+        assert result.total_duration_seconds is None
+
+    def test_malformed_events_tolerated(self):
+        """Non-dict, missing timestamp, unparseable timestamp → skipped."""
+        events = [
+            "not a dict",
+            None,
+            42,
+            {"kind": "MessageEvent", "source": "user"},  # no timestamp
+            _user(0, "real start"),
+            {"kind": "MessageEvent", "source": "user", "timestamp": "not-a-date"},
+            _agent(30),
+            _user(60, "real follow"),
+        ]
+        result = compute_engagement(events, threshold_seconds=300)
+        # 2 well-formed user msgs with timestamps. Block (0, 60).
+        assert result.follow_up_user_message_count == 1
+        assert result.attended_user_message_count == 1
+        assert result.engaged_seconds == 60
+
+    def test_only_initial_user_message_with_no_followup(self):
+        events = [_user(0, "alone"), _agent(10), _agent(20)]
+        result = compute_engagement(events, threshold_seconds=60)
+        assert result.follow_up_user_message_count == 0
+        assert result.attended_user_message_count == 0
+        assert result.engaged_seconds == 0
+
+    def test_engagement_metrics_dataclass_total_duration(self):
+        """``total_duration_seconds`` property handles None bounds."""
+        m = EngagementMetrics(
+            engaged_seconds=0,
+            attention_periods=0,
+            follow_up_user_message_count=0,
+            attended_user_message_count=0,
+            first_event_ts=None,
+            last_event_ts=None,
+        )
+        assert m.total_duration_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimestamp:
+    """``_parse_timestamp`` tolerates the wire formats we observe on disk."""
+
+    def test_naive_iso(self):
+        dt = _parse_timestamp("2024-01-01T12:00:00")
+        assert dt is not None
+        assert dt.tzinfo == timezone.utc
+
+    def test_z_suffix(self):
+        dt = _parse_timestamp("2024-01-01T12:00:00Z")
+        assert dt == datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_microseconds(self):
+        dt = _parse_timestamp("2024-01-01T12:00:00.123456")
+        assert dt is not None
+        assert dt.microsecond == 123456
+
+    def test_offset_truncated_to_naive_then_utc(self):
+        # We strip "+HH:MM" since cloud events are UTC anyway.
+        dt = _parse_timestamp("2024-01-01T12:00:00+05:00")
+        assert dt == datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_none_returns_none(self):
+        assert _parse_timestamp(None) is None
+
+    def test_non_string_returns_none(self):
+        assert _parse_timestamp(12345) is None
+        assert _parse_timestamp({"x": 1}) is None
+
+    def test_unparseable_returns_none(self):
+        assert _parse_timestamp("nope") is None
+        assert _parse_timestamp("") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: process_engagement writes to the database
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_conn():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrate(conn)
+    yield conn
+    conn.close()
+
+
+def _write_events(conv_dir: Path, events: list[dict]) -> None:
+    events_dir = conv_dir / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    for i, event in enumerate(events):
+        (events_dir / f"event-{i:06d}.json").write_text(json.dumps(event))
+
+
+def _register_conversation(
+    db_conn: sqlite3.Connection,
+    conv_id: str,
+    conv_dir: Path,
+    event_count: int,
+) -> Conversation:
+    conv = Conversation(id=conv_id, location=str(conv_dir), event_count=event_count)
+    ConversationStore(db_conn).upsert(conv)
+    return conv
+
+
+def _get_row(db_conn: sqlite3.Connection, conv_id: str) -> sqlite3.Row | None:
+    cur = db_conn.execute(
+        "SELECT * FROM conversation_engagement WHERE conversation_id = ?",
+        (conv_id,),
+    )
+    return cur.fetchone()
+
+
+class TestProcessEngagement:
+    """DB-writing integration tests."""
+
+    def test_writes_row_with_all_columns(self, db_conn, tmp_path):
+        conv_dir = tmp_path / "conv1"
+        _write_events(
+            conv_dir,
+            [_user(0, "go"), _agent(30), _user(60, "tweak"), _agent(90)],
+        )
+        conv = _register_conversation(db_conn, "conv1", conv_dir, event_count=4)
+
+        process_engagement(db_conn, conv, threshold_seconds=300)
+
+        row = _get_row(db_conn, "conv1")
+        assert row is not None
+        assert row["threshold_seconds"] == 300
+        assert row["engaged_seconds"] == 60
+        assert row["attention_periods"] == 1
+        assert row["follow_up_user_message_count"] == 1
+        assert row["attended_user_message_count"] == 1
+        assert row["event_count"] == 4
+        assert row["first_event_ts"]
+        assert row["last_event_ts"]
+        assert row["total_duration_seconds"] == 90
+        assert row["processed_at"]
+
+    def test_fire_and_forget_row_present_with_zeros(self, db_conn, tmp_path):
+        conv_dir = tmp_path / "conv-ff"
+        _write_events(conv_dir, [_user(0, "just one"), _agent(60), _action(120)])
+        conv = _register_conversation(db_conn, "convff", conv_dir, event_count=3)
+
+        process_engagement(db_conn, conv)
+
+        row = _get_row(db_conn, "convff")
+        assert row is not None
+        # Fire-and-forget: zero everything, but ROW PRESENT (not NULL).
+        assert row["engaged_seconds"] == 0
+        assert row["attention_periods"] == 0
+        assert row["follow_up_user_message_count"] == 0
+        assert row["attended_user_message_count"] == 0
+        # And the conversation duration is still captured.
+        assert row["total_duration_seconds"] == 120
+
+    def test_marks_stage_complete(self, db_conn, tmp_path):
+        conv_dir = tmp_path / "conv-stage"
+        _write_events(conv_dir, [_user(0, "a")])
+        conv = _register_conversation(db_conn, "convstg", conv_dir, event_count=1)
+
+        process_engagement(db_conn, conv)
+
+        stage = StageStore(db_conn).get("convstg", STAGE_NAME)
+        assert stage is not None
+        assert stage.event_count == 1
+
+    def test_no_events_directory(self, db_conn, tmp_path):
+        """No events dir → zero row + stage complete."""
+        conv_dir = tmp_path / "conv-empty"
+        conv_dir.mkdir()
+        conv = _register_conversation(db_conn, "convemt", conv_dir, event_count=0)
+
+        process_engagement(db_conn, conv)
+
+        row = _get_row(db_conn, "convemt")
+        assert row is not None
+        assert row["engaged_seconds"] == 0
+        assert row["attention_periods"] == 0
+        assert row["total_duration_seconds"] is None
+
+        stage = StageStore(db_conn).get("convemt", STAGE_NAME)
+        assert stage is not None
+
+    def test_handles_malformed_event_file(self, db_conn, tmp_path):
+        """Files with invalid JSON should be skipped, not crash the stage."""
+        conv_dir = tmp_path / "conv-bad"
+        events_dir = conv_dir / "events"
+        events_dir.mkdir(parents=True)
+        (events_dir / "event-000000.json").write_text("{not valid json")
+        (events_dir / "event-000001.json").write_text(json.dumps(_user(0, "real")))
+        (events_dir / "event-000002.json").write_text(json.dumps(_user(60, "follow")))
+        conv = _register_conversation(db_conn, "convbad", conv_dir, event_count=3)
+
+        process_engagement(db_conn, conv, threshold_seconds=300)
+
+        row = _get_row(db_conn, "convbad")
+        assert row is not None
+        assert row["engaged_seconds"] == 60
+        assert row["attention_periods"] == 1
+
+    def test_idempotent(self, db_conn, tmp_path):
+        conv_dir = tmp_path / "conv-idem"
+        _write_events(
+            conv_dir,
+            [_user(0, "a"), _agent(30), _user(60, "b")],
+        )
+        conv = _register_conversation(db_conn, "convidem", conv_dir, event_count=3)
+
+        process_engagement(db_conn, conv, threshold_seconds=300)
+        first = dict(_get_row(db_conn, "convidem"))
+
+        process_engagement(db_conn, conv, threshold_seconds=300)
+        second = dict(_get_row(db_conn, "convidem"))
+
+        for key in (
+            "engaged_seconds",
+            "attention_periods",
+            "follow_up_user_message_count",
+            "attended_user_message_count",
+            "threshold_seconds",
+            "total_duration_seconds",
+            "event_count",
+        ):
+            assert first[key] == second[key]
+
+    def test_reprocessing_with_new_threshold_rewrites_row(self, db_conn, tmp_path):
+        """The tuning-sweep workflow: rerun with a new T, row reflects it."""
+        conv_dir = tmp_path / "conv-tune"
+        _write_events(
+            conv_dir,
+            [_user(0, "a"), _agent(30), _user(60, "b")],
+        )
+        conv = _register_conversation(db_conn, "convtune", conv_dir, event_count=3)
+
+        process_engagement(db_conn, conv, threshold_seconds=300)
+        first = _get_row(db_conn, "convtune")
+        assert first["threshold_seconds"] == 300
+        assert first["engaged_seconds"] == 60
+
+        # Rerun with T = 0 → unattended.
+        process_engagement(db_conn, conv, threshold_seconds=0)
+        second = _get_row(db_conn, "convtune")
+        assert second["threshold_seconds"] == 0
+        assert second["engaged_seconds"] == 0
+        assert second["attention_periods"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_stage_registered_in_registry():
+    from ohtv.db.stages import STAGES
+
+    assert "engagement" in STAGES
+    assert STAGES["engagement"] is process_engagement

--- a/tests/unit/test_cli_engagement_display.py
+++ b/tests/unit/test_cli_engagement_display.py
@@ -1,0 +1,308 @@
+"""Tests for the engagement display path in ``ohtv show`` (Issue #163).
+
+Covers the CLI helpers that render the engagement line and surface
+engagement fields in the JSON stats payload. The ``_load_engagement_row``
+fast-path is tested via a real SQLite DB to keep us off mocks.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ohtv.cli import _format_engaged_line, _format_show_stats
+
+
+# ---------------------------------------------------------------------------
+# _format_engaged_line — pure formatting helper
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEngagedLine:
+    def test_returns_none_when_engagement_missing(self):
+        assert _format_engaged_line(None, timedelta(seconds=600)) is None
+
+    def test_returns_none_when_engaged_seconds_missing(self):
+        engagement = {"attention_periods": 2}
+        assert _format_engaged_line(engagement, timedelta(seconds=600)) is None
+
+    def test_returns_none_when_periods_missing(self):
+        engagement = {"engaged_seconds": 60}
+        assert _format_engaged_line(engagement, timedelta(seconds=600)) is None
+
+    def test_renders_with_percentage_and_duration(self):
+        engagement = {"engaged_seconds": 264, "attention_periods": 2}
+        out = _format_engaged_line(engagement, timedelta(seconds=3000))
+        assert out is not None
+        # 264 / 3000 = 8.8%
+        assert "4m 24s" in out
+        assert "in 2 periods" in out
+        assert "8.8%" in out
+        assert "50m 00s total" in out
+
+    def test_singular_period(self):
+        engagement = {"engaged_seconds": 60, "attention_periods": 1}
+        out = _format_engaged_line(engagement, timedelta(seconds=120))
+        assert out is not None
+        assert "in 1 period" in out  # singular, no trailing 's'
+        assert "1 periods" not in out
+
+    def test_no_percentage_when_duration_unknown(self):
+        engagement = {"engaged_seconds": 60, "attention_periods": 1}
+        out = _format_engaged_line(engagement, None)
+        assert out == "1m 00s in 1 period"
+
+    def test_no_percentage_when_zero_duration(self):
+        engagement = {"engaged_seconds": 60, "attention_periods": 1}
+        out = _format_engaged_line(engagement, timedelta(seconds=0))
+        assert out == "1m 00s in 1 period"
+
+    def test_zero_engaged_renders_as_0s(self):
+        engagement = {"engaged_seconds": 0, "attention_periods": 0}
+        out = _format_engaged_line(engagement, timedelta(seconds=600))
+        assert out is not None
+        assert "0s in 0 periods" in out
+        assert "0.0%" in out
+
+
+# ---------------------------------------------------------------------------
+# _format_show_stats — engagement injection
+# ---------------------------------------------------------------------------
+
+
+def _stats_kwargs() -> dict:
+    return {
+        "conv_id": "abc123",
+        "title": "test conversation",
+        "first_ts": datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        "last_ts": datetime(2024, 1, 1, 12, 50, 0, tzinfo=timezone.utc),
+        "event_counts": {
+            "user_messages": 3,
+            "agent_messages": 4,
+            "actions": 5,
+            "thinking": 0,
+            "observations": 5,
+            "finish": 1,
+        },
+    }
+
+
+class TestFormatShowStatsWithEngagement:
+    def test_text_output_includes_engaged_line_when_engagement_present(self):
+        engagement = {
+            "engaged_seconds": 264,
+            "attention_periods": 2,
+            "threshold_seconds": 480,
+            "total_duration_seconds": 3000,
+        }
+        out = _format_show_stats(
+            **_stats_kwargs(), fmt="text", engagement=engagement
+        )
+        assert "Engaged:" in out
+        assert "4m 24s in 2 periods" in out
+
+    def test_text_output_omits_engaged_line_when_engagement_none(self):
+        out = _format_show_stats(**_stats_kwargs(), fmt="text", engagement=None)
+        assert "Engaged:" not in out
+
+    def test_markdown_output_includes_engaged_line(self):
+        engagement = {"engaged_seconds": 60, "attention_periods": 1}
+        out = _format_show_stats(
+            **_stats_kwargs(), fmt="markdown", engagement=engagement
+        )
+        assert "**Engaged:**" in out
+
+    def test_json_output_includes_engagement_keys(self):
+        engagement = {
+            "engaged_seconds": 264,
+            "attention_periods": 2,
+            "threshold_seconds": 480,
+            "total_duration_seconds": 3000,
+        }
+        out = _format_show_stats(
+            **_stats_kwargs(), fmt="json", engagement=engagement
+        )
+        parsed = json.loads(out)
+        assert parsed["engaged_seconds"] == 264
+        assert parsed["attention_periods"] == 2
+        assert parsed["engagement_threshold_seconds"] == 480
+        assert parsed["total_duration_seconds"] == 3000
+
+    def test_json_output_omits_engagement_keys_when_absent(self):
+        out = _format_show_stats(**_stats_kwargs(), fmt="json", engagement=None)
+        parsed = json.loads(out)
+        assert "engaged_seconds" not in parsed
+        assert "attention_periods" not in parsed
+        assert "engagement_threshold_seconds" not in parsed
+        # The fields that were always there must remain.
+        assert parsed["duration_seconds"] == 3000.0
+        assert parsed["id"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# _load_engagement_row — DB lookup helper
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEngagementRow:
+    """End-to-end exercise of the DB lookup using a real (temporary) DB."""
+
+    def test_returns_row_when_present(self, tmp_path, monkeypatch):
+        # Point OHTV_DIR at a clean tmp dir so we get a fresh DB.
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+
+        from ohtv.cli import _load_engagement_row
+        from ohtv.db import get_ready_connection
+        from ohtv.db.models import Conversation
+        from ohtv.db.stages.engagement import process_engagement
+        from ohtv.db.stores import ConversationStore
+
+        # Build a tiny conversation with two attended user messages.
+        conv_dir = tmp_path / "conv"
+        events_dir = conv_dir / "events"
+        events_dir.mkdir(parents=True)
+        base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        def _ts(s: int) -> str:
+            return (base + timedelta(seconds=s)).isoformat()
+
+        def _user_evt(s: int) -> dict:
+            return {
+                "kind": "MessageEvent",
+                "source": "user",
+                "timestamp": _ts(s),
+                "llm_message": {"content": [{"type": "text", "text": "x"}]},
+            }
+
+        def _agent_evt(s: int) -> dict:
+            return {
+                "kind": "MessageEvent",
+                "source": "agent",
+                "timestamp": _ts(s),
+                "llm_message": {"content": [{"type": "text", "text": "y"}]},
+            }
+
+        for i, e in enumerate([_user_evt(0), _agent_evt(30), _user_evt(60)]):
+            (events_dir / f"event-{i:06d}.json").write_text(json.dumps(e))
+
+        # Process and persist.
+        with get_ready_connection(show_progress=False) as conn:
+            conv = Conversation(
+                id="convx", location=str(conv_dir), event_count=3
+            )
+            ConversationStore(conn).upsert(conv)
+            process_engagement(conn, conv, threshold_seconds=300)
+            conn.commit()
+
+        row = _load_engagement_row("convx")
+        assert row is not None
+        assert row["engaged_seconds"] == 60
+        assert row["attention_periods"] == 1
+        assert row["threshold_seconds"] == 300
+
+    def test_returns_none_when_row_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        from ohtv.cli import _load_engagement_row
+        from ohtv.db import get_ready_connection
+
+        # Init DB but don't create any rows.
+        with get_ready_connection(show_progress=False) as _:
+            pass
+
+        assert _load_engagement_row("nonexistent") is None
+
+    def test_normalizes_dashed_conversation_id(self, tmp_path, monkeypatch):
+        """LocalSource returns dashed IDs; the DB stores dashless ones."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+
+        from ohtv.cli import _load_engagement_row
+        from ohtv.db import get_ready_connection
+        from ohtv.db.models import Conversation
+        from ohtv.db.stages.engagement import process_engagement
+        from ohtv.db.stores import ConversationStore
+
+        conv_dir = tmp_path / "conv-dashed"
+        events_dir = conv_dir / "events"
+        events_dir.mkdir(parents=True)
+        base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        for i, e in enumerate([
+            {
+                "kind": "MessageEvent",
+                "source": "user",
+                "timestamp": (base + timedelta(seconds=i * 30)).isoformat(),
+                "llm_message": {"content": [{"type": "text", "text": "x"}]},
+            }
+            for i in range(2)
+        ]):
+            (events_dir / f"event-{i:06d}.json").write_text(json.dumps(e))
+
+        with get_ready_connection(show_progress=False) as conn:
+            conv = Conversation(
+                id="abcdef0123456789abcdef0123456789",
+                location=str(conv_dir),
+                event_count=2,
+            )
+            ConversationStore(conn).upsert(conv)
+            process_engagement(conn, conv, threshold_seconds=300)
+            conn.commit()
+
+        # The store row is dashless; the LOOKUP key uses dashes — must
+        # be normalized internally.
+        dashed = "abcdef01-2345-6789-abcd-ef0123456789"
+        row = _load_engagement_row(dashed)
+        assert row is not None
+        assert row["engaged_seconds"] == 30  # block (0, 30)
+
+
+# ---------------------------------------------------------------------------
+# Stage CLI wiring — engagement is in `db process all` order
+# ---------------------------------------------------------------------------
+
+
+def test_engagement_stage_is_in_all_choices():
+    """`db process engagement` must be a valid stage choice."""
+    from ohtv.db.stages import STAGES
+
+    assert "engagement" in STAGES
+    # Ordering: engagement comes after contributions so other reports
+    # remain unaffected by its placement.
+    keys = list(STAGES.keys())
+    assert keys.index("engagement") > keys.index("contributions")
+
+
+@pytest.mark.parametrize("threshold_minutes", [6, 8, 12, 14, 16, 18, 20, 22, 24, 26, 28])
+def test_compute_engagement_handles_all_sweep_thresholds(threshold_minutes):
+    """Smoke-test the threshold values from the tuning sweep."""
+    from ohtv.db.stages.engagement import compute_engagement
+
+    base = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _ts(s: int) -> str:
+        return (base + timedelta(seconds=s)).isoformat()
+
+    events = [
+        {
+            "kind": "MessageEvent",
+            "source": "user",
+            "timestamp": _ts(0),
+            "llm_message": {"content": [{"type": "text", "text": "a"}]},
+        },
+        {
+            "kind": "MessageEvent",
+            "source": "agent",
+            "timestamp": _ts(60),
+            "llm_message": {"content": [{"type": "text", "text": "b"}]},
+        },
+        {
+            "kind": "MessageEvent",
+            "source": "user",
+            "timestamp": _ts(120),
+            "llm_message": {"content": [{"type": "text", "text": "c"}]},
+        },
+    ]
+    result = compute_engagement(events, threshold_seconds=threshold_minutes * 60)
+    # All gaps are 60s; every threshold ≥ 6min = 360s ≫ 60s → attended.
+    assert result.engaged_seconds == 120
+    assert result.attention_periods == 1


### PR DESCRIPTION
Fixes #163

## Summary

Adds a per-conversation **engaged human minutes** metric (working name from the issue) that estimates how many minutes a human was actively monitoring/steering each conversation, inferred from the temporal gaps around each user message. Two related numbers fall out of the same pass — **attention periods** (distinct "human was here" windows) and a normalized **total conversation duration** computed from `last_event_ts - first_event_ts` (the correct definition) — so the three numbers are self-consistent.

This is the first ohtv worker to run after PR #164 (the auto-enable-orchestrator workflow) merged at 22:08Z, so this PR's `ready_for_review` transition will be the first time that new workflow fires. Expected and desirable — self-heals the orchestrator if it's been auto-disabled.

## Algorithm (Issue #163 pseudocode, literally)

Timing-only, no content inspection — intentionally simple and reproducible:

1. Order events ascending by timestamp; find user-message indices `Uᵢ`.
2. For each follow-up `Uᵢ` (i ≥ 1), look at gap from immediately preceding event `Pᵢ`. If `Uᵢ.ts - Pᵢ.ts ≤ T` (default **12 minutes**, per Open Question #3), record attended block `(Uᵢ₋₁.ts, Uᵢ.ts)`.
3. Sort blocks ascending; merge any two adjacent blocks with seam `≤ T` into a single **attention period**.
4. `engaged_seconds = Σ (period.end - period.start)`. `attention_periods = len(periods)`.

Tail handling (events after the last user message) follows the recommended default — does NOT extend the attention period. The forward-extension hinted at in the issue's prose worked example is left as a deliberate follow-up (Open Question #1).

## Files

### New
- **`src/ohtv/db/migrations/023_conversation_engagement.py`** — `conversation_engagement` table (PK `conversation_id`, FK `ON DELETE CASCADE`) + `idx_conv_engagement_threshold`. `threshold_seconds` is stored per row so the tuning sweep can keep variants distinguishable.
- **`src/ohtv/db/stages/engagement.py`** — `compute_engagement` (pure) + `process_engagement` (DB-writing). `EngagementMetrics` dataclass exposes the supporting counts (`follow_up_user_message_count`, `attended_user_message_count`).
- **`scripts/engagement_threshold_sweep.py`** — non-destructive sweep over `T ∈ {6, 8, 12, 14, 16, 18, 20, 22, 24, 26, 28}` min (default); emits per-threshold totals CSV + a gap-histogram CSV for offline plotting.
- **`tests/unit/db/stages/test_engagement.py`** — 35 tests.
- **`tests/unit/test_cli_engagement_display.py`** — 28 tests for the CLI display path.

### Modified
- **`src/ohtv/db/stages/__init__.py`** — register `engagement` stage after `contributions`.
- **`src/ohtv/cli.py`** — `--threshold N` (seconds) on `ohtv db process`, only consumed by `engagement` (other stages ignore it with a debug-only note). `ohtv show <id>` stats output gains an `Engaged: …` line in text/markdown; the JSON payload adds `engaged_seconds`, `attention_periods`, `engagement_threshold_seconds`, `total_duration_seconds`.
- **`docs/design/conversation-metrics.md`** — new section covering definition, schema, edge cases, CLI surface, threshold tuning, and reconciliation with the legacy `ConversationInfo.duration`.

## Acceptance criteria from #163

- [x] New `engagement` stage computes `engaged_seconds`, `attention_periods`, and supporting counts for every conversation, including fire-and-forget (zero, not NULL).
- [x] Threshold configurable per run; `threshold_seconds` stored on each row so values computed under different thresholds are distinguishable.
- [x] `total_duration_seconds` derived from `last_event_ts - first_event_ts`. The legacy `ConversationInfo.duration` (uses `updated_at - created_at`) is annotated as an approximation in the design doc; consistency migration is left as a follow-up to keep this PR focused.
- [x] Unit tests cover: worked example, zero follow-ups, all follow-ups inside T, all follow-ups outside T, mixed multi-period, `T = 0`, `T = ∞`. Plus single-instant period, malformed events, idempotency, and threshold-rewrite reprocessing.
- [x] `ohtv show` displays engaged minutes and periods alongside total duration.
- [x] `scripts/engagement_threshold_sweep.py` sweeps the documented threshold set and emits both the per-threshold totals CSV and the gap histogram CSV.
- [x] Docs section appended to `docs/design/conversation-metrics.md`.

## Worked-example test note (Open Question #1)

The worked example in the issue body suggests two periods (~4:24 engaged) under a forward-extension rule, while the pseudocode merges the two blocks into one period (2460 s engaged on that timeline) because their seam is 0 s ≤ T. The test (`test_worked_example_from_issue`) pins the literal-pseudocode output and documents the discrepancy. Both attended user messages are still counted; the tail/forward-extension can be added incrementally without a schema change. Recorded in the design doc.

## Test results

```
tests/unit/db/stages/test_engagement.py ........ 35 passed
tests/unit/test_cli_engagement_display.py ...... 28 passed
tests/unit                                  2228 passed, 2 skipped, 3 xfailed
```

ruff: no new errors introduced in modified files (went from 79 → 74 pre-existing errors in `cli.py` as a side effect of removing dead imports in the `db process` wiring).

---

_This PR was opened by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/266ba82d-89e2-48ee-9dc2-472c71ddf597)