### PR TITLE
feat: add list_conversations tool to ohtv ask --agent investigator

### DIFF
--- a/docs/guides/search-and-ask.md
+++ b/docs/guides/search-and-ask.md
@@ -174,8 +174,50 @@ When `--agent` is enabled, the answer is enhanced through multi-turn investigati
 
 **Available tools in investigation mode:**
 - `show_conversation` - Load and examine a specific conversation transcript
-- `search_conversations` - Search for related conversations by query
+- `search_conversations` - Search for related conversations by semantic similarity
+- `list_conversations` - Enumerate conversations by metadata (date / repo / PR / action / label)
 - `get_refs` - Get git references (repos, PRs, issues) for a conversation
+
+### `list_conversations` — metadata-driven enumeration
+
+`list_conversations` complements `search_conversations`. Use it whenever the question is anchored to *what / when* rather than *similar to*:
+
+- **Temporal**: _"what did we work on yesterday?"_, _"every conv from last week"_
+- **Enumerative**: _"list all conversations that touched repo X"_, _"every PR we opened"_
+- **Aggregative**: _"how many conversations landed merges in May?"_
+- **Verifying a negative**: _"did we work on the auth refactor at all?"_
+
+Vector search returns the *most-similar* matches; it cannot reliably enumerate, count, or prove absence. The agent will reach for `list_conversations` for those classes of questions, and for `search_conversations` when the question is about meaning ("how did we…", "explain the…").
+
+**Filter surface** — the same shape as `ohtv gen objs` multi-conversation mode, so anything you can ask the CLI to batch over, the agent can browse:
+
+| Filter | Notes |
+|---|---|
+| `since` / `until` | Accept the full `parse_date_filter` surface: ISO date (`2026-04-15`), relative (`7d`, `2w`, `1m`), or keywords (`today`, `yesterday`). |
+| `day` | A specific day (`YYYY-MM-DD` or `today`) or a small integer for an N-day lookback. |
+| `week` | `today` (this week) or a small integer for an N-week lookback. |
+| `repo` | Full URL, `owner/repo`, or short name. |
+| `pr` | PR URL, `owner/repo#N`, or `repo#N` (precise — `#1` won't match `#10`). |
+| `action` | e.g. `pushed`, `open-pr`, `merged`. |
+| `label` | Cloud-side labels in `key=value` form. |
+| `limit` | Default 20, **hard-capped at `LIST_CONVERSATIONS_MAX_LIMIT = 50`** so the observation stays inside the prompt budget. |
+| `include_sub_conversations` | **Default `False`** (roots-only, matching the post-Issue #125 CLI default — agent-delegated sub-conversations are rolled up into their root). Set to `True` to enumerate every sub. |
+
+**Observation shape** — the agent always sees three counts so it knows whether it's looking at the full set:
+
+- `total_matching` — ground-truth count of conversations matching the filters.
+- `returned` — the capped list of summaries (≤ `limit`, ≤ 50).
+- `truncated` — `True` when `total_matching > len(returned)`.
+
+If you see the agent say _"there are 137 matches and I'm looking at the top 50"_, that's `truncated=True` doing its job. The agent will typically narrow filters (`since=3d`, a specific `repo`, etc.) and re-query rather than ask for a higher `limit`.
+
+**Cache-only reads** — each row carries a `goal` field populated from the **cached `brief` `gen objs` analysis** for that conversation (the same variant `gen objs` multi-conv mode displays). `list_conversations` **never triggers LLM analysis** on a cache miss; instead, `goal=None` is a signal to the agent: _"call `show_conversation` on this id if you want to know what it was about."_ So the practical workflow inside investigation mode is:
+
+1. `list_conversations` to enumerate candidates by metadata.
+2. Sort/filter the rows by `goal` previews + `selected_repository` + `labels`.
+3. `show_conversation` or `get_refs` on the specific ids worth drilling into.
+
+To pre-warm the cache for a date range so `goal` is populated, run `ohtv gen objs` with matching filters (see [analysis.md](analysis.md)) before asking.
 
 **Example with investigation:**
 ```bash

--- a/src/ohtv/analysis/agent_tools.py
+++ b/src/ohtv/analysis/agent_tools.py
@@ -4,12 +4,14 @@ Provides tools that allow the agent to:
 1. Load and examine specific conversation trajectories
 2. Search for related conversations
 3. Get git references (PRs, issues, repos) for conversations
+4. Enumerate conversations by metadata filters (date / repo / PR / action / label)
 """
 
 from collections.abc import Sequence
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 from rich.text import Text
 
 from openhands.sdk.tool.schema import Action, Observation
@@ -19,6 +21,7 @@ from openhands.sdk.tool.tool import ToolAnnotations, ToolDefinition, ToolExecuto
 if TYPE_CHECKING:
     from openhands.sdk.conversation import LocalConversation
 
+    from ohtv.config import Config
     from ohtv.db.stores import (
         ConversationStore,
         EmbeddingStore,
@@ -544,3 +547,487 @@ class GetRefsTool(ToolDefinition[GetRefsAction, GetRefsObservation]):
                 ),
             )
         ]
+
+
+# ============================================================================
+# ListConversations Tool (Issue #160)
+# ============================================================================
+
+
+class ConversationSummary(BaseModel):
+    """Compact summary of a conversation, used by ListConversationsObservation.
+
+    Mirrors the minimal shape that ``ohtv gen objs -F json`` emits so the agent
+    sees the same "shape" of a conversation that the user would see at the CLI.
+    Refs are intentionally NOT included here; the agent can call ``get_refs``
+    on any id it wants to investigate further. This keeps each summary at
+    ~200 bytes so a 20-row response stays well within the prompt budget.
+    """
+
+    id: str = Field(description="Conversation ID")
+    short_id: str = Field(description="First 8 characters of the ID")
+    title: str | None = Field(default=None, description="Conversation title")
+    source: str = Field(description="'local' or 'cloud'")
+    created_at: str | None = Field(
+        default=None, description="ISO 8601 timestamp when the conversation was created"
+    )
+    duration_seconds: int | None = Field(
+        default=None, description="Duration between created_at and updated_at, in seconds"
+    )
+    event_count: int | None = Field(default=None, description="Total events in the conversation")
+    selected_repository: str | None = Field(
+        default=None, description="Repository the conversation was scoped to, if any"
+    )
+    goal: str | None = Field(
+        default=None,
+        description=(
+            "Cached 'gen objs' brief-variant goal. None when no cached analysis "
+            "exists for this conversation (cache miss). The agent may call "
+            "show_conversation to inspect details on cache miss."
+        ),
+    )
+    labels: dict[str, str] | None = Field(default=None, description="Cloud-side labels (key=value)")
+
+
+class ListConversationsAction(Action):
+    """Action to enumerate conversations by metadata filters.
+
+    Mirrors the filter surface of ``ohtv gen objs`` multi-conversation mode
+    (since/until/day/week/repo/pr/action/label/include-sub-conversations).
+    """
+
+    since: str | None = Field(
+        default=None,
+        description="ISO date (YYYY-MM-DD) or relative ('7d', '2w', '1m', 'today', 'yesterday')",
+    )
+    until: str | None = Field(
+        default=None,
+        description="ISO date (YYYY-MM-DD) or relative",
+    )
+    day: str | None = Field(
+        default=None,
+        description=(
+            "A specific day: 'YYYY-MM-DD' or 'today'. May also be a small integer "
+            "for an N-day lookback (e.g. '3' = today + 2 days back)."
+        ),
+    )
+    week: str | None = Field(
+        default=None,
+        description=(
+            "A specific week reference: 'today' (this week) or a small integer for "
+            "an N-week lookback (e.g. '2' = this week + last week)."
+        ),
+    )
+    repo: str | None = Field(
+        default=None,
+        description="Repo filter: full URL, owner/repo, or short name",
+    )
+    pr: str | None = Field(
+        default=None,
+        description="PR filter: URL, owner/repo#N, or repo#N",
+    )
+    action: str | None = Field(
+        default=None,
+        description="Action filter, e.g. 'pushed', 'open-pr', 'merged'",
+    )
+    label: str | None = Field(
+        default=None,
+        description="Label filter in 'key=value' form",
+    )
+    limit: int = Field(
+        default=20,
+        description="Maximum number of conversations to return (capped at 50)",
+    )
+    include_sub_conversations: bool = Field(
+        default=False,
+        description=(
+            "Include agent-delegated sub-conversations. Default False matches the "
+            "CLI's post-#125 roots-only behavior."
+        ),
+    )
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        content.append("List conversations", style="bold blue")
+        parts: list[str] = []
+        for name in ("since", "until", "day", "week", "repo", "pr", "action", "label"):
+            value = getattr(self, name)
+            if value:
+                parts.append(f"{name}={value}")
+        if self.include_sub_conversations:
+            parts.append("include_sub_conversations=True")
+        if parts:
+            content.append(" (", style="dim")
+            content.append(", ".join(parts), style="dim")
+            content.append(")", style="dim")
+        return content
+
+
+class ListConversationsObservation(Observation):
+    """Observation returned by the ``list_conversations`` tool."""
+
+    total_matching: int = Field(
+        description="Ground-truth count of conversations matching the filters"
+    )
+    returned: list[ConversationSummary] = Field(
+        default_factory=list,
+        description="List of conversation summaries, capped at the requested limit",
+    )
+    truncated: bool = Field(
+        default=False, description="True when total_matching > len(returned)"
+    )
+    filters_applied: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Echo of the resolved filter parameters",
+    )
+    error: str | None = Field(default=None, description="Error message if any")
+
+    def to_text(self) -> str:
+        """Return a compact text representation for LLM context."""
+        if self.error:
+            return f"Error: {self.error}"
+        if self.total_matching == 0:
+            return (
+                f"No conversations match the filters. "
+                f"filters_applied={self.filters_applied}"
+            )
+
+        lines = [
+            f"Found {self.total_matching} matching conversation(s); "
+            f"returning {len(self.returned)}"
+            f"{' (truncated)' if self.truncated else ''}.",
+        ]
+        for summary in self.returned:
+            parts = [
+                f"- [{summary.short_id}] ({summary.source})",
+            ]
+            if summary.created_at:
+                parts.append(summary.created_at)
+            if summary.duration_seconds is not None:
+                parts.append(f"{summary.duration_seconds}s")
+            if summary.event_count is not None:
+                parts.append(f"{summary.event_count} events")
+            if summary.selected_repository:
+                parts.append(summary.selected_repository)
+            if summary.labels:
+                labels_str = ",".join(f"{k}={v}" for k, v in sorted(summary.labels.items()))
+                parts.append(f"labels={labels_str}")
+            lines.append(" | ".join(parts))
+            if summary.title:
+                lines.append(f"    title: {summary.title}")
+            if summary.goal:
+                # Single-line, truncated goal preview
+                goal = summary.goal.replace("\n", " ").strip()
+                if len(goal) > 200:
+                    goal = goal[:197] + "..."
+                lines.append(f"    goal:  {goal}")
+            else:
+                lines.append("    goal:  (no cached analysis)")
+        return "\n".join(lines)
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        if self.error:
+            content.append(f"Error: {self.error}", style="red")
+            return content
+        content.append(
+            f"{self.total_matching} matching, showing {len(self.returned)}"
+            f"{' (truncated)' if self.truncated else ''}\n",
+            style="dim",
+        )
+        for summary in self.returned[:10]:
+            line = f"  [{summary.short_id}] {summary.title or '(no title)'}"
+            content.append(line + "\n")
+        if len(self.returned) > 10:
+            content.append(f"  ... and {len(self.returned) - 10} more\n", style="dim")
+        return content
+
+
+# Hard cap on the limit value the agent can request. Keeps the observation
+# under a few kilobytes even when the agent asks for "all" of something.
+LIST_CONVERSATIONS_MAX_LIMIT = 50
+
+# Cache lookup defaults — must match ``gen objs`` multi-conv mode.
+LIST_CONVERSATIONS_CACHE_CONTEXT = "minimal"
+LIST_CONVERSATIONS_CACHE_DETAIL = "brief"
+LIST_CONVERSATIONS_CACHE_ASSESS = False
+
+
+# Sentinel used for sorting conversations with no created_at field.
+# Tz-aware so it can be compared against tz-aware created_at values.
+_MIN_DATETIME = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _normalize_for_sort(dt: datetime | None) -> datetime:
+    """Coerce a datetime to a tz-aware value usable as a sort key.
+
+    Naive datetimes (e.g. from local-CLI conversations) are interpreted
+    as UTC; this matches the convention the rest of the codebase uses
+    when bucketing across sources (see AGENTS.md item 29's UTC-bin
+    caveat).
+    """
+    if dt is None:
+        return _MIN_DATETIME
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _find_conv_dir_for_executor(config: "Config", conv_id: str):
+    """Lazy wrapper around ``cli._find_conversation_dir``.
+
+    Kept as a module-level helper so tests can patch it independently of the
+    full cli import.
+    """
+    from ohtv.cli import _find_conversation_dir
+
+    return _find_conversation_dir(config, conv_id)
+
+
+class ListConversationsExecutor(
+    ToolExecutor[ListConversationsAction, ListConversationsObservation]
+):
+    """Executor that delegates to ``cli._apply_conversation_filters`` and
+    pulls cached brief ``gen objs`` analyses from the analysis cache.
+
+    Reads only — never triggers LLM analysis on cache miss. On a cache miss
+    the conversation is still returned, but with ``goal=None`` so the agent
+    knows to use ``show_conversation`` if it wants the trajectory.
+    """
+
+    def __init__(self, config: "Config", conv_store: "ConversationStore"):
+        self.config = config
+        self.conv_store = conv_store
+
+    def _resolve_dates(
+        self, action: ListConversationsAction
+    ) -> tuple[datetime | None, datetime | None]:
+        """Resolve since/until/day/week to (since, until) datetimes.
+
+        ``since`` / ``until`` accept the full ``parse_date_filter`` surface
+        (ISO date, '7d'/'2w'/'1m', 'today'/'yesterday') so the agent can
+        say "since 7d" without needing to compute the absolute date itself.
+        ``day`` / ``week`` are handled by the cli helper, which understands
+        numeric lookbacks (e.g. ``week='2'`` = last 2 weeks).
+        """
+        from ohtv.cli import _parse_date_filters
+        from ohtv.filters import parse_date_filter
+
+        since: datetime | None = None
+        until: datetime | None = None
+        if action.since:
+            since = parse_date_filter(action.since)
+            if since is None:
+                raise ValueError(f"Could not parse 'since' value: {action.since!r}")
+        if action.until:
+            until = parse_date_filter(action.until)
+            if until is None:
+                raise ValueError(f"Could not parse 'until' value: {action.until!r}")
+
+        # Delegate day/week handling to the cli helper. since/until are
+        # already resolved above; pass None so the helper only fills in
+        # what's still missing (it preserves an existing value with
+        # ``since = since or day_start``).
+        if action.day is not None or action.week is not None:
+            day_since, day_until = _parse_date_filters(
+                None, None, action.day, action.week
+            )
+            if since is None:
+                since = day_since
+            if until is None:
+                until = day_until
+
+        return since, until
+
+    def _lookup_cached_goal(self, conv_id: str) -> str | None:
+        """Look up the brief ``gen objs`` goal in the analysis cache.
+
+        Returns None on any cache miss; never raises.
+        """
+        from ohtv.analysis.cache import load_all_analyses, make_cache_key
+
+        try:
+            result = _find_conv_dir_for_executor(self.config, conv_id)
+            if result is None:
+                return None
+            conv_dir, _ = result
+            analyses = load_all_analyses(conv_dir)
+            if not analyses:
+                return None
+            cache_key = make_cache_key(
+                context=LIST_CONVERSATIONS_CACHE_CONTEXT,
+                detail=LIST_CONVERSATIONS_CACHE_DETAIL,
+                assess=LIST_CONVERSATIONS_CACHE_ASSESS,
+            )
+            entry = analyses.get(cache_key)
+            if entry is None:
+                # Fall back: return any cached goal so the agent still gets
+                # *something* useful when only e.g. the `standard` variant
+                # has been warmed. The brief variant is preferred when
+                # available because that's what the multi-conv CLI shows.
+                entry = next(iter(analyses.values()), None)
+            if not entry:
+                return None
+            goal = entry.get("goal")
+            if goal:
+                return goal
+            # 'detailed' variant uses summary / primary_objectives instead
+            summary = entry.get("summary")
+            if summary:
+                return summary
+            primary = entry.get("primary_objectives") or []
+            if primary and isinstance(primary, list):
+                first = primary[0]
+                if isinstance(first, dict):
+                    return first.get("description")
+            return None
+        except Exception:  # noqa: BLE001 - cache lookup is best-effort
+            return None
+
+    def _build_summary(self, conv: Any) -> ConversationSummary:
+        """Convert a ``ConversationInfo`` into a ``ConversationSummary``."""
+        duration_seconds: int | None = None
+        if conv.duration is not None:
+            duration_seconds = int(conv.duration.total_seconds())
+        created_at_str: str | None = None
+        if conv.created_at is not None:
+            created_at_str = conv.created_at.isoformat()
+        return ConversationSummary(
+            id=conv.id,
+            short_id=conv.short_id,
+            title=conv.title,
+            source=conv.source,
+            created_at=created_at_str,
+            duration_seconds=duration_seconds,
+            event_count=conv.event_count,
+            selected_repository=conv.selected_repository,
+            goal=self._lookup_cached_goal(conv.id),
+            labels=conv.labels,
+        )
+
+    def __call__(
+        self,
+        action: ListConversationsAction,
+        conversation: "LocalConversation | None" = None,
+    ) -> ListConversationsObservation:
+        # Reject obviously-bad limits up front so we never echo nonsense
+        # back to the agent.
+        requested_limit = max(1, min(action.limit, LIST_CONVERSATIONS_MAX_LIMIT))
+
+        try:
+            since, until = self._resolve_dates(action)
+        except Exception as e:  # noqa: BLE001
+            return ListConversationsObservation(
+                total_matching=0,
+                returned=[],
+                truncated=False,
+                filters_applied={},
+                error=f"Failed to parse date filters: {e}",
+            )
+
+        filters_applied: dict[str, Any] = {
+            "since": since.isoformat() if since else None,
+            "until": until.isoformat() if until else None,
+            "repo": action.repo,
+            "pr": action.pr,
+            "action": action.action,
+            "label": action.label,
+            "limit": requested_limit,
+            "include_sub_conversations": action.include_sub_conversations,
+        }
+
+        try:
+            from ohtv.cli import _apply_conversation_filters
+
+            filter_result = _apply_conversation_filters(
+                self.config,
+                since=since,
+                until=until,
+                pr_filter=action.pr,
+                repo_filter=action.repo,
+                action_filter=action.action,
+                label_filter=action.label,
+                include_sub_conversations=action.include_sub_conversations,
+            )
+        except Exception as e:  # noqa: BLE001
+            return ListConversationsObservation(
+                total_matching=0,
+                returned=[],
+                truncated=False,
+                filters_applied=filters_applied,
+                error=f"Filter resolution failed: {e}",
+            )
+
+        conversations = filter_result.conversations
+        # Sort by created_at descending (newest first) for stable, useful order.
+        # ``_normalize_for_sort`` makes naive and tz-aware created_at values
+        # comparable without raising on mixed sources (local CLI vs cloud).
+        conversations = sorted(
+            conversations,
+            key=lambda c: _normalize_for_sort(c.created_at),
+            reverse=True,
+        )
+        total_matching = len(conversations)
+        returned_convs = conversations[:requested_limit]
+
+        summaries = [self._build_summary(c) for c in returned_convs]
+
+        return ListConversationsObservation(
+            total_matching=total_matching,
+            returned=summaries,
+            truncated=total_matching > len(summaries),
+            filters_applied=filters_applied,
+        )
+
+
+class ListConversationsTool(
+    ToolDefinition[ListConversationsAction, ListConversationsObservation]
+):
+    """Tool for enumerating conversations by metadata filters.
+
+    Use this when the user's question is anchored to time
+    ("yesterday", "last week"), is enumerative ("every conv that touched X"),
+    or needs an aggregate ("how many PRs did we land in May?"). Pair with
+    ``show_conversation``, ``get_refs``, or ``search_conversations`` for
+    deeper investigation of individual results.
+    """
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: Any = None,
+        config: "Config | None" = None,
+        conv_store: "ConversationStore | None" = None,
+        **params,
+    ) -> Sequence[Self]:
+        if config is None:
+            raise ValueError("config is required for ListConversationsTool")
+        if conv_store is None:
+            raise ValueError("conv_store is required for ListConversationsTool")
+
+        return [
+            cls(
+                action_type=ListConversationsAction,
+                observation_type=ListConversationsObservation,
+                description=(
+                    "Enumerate conversations matching metadata filters "
+                    "(date range, repo, PR, action, label). Prefer this over "
+                    "search_conversations for temporal ('yesterday', 'last week') "
+                    "or enumerative ('every conv that touched repo X') questions, "
+                    "and for verifying negatives ('did we work on Y at all?'). "
+                    "Returns at most 50 conversations; narrow filters if "
+                    "total_matching is much larger than what was returned."
+                ),
+                executor=ListConversationsExecutor(config, conv_store),
+                annotations=ToolAnnotations(
+                    title="list_conversations",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=False,
+                ),
+            )
+        ]
+

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -23,12 +23,14 @@ from openhands.sdk.tool import FinishTool, ThinkTool, ToolDefinition
 
 from ohtv.analysis.agent_tools import (
     GetRefsTool,
+    ListConversationsTool,
     SearchConversationsTool,
     ShowConversationTool,
 )
 from ohtv.analysis.rag import RAGAnswer
 
 if TYPE_CHECKING:
+    from ohtv.config import Config
     from ohtv.db.stores import (
         ConversationStore,
         EmbeddingStore,
@@ -68,7 +70,13 @@ You have been given an initial answer to a question, along with source citations
 1. **Assess the initial answer**: Is it complete? Are there gaps or areas that need more detail?
 2. **Investigate if needed**: Use your tools to gather more information:
    - `show_conversation`: Load the full transcript of a specific conversation to get more detail
-   - `search_conversations`: Find additional related conversations that might help
+   - `search_conversations`: Find additional related conversations using semantic similarity
+   - `list_conversations`: Enumerate conversations by metadata (date range, repo, PR, action, label). Use this when:
+       - The question is anchored to time ("yesterday", "last week", "in May")
+       - The question asks "how many" / "list all" / "every X"
+       - You want to verify a negative ("did we work on Y at all?")
+       - Search returned nothing or returned obviously-stale matches
+     Prefer this over `search_conversations` for temporal or enumerative questions.
    - `get_refs`: Get git references (PRs, issues, repos) for a conversation
 3. **Synthesize findings**: Produce a final comprehensive answer with citations
 
@@ -150,6 +158,7 @@ class InvestigationAgent:
         ref_store: "ReferenceStore | None" = None,
         repo_store: "RepoStore | None" = None,
         conversation_dirs: list[str] | None = None,
+        config: "Config | None" = None,
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
         console: Console | None = None,
     ):
@@ -163,6 +172,9 @@ class InvestigationAgent:
             ref_store: ReferenceStore for ref details
             repo_store: RepoStore for repository details
             conversation_dirs: List of directories containing conversations
+            config: Application Config; required to enable the
+                ``list_conversations`` metadata-browsing tool. When None
+                the tool is skipped (existing three tools still work).
             max_iterations: Maximum number of agent iterations
             console: Rich console for output (optional)
         """
@@ -173,6 +185,7 @@ class InvestigationAgent:
         self.ref_store = ref_store
         self.repo_store = repo_store
         self.conversation_dirs = conversation_dirs or []
+        self.config = config
         self.max_iterations = max_iterations
         self.console = console or Console()
 
@@ -210,6 +223,16 @@ class InvestigationAgent:
                 repo_store=self.repo_store,
             )
             tools.extend(ref_tools)
+
+        # ListConversations tool (Issue #160) — only when a Config is
+        # available, since the executor needs it to resolve conversation
+        # directories and dispatch to the cli filter helpers.
+        if self.config is not None:
+            list_tools = ListConversationsTool.create(
+                config=self.config,
+                conv_store=self.conv_store,
+            )
+            tools.extend(list_tools)
 
         return tools
 
@@ -449,6 +472,14 @@ class InvestigationAgent:
         elif tool_name == "get_refs":
             conv_id = args.get("conversation_id", "unknown")[:8]
             self.console.print(f"[dim]🔗 Getting refs for {conv_id}...[/dim]")
+        elif tool_name == "list_conversations":
+            filter_parts = []
+            for name in ("day", "week", "since", "until", "repo", "pr", "action", "label"):
+                value = args.get(name)
+                if value:
+                    filter_parts.append(f"{name}={value}")
+            filters_str = " ".join(filter_parts) if filter_parts else "no filters"
+            self.console.print(f"[dim]📋 Listing conversations: {filters_str}[/dim]")
         elif tool_name == "think":
             # Handled separately in the loop
             pass

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -3579,6 +3579,7 @@ def ask(
                     ref_store=ref_store,
                     repo_store=repo_store,
                     conversation_dirs=conversation_dirs,
+                    config=config,
                     max_iterations=max_steps,
                     console=console,
                 )

--- a/tests/unit/analysis/test_investigator.py
+++ b/tests/unit/analysis/test_investigator.py
@@ -209,6 +209,46 @@ class TestInvestigationAgentCreateTools:
         assert "search_conversations" in tool_names
         assert "get_refs" in tool_names
 
+    @patch.dict('os.environ', {'LLM_API_KEY': 'test-key'})
+    def test_create_tools_with_config_includes_list_conversations(self):
+        """Issue #160: When config is provided, list_conversations is registered."""
+        from ohtv.analysis.investigator import InvestigationAgent
+
+        agent = InvestigationAgent(
+            model="gpt-4o-mini",
+            embed_store=MagicMock(),
+            conv_store=MagicMock(),
+            config=MagicMock(),
+        )
+
+        tool_names = [t.name for t in agent._create_tools()]
+        assert "list_conversations" in tool_names
+
+    @patch.dict('os.environ', {'LLM_API_KEY': 'test-key'})
+    def test_create_tools_without_config_skips_list_conversations(self):
+        """When config is missing the new tool is silently omitted."""
+        from ohtv.analysis.investigator import InvestigationAgent
+
+        agent = InvestigationAgent(
+            model="gpt-4o-mini",
+            embed_store=MagicMock(),
+            conv_store=MagicMock(),
+            config=None,
+        )
+
+        tool_names = [t.name for t in agent._create_tools()]
+        assert "list_conversations" not in tool_names
+
+    def test_system_prompt_mentions_list_conversations(self):
+        """The system prompt must teach the agent when to choose browse vs. search."""
+        from ohtv.analysis.investigator import get_investigation_system_prompt
+
+        prompt = get_investigation_system_prompt()
+        assert "list_conversations" in prompt
+        # Must reference the temporal / enumerative cues
+        assert "yesterday" in prompt or "temporal" in prompt
+        assert "enumerative" in prompt or "list all" in prompt or "every X" in prompt
+
 
 class TestInvestigationAgentInvestigate:
     """Integration tests for InvestigationAgent.investigate() method."""

--- a/tests/unit/analysis/test_list_conversations_tool.py
+++ b/tests/unit/analysis/test_list_conversations_tool.py
@@ -1,0 +1,602 @@
+"""Tests for the ``list_conversations`` agent tool (Issue #160).
+
+The executor delegates to ``cli._apply_conversation_filters`` for filtering
+and to ``cli._find_conversation_dir`` + ``cache.load_all_analyses`` for
+the warm-cache goal lookup. We exercise the real action/observation models
+and the executor's own logic (sort, truncate, filter-echo, error handling)
+against a patched filter helper so individual tests stay hermetic.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ohtv.analysis.agent_tools import (
+    LIST_CONVERSATIONS_MAX_LIMIT,
+    ConversationSummary,
+    ListConversationsAction,
+    ListConversationsExecutor,
+    ListConversationsObservation,
+    ListConversationsTool,
+)
+from ohtv.cli import FilterResult
+from ohtv.sources.base import ConversationInfo
+
+
+# =============================================================================
+# Fixtures / helpers
+# =============================================================================
+
+
+def _conv(
+    conv_id: str,
+    *,
+    title: str | None = "T",
+    source: str = "cloud",
+    created_at: datetime | None = None,
+    event_count: int | None = 10,
+    selected_repository: str | None = None,
+    labels: dict[str, str] | None = None,
+) -> ConversationInfo:
+    """Build a ConversationInfo with sensible defaults."""
+    created_at = created_at or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    return ConversationInfo(
+        id=conv_id,
+        title=title,
+        created_at=created_at,
+        updated_at=created_at + timedelta(minutes=30),
+        event_count=event_count,
+        source=source,
+        selected_repository=selected_repository,
+        labels=labels,
+        dir_name=conv_id.replace("-", ""),
+    )
+
+
+def _make_filter_result(convs: list[ConversationInfo]) -> FilterResult:
+    return FilterResult(conversations=convs, possible_match_ids=set(), show_all=True)
+
+
+@pytest.fixture
+def executor(tmp_path: Path) -> ListConversationsExecutor:
+    config = MagicMock()
+    config.local_conversations_dir = tmp_path / "local"
+    config.synced_conversations_dir = tmp_path / "cloud"
+    config.extra_conversation_paths = []
+    conv_store = MagicMock()
+    return ListConversationsExecutor(config=config, conv_store=conv_store)
+
+
+# =============================================================================
+# Action / Observation / ConversationSummary
+# =============================================================================
+
+
+class TestListConversationsAction:
+    def test_defaults(self) -> None:
+        action = ListConversationsAction()
+        assert action.since is None
+        assert action.until is None
+        assert action.day is None
+        assert action.week is None
+        assert action.repo is None
+        assert action.pr is None
+        assert action.action is None
+        assert action.label is None
+        assert action.limit == 20
+        assert action.include_sub_conversations is False
+
+    def test_explicit_fields(self) -> None:
+        action = ListConversationsAction(
+            since="7d",
+            repo="owner/repo",
+            label="team=AI",
+            include_sub_conversations=True,
+            limit=10,
+        )
+        assert action.since == "7d"
+        assert action.repo == "owner/repo"
+        assert action.label == "team=AI"
+        assert action.include_sub_conversations is True
+        assert action.limit == 10
+
+    def test_visualize_renders_filters(self) -> None:
+        action = ListConversationsAction(since="7d", repo="owner/repo")
+        rendered = action.visualize.plain
+        assert "List conversations" in rendered
+        assert "since=7d" in rendered
+        assert "repo=owner/repo" in rendered
+
+    def test_visualize_with_no_filters(self) -> None:
+        action = ListConversationsAction()
+        rendered = action.visualize.plain
+        assert "List conversations" in rendered
+
+
+class TestConversationSummary:
+    def test_basic(self) -> None:
+        summary = ConversationSummary(
+            id="abc12345" + "0" * 24,
+            short_id="abc12345",
+            source="cloud",
+        )
+        assert summary.title is None
+        assert summary.goal is None
+        assert summary.labels is None
+        assert summary.event_count is None
+
+
+class TestListConversationsObservation:
+    def test_to_text_with_results(self) -> None:
+        summary = ConversationSummary(
+            id="abc12345" + "0" * 24,
+            short_id="abc12345",
+            title="Fix auth bug",
+            source="cloud",
+            created_at="2026-05-01T12:00:00+00:00",
+            duration_seconds=300,
+            event_count=42,
+            goal="Restore login flow after refresh-token rotation",
+            labels={"team": "auth"},
+        )
+        obs = ListConversationsObservation(
+            total_matching=1,
+            returned=[summary],
+            truncated=False,
+            filters_applied={"since": "2026-05-01", "limit": 20},
+        )
+        text = obs.to_text()
+        assert "Found 1 matching" in text
+        assert "abc12345" in text
+        assert "Fix auth bug" in text
+        assert "Restore login flow" in text
+        assert "labels=team=auth" in text
+        assert "42 events" in text
+
+    def test_to_text_empty(self) -> None:
+        obs = ListConversationsObservation(
+            total_matching=0,
+            returned=[],
+            truncated=False,
+            filters_applied={"repo": "owner/repo"},
+        )
+        assert "No conversations match" in obs.to_text()
+        assert "owner/repo" in obs.to_text()
+
+    def test_to_text_truncated_marker(self) -> None:
+        summary = ConversationSummary(
+            id="x" * 32, short_id="xxxxxxxx", source="cloud"
+        )
+        obs = ListConversationsObservation(
+            total_matching=100,
+            returned=[summary],
+            truncated=True,
+            filters_applied={"limit": 1},
+        )
+        assert "(truncated)" in obs.to_text()
+
+    def test_to_text_error(self) -> None:
+        obs = ListConversationsObservation(
+            total_matching=0,
+            returned=[],
+            truncated=False,
+            filters_applied={},
+            error="DB unavailable",
+        )
+        assert obs.to_text() == "Error: DB unavailable"
+
+    def test_to_text_marks_cache_miss(self) -> None:
+        summary = ConversationSummary(
+            id="x" * 32, short_id="xxxxxxxx", source="cloud", goal=None
+        )
+        obs = ListConversationsObservation(
+            total_matching=1, returned=[summary], truncated=False, filters_applied={}
+        )
+        assert "(no cached analysis)" in obs.to_text()
+
+    def test_to_text_truncates_long_goal(self) -> None:
+        summary = ConversationSummary(
+            id="x" * 32,
+            short_id="xxxxxxxx",
+            source="cloud",
+            goal="A" * 500,
+        )
+        obs = ListConversationsObservation(
+            total_matching=1, returned=[summary], truncated=False, filters_applied={}
+        )
+        text = obs.to_text()
+        # 200 char cap with trailing "..."
+        assert "A" * 197 + "..." in text
+        # No 500-A run anywhere
+        assert "A" * 500 not in text
+
+    def test_visualize_renders_summaries(self) -> None:
+        summaries = [
+            ConversationSummary(
+                id=str(i) * 32, short_id=str(i) * 8, source="cloud", title=f"t{i}"
+            )
+            for i in range(3)
+        ]
+        obs = ListConversationsObservation(
+            total_matching=3,
+            returned=summaries,
+            truncated=False,
+            filters_applied={},
+        )
+        rendered = obs.visualize.plain
+        assert "showing 3" in rendered
+        assert "t0" in rendered
+
+    def test_visualize_error(self) -> None:
+        obs = ListConversationsObservation(
+            total_matching=0,
+            returned=[],
+            truncated=False,
+            filters_applied={},
+            error="boom",
+        )
+        assert "boom" in obs.visualize.plain
+
+
+# =============================================================================
+# Executor — core paths
+# =============================================================================
+
+
+class TestExecutorEmpty:
+    def test_no_matches_returns_zero(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            return_value=_make_filter_result([]),
+        ):
+            obs = executor(ListConversationsAction(since="7d"))
+        assert obs.total_matching == 0
+        assert obs.returned == []
+        assert obs.truncated is False
+        assert obs.filters_applied["since"] is not None  # resolved to ISO
+
+
+class TestExecutorSingleResult:
+    def test_single_conv_no_cache(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        conv = _conv("a" * 32, title="Hello")
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result([conv]),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+        ):
+            obs = executor(ListConversationsAction())
+        assert obs.total_matching == 1
+        assert len(obs.returned) == 1
+        s = obs.returned[0]
+        assert s.id == "a" * 32
+        assert s.short_id == "a" * 7
+        assert s.title == "Hello"
+        assert s.duration_seconds == 1800  # 30 minutes
+        assert s.goal is None  # No cache file -> miss
+
+    def test_single_conv_with_cached_goal(
+        self, executor: ListConversationsExecutor, tmp_path: Path
+    ) -> None:
+        conv = _conv("b" * 32, title="Cache-warmed")
+        conv_dir = tmp_path / "cache" / conv.dir_name
+        # Build a real cache file the executor will read.
+        from ohtv.analysis.cache import make_cache_key
+
+        analyses = {
+            make_cache_key(context="minimal", detail="brief", assess=False): {
+                "goal": "Add pagination",
+                "primary_outcomes": [],
+                "secondary_outcomes": [],
+                "primary_objectives": [],
+                "summary": None,
+            }
+        }
+        conv_dir.mkdir(parents=True)
+        (conv_dir / "objective_analysis.json").write_text(
+            __import__("json").dumps({"version": 1, "analyses": analyses})
+        )
+
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result([conv]),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=(conv_dir, True),
+            ),
+        ):
+            obs = executor(ListConversationsAction())
+
+        assert obs.total_matching == 1
+        assert obs.returned[0].goal == "Add pagination"
+
+
+class TestExecutorTruncation:
+    def test_truncates_to_limit(self, executor: ListConversationsExecutor) -> None:
+        convs = [
+            _conv(
+                hex(i)[2:].rjust(32, "0"),
+                created_at=datetime(2026, 5, 1, 12, i, tzinfo=timezone.utc),
+            )
+            for i in range(30)
+        ]
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result(convs),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+        ):
+            obs = executor(ListConversationsAction(limit=10))
+        assert obs.total_matching == 30
+        assert len(obs.returned) == 10
+        assert obs.truncated is True
+
+    def test_limit_clamped_to_max(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        convs = [_conv(hex(i)[2:].rjust(32, "0")) for i in range(60)]
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result(convs),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+        ):
+            obs = executor(ListConversationsAction(limit=200))
+        assert len(obs.returned) == LIST_CONVERSATIONS_MAX_LIMIT
+        assert obs.filters_applied["limit"] == LIST_CONVERSATIONS_MAX_LIMIT
+
+    def test_limit_floor_is_one(self, executor: ListConversationsExecutor) -> None:
+        convs = [_conv("a" * 32)]
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result(convs),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+        ):
+            obs = executor(ListConversationsAction(limit=0))
+        assert obs.filters_applied["limit"] == 1
+
+
+class TestExecutorSorting:
+    def test_results_sorted_newest_first(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        old = _conv(
+            "a" * 32,
+            created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        mid = _conv(
+            "b" * 32,
+            created_at=datetime(2026, 5, 15, tzinfo=timezone.utc),
+        )
+        new = _conv(
+            "c" * 32,
+            created_at=datetime(2026, 5, 30, tzinfo=timezone.utc),
+        )
+        # Feed in arbitrary order
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result([mid, new, old]),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+        ):
+            obs = executor(ListConversationsAction())
+        ids = [s.id for s in obs.returned]
+        assert ids == ["c" * 32, "b" * 32, "a" * 32]
+
+    def test_handles_none_created_at(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        no_date = ConversationInfo(
+            id="a" * 32,
+            title=None,
+            created_at=None,
+            updated_at=None,
+            event_count=1,
+            source="cloud",
+        )
+        with_date = _conv("b" * 32)
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result([no_date, with_date]),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+        ):
+            obs = executor(ListConversationsAction())
+        # The dated conv sorts ahead of the dateless one
+        assert obs.returned[0].id == "b" * 32
+        # The dateless conv has duration_seconds = None
+        assert obs.returned[1].duration_seconds is None
+        assert obs.returned[1].created_at is None
+
+
+# =============================================================================
+# Executor — filter-axis pass-through
+# =============================================================================
+
+
+class TestExecutorFilterAxes:
+    """Every filter parameter is forwarded to ``_apply_conversation_filters``."""
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_kwarg,expected_value",
+        [
+            ({"repo": "owner/repo"}, "repo_filter", "owner/repo"),
+            ({"pr": "owner/repo#7"}, "pr_filter", "owner/repo#7"),
+            ({"action": "pushed"}, "action_filter", "pushed"),
+            ({"label": "team=AI"}, "label_filter", "team=AI"),
+            (
+                {"include_sub_conversations": True},
+                "include_sub_conversations",
+                True,
+            ),
+        ],
+    )
+    def test_filter_kwarg_forwarded(
+        self,
+        executor: ListConversationsExecutor,
+        kwargs: dict,
+        expected_kwarg: str,
+        expected_value,
+    ) -> None:
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            return_value=_make_filter_result([]),
+        ) as patched:
+            executor(ListConversationsAction(**kwargs))
+        assert patched.call_args.kwargs[expected_kwarg] == expected_value
+
+    def test_since_until_resolved_to_datetimes(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            return_value=_make_filter_result([]),
+        ) as patched:
+            executor(ListConversationsAction(since="7d", until="today"))
+        kwargs = patched.call_args.kwargs
+        assert isinstance(kwargs["since"], datetime)
+        assert isinstance(kwargs["until"], datetime)
+
+    def test_day_filter_resolved(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            return_value=_make_filter_result([]),
+        ) as patched:
+            executor(ListConversationsAction(day="2026-05-15"))
+        kwargs = patched.call_args.kwargs
+        # day populates both since AND until (day bounds)
+        assert kwargs["since"] is not None
+        assert kwargs["until"] is not None
+
+    def test_week_filter_resolved(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            return_value=_make_filter_result([]),
+        ) as patched:
+            executor(ListConversationsAction(week="2"))
+        kwargs = patched.call_args.kwargs
+        assert kwargs["since"] is not None
+        assert kwargs["until"] is not None
+
+    def test_default_excludes_sub_conversations(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        """Issue #125 default: roots only unless explicitly opted in."""
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            return_value=_make_filter_result([]),
+        ) as patched:
+            executor(ListConversationsAction())
+        assert patched.call_args.kwargs["include_sub_conversations"] is False
+
+
+# =============================================================================
+# Executor — error paths
+# =============================================================================
+
+
+class TestExecutorErrors:
+    def test_filter_failure_reported_as_observation_error(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        with patch(
+            "ohtv.cli._apply_conversation_filters",
+            side_effect=RuntimeError("DB closed"),
+        ):
+            obs = executor(ListConversationsAction(repo="x/y"))
+        assert obs.error is not None
+        assert "DB closed" in obs.error
+        assert obs.total_matching == 0
+        # filters_applied still echoes the inputs so the agent can correct
+        assert obs.filters_applied["repo"] == "x/y"
+
+
+class TestExecutorCacheReadsOnly:
+    """The executor MUST NOT trigger LLM analysis on a cache miss (AC bullet)."""
+
+    def test_cache_miss_does_not_invoke_analyze_objectives(
+        self, executor: ListConversationsExecutor
+    ) -> None:
+        conv = _conv("a" * 32)
+        with (
+            patch(
+                "ohtv.cli._apply_conversation_filters",
+                return_value=_make_filter_result([conv]),
+            ),
+            patch(
+                "ohtv.analysis.agent_tools._find_conv_dir_for_executor",
+                return_value=None,
+            ),
+            patch(
+                "ohtv.analysis.objectives.analyze_objectives",
+                side_effect=AssertionError("Must not be called on cache miss"),
+            ),
+        ):
+            obs = executor(ListConversationsAction())
+        assert obs.total_matching == 1
+        assert obs.returned[0].goal is None
+
+
+# =============================================================================
+# Tool factory
+# =============================================================================
+
+
+class TestListConversationsToolCreate:
+    def test_create_returns_one_tool(self) -> None:
+        config = MagicMock()
+        conv_store = MagicMock()
+        tools = ListConversationsTool.create(config=config, conv_store=conv_store)
+        assert len(tools) == 1
+        assert tools[0].name == "list_conversations"
+        assert tools[0].executor is not None
+        # Tool advertised as read-only / idempotent so the host can cache.
+        assert tools[0].annotations.readOnlyHint is True
+        assert tools[0].annotations.destructiveHint is False
+
+    def test_create_requires_config(self) -> None:
+        with pytest.raises(ValueError, match="config is required"):
+            ListConversationsTool.create(conv_store=MagicMock())
+
+    def test_create_requires_conv_store(self) -> None:
+        with pytest.raises(ValueError, match="conv_store is required"):
+            ListConversationsTool.create(config=MagicMock())


### PR DESCRIPTION
Fixes #160.

## Summary

Adds a fourth tool to the `InvestigationAgent` — `list_conversations` — that lets the agent enumerate conversations by metadata (date range, repo, PR, action, label) rather than by semantic similarity. This closes the class of questions (temporal, enumerative, aggregative, outlier/negative) that vector search fundamentally cannot answer well, e.g. _"what did we work on yesterday?"_, _"every conv that touched repo X this week"_, _"how many PRs did we land in May?"_, _"did we work on Y at all?"_.

## What changed

**New tool (`src/ohtv/analysis/agent_tools.py`)**
- `ListConversationsAction` mirrors the `ohtv gen objs` multi-conversation filter surface: `since`/`until`/`day`/`week`/`repo`/`pr`/`action`/`label`/`limit`/`include_sub_conversations`.
- `ConversationSummary` matches the minimal `gen objs -F json` shape (id, source, created_at, duration_seconds, event_count, goal, labels, selected_repository). Refs are intentionally omitted to keep each row at ~200 bytes — the agent can call `get_refs(id)` for any conv it wants to dig into.
- `ListConversationsObservation` exposes `total_matching` (ground-truth count) alongside `returned` (capped list) and `truncated`, so the agent always knows whether it saw the full set.
- `ListConversationsExecutor` delegates filtering to `cli._apply_conversation_filters` (no duplicated filter logic, per the AC) and pulls the cached **brief** `gen objs` variant from `load_all_analyses`. Reads-only — never triggers LLM analysis on a cache miss; `goal=None` signals _"use `show_conversation` if you want the trajectory"_.
- `since` / `until` accept the full `parse_date_filter` surface (`7d`, `2w`, `today`, `yesterday`, ISO), so the agent doesn't have to do date math.
- Sub-conversation rollup defaults to `False` (Issue #125 roots-only semantics); `include_sub_conversations=True` overrides.
- Hard cap of `LIST_CONVERSATIONS_MAX_LIMIT = 50` keeps the observation inside the prompt budget (~4 KB for a 20-row response).

**Wiring (`src/ohtv/analysis/investigator.py`, `src/ohtv/cli.py`)**
- `InvestigationAgent.__init__` gains an optional `config` kwarg; `ohtv ask --agent` (cli.py:3582) passes it. When `config is None` the new tool is silently skipped and the existing three tools remain available — no behavior change for callers that don't opt in.
- `get_investigation_system_prompt()` teaches the agent when to prefer `list_conversations` (temporal / enumerative / verifying a negative) over `search_conversations`. Wording follows the issue's "system prompt update" block.
- `_show_tool_progress` gets a 📋 emoji line for the new tool so the user can see what's being filtered.

## Acceptance criteria

- [x] `ListConversationsTool` available to `InvestigationAgent`.
- [x] Observation includes both `total_matching` (ground-truth count) and `returned` (capped list).
- [x] Filter parameters cover the same surface as `ohtv gen objs` multi-conv mode.
- [x] Reuses existing filter helpers from `cli.py` — no duplicated filter logic.
- [x] Reads from the warm `gen objs` cache; does NOT trigger LLM analysis on cache miss (returns `goal=None`).
- [x] `roots-only` is the default; `include_sub_conversations=True` overrides.
- [x] System prompt updated to teach the agent when to choose browse over search.
- [x] Unit tests cover: empty result, single result, truncation at `limit`, each filter axis, sub-conv include/exclude, cache-reads-only invariant, error reporting, and the tool-factory contract.

## Tests

`tests/unit/analysis/test_list_conversations_tool.py` adds **35 tests** in 8 classes. Highlights:

- `TestExecutorCacheReadsOnly::test_cache_miss_does_not_invoke_analyze_objectives` — the AC's "reads only" invariant, enforced by an `AssertionError` side-effect on `analyze_objectives`.
- `TestExecutorFilterAxes` — every filter parameter is asserted to be forwarded to `_apply_conversation_filters` with the right kwarg name (`repo` → `repo_filter`, `pr` → `pr_filter`, etc.). Also asserts the Issue #125 roots-only default.
- `TestExecutorTruncation` — verifies `limit` is clamped to `LIST_CONVERSATIONS_MAX_LIMIT=50` and floored at 1.
- `TestExecutorSorting::test_handles_none_created_at` — guards the naive-vs-aware datetime path I had to handle when local-CLI and cloud conversations are mixed.

`tests/unit/analysis/test_investigator.py` adds three coverage tests for the new wiring (with-config / without-config / system-prompt).

All **2266** unit tests pass locally (`uv run pytest tests/unit`). `ruff` was clean on every line I added.

## Open questions deliberately deferred

- **Open Q1 (cache miss → fast-path summary builder)**: deferred. We return `goal=None`; the prompt tells the agent to call `show_conversation` on cache misses it cares about.
- **Open Q2 (query+FTS5 keyword filter on top of metadata)**: deferred. Out of scope; tackle as a follow-up if the usage pattern emerges.
- **Open Q3 (`errors_only` filter)**: deferred. Cheap to add later; not in the AC.

## Non-obvious decisions

- `since` / `until` use `ohtv.filters.parse_date_filter` (which understands `7d`/`2w`/`yesterday`) rather than `cli._parse_date_option` (which only understands `today` + ISO). The agent calls naturally pass relative dates; the CLI uses absolute. The day/week shortcuts still go through `cli._parse_date_filters` so numeric lookbacks (`week='2'` = last 2 weeks) work identically to the CLI.
- The executor sorts results newest-first via a `_normalize_for_sort` helper that coerces naive datetimes to UTC. This matches AGENTS.md item #29's UTC-bin convention and prevents a `TypeError` when local-CLI (naive) and cloud (aware) conversations are mixed.
- Refs are NOT included in `ConversationSummary` even though `gen objs -F json` carries them. Reasoning: refs require an extra DB roundtrip per row and would push each summary well past 200 bytes. The agent has `get_refs` for that.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._


@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8fe6274f-8b99-4312-9489-7449b42c6f66)