### PR TITLE
feat: add --with-engagement flag to gen objs JSON output

### DIFF
--- a/docs/guides/analysis.md
+++ b/docs/guides/analysis.md
@@ -203,6 +203,110 @@ Showing 2 of 150 (2/2 cached)
 | `goal` | Extracted goal description |
 | `labels` | Cloud-sourced labels/tags as key-value pairs (if present) |
 
+<a id="engagement-fields--with-engagement"></a>
+
+### Engagement fields (`--with-engagement`)
+
+The `--with-engagement` flag (added in [#172](https://github.com/jpshackelford/ohtv/pull/172), tracks [#168](https://github.com/jpshackelford/ohtv/issues/168)) extends `ohtv gen objs` JSON output with the sustained-attention metric, mirroring the pattern established for `ohtv list --with-engagement` in [#171](https://github.com/jpshackelford/ohtv/pull/171) (see [`docs/guides/exploration.md` § Engagement columns](exploration.md#engagement-columns--with-engagement)) and `ohtv show -F json` in [#165](https://github.com/jpshackelford/ohtv/pull/165).
+
+**JSON-only.** The flag is a no-op for `-F table` and `-F markdown` — both display formats are unchanged. (Markdown engagement output is tracked separately in [#169](https://github.com/jpshackelford/ohtv/issues/169).) Works in both single-conversation (`ohtv gen objs <id> --json --with-engagement`) and multi-conversation (`ohtv gen objs -F json --with-engagement`) modes.
+
+**Prerequisite:** values come from the [`engagement` indexing stage](indexing.md#engagement-stage). Run `ohtv db process all` (or `ohtv db process engagement`) after syncing. Without it the five fields render as `null` — rows are **never** filtered out and the JSON schema stays stable across rows.
+
+**Examples:**
+
+```bash
+# Multi-conversation: 5 engagement fields per item in the JSON array
+ohtv gen objs -F json --with-engagement --week
+
+# Single-conversation: 5 engagement fields at the top level
+ohtv gen objs abc123 --json --with-engagement
+
+# Composes with every existing filter and flag
+ohtv gen objs -F json --with-engagement --repo OpenPaw -A
+```
+
+**Multi-conversation example (`-F json --with-engagement`).** Each item in the JSON array gains the same five keys appended after the existing fields:
+
+```json
+[
+  {
+    "id": "a711cbbc61f04bd2a1c0f3e8d5b9c2d4",
+    "source": "cloud",
+    "created_at": "2026-05-30T14:02:00+00:00",
+    "start_time": "14:02",
+    "duration_seconds": 8040,
+    "event_count": 312,
+    "goal": "Add staging deploy hooks to the pipeline.",
+    "engaged_seconds": 2460,
+    "attention_periods": 3,
+    "engagement_threshold_seconds": 720,
+    "total_duration_seconds": 8040,
+    "engagement_ratio": 0.306
+  },
+  {
+    "id": "1c0a5b3e2f9d4e7a8b1c0d3e5f7a9b2c",
+    "source": "local",
+    "created_at": "2026-05-29T22:45:00+00:00",
+    "start_time": "22:45",
+    "duration_seconds": 480,
+    "event_count": 12,
+    "goal": "Quick repo poke.",
+    "engaged_seconds": null,
+    "attention_periods": null,
+    "engagement_threshold_seconds": null,
+    "total_duration_seconds": null,
+    "engagement_ratio": null
+  }
+]
+```
+
+The first item has an engagement row from `ohtv db process engagement`; the second does not. Both items carry **all five keys** — missing rows emit JSON `null` so the schema is stable. Consumers can rely on `engagement_ratio` being either a float in `[0.0, 1.0]` rounded to 4 decimals or `null`.
+
+**Single-conversation example (`--json --with-engagement`).** The five fields are merged into the top level of the analysis payload:
+
+```json
+{
+  "goal": "Add staging deploy hooks to the pipeline.",
+  "primary_outcomes": ["Wired post-deploy smoke test", "Documented runbook"],
+  "secondary_outcomes": [],
+  "engaged_seconds": 2460,
+  "attention_periods": 3,
+  "engagement_threshold_seconds": 720,
+  "total_duration_seconds": 8040,
+  "engagement_ratio": 0.306
+}
+```
+
+When no engagement row exists for the conversation, the analysis payload still gains all five keys with `null` values:
+
+```json
+{
+  "goal": "Quick repo poke.",
+  "primary_outcomes": [],
+  "secondary_outcomes": [],
+  "engaged_seconds": null,
+  "attention_periods": null,
+  "engagement_threshold_seconds": null,
+  "total_duration_seconds": null,
+  "engagement_ratio": null
+}
+```
+
+**Field reference** (identical schema to `ohtv list --with-engagement -F json` and `ohtv show -F json`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `engaged_seconds` | int \| null | Seconds the user was actively monitoring/steering (sum of attention periods). |
+| `attention_periods` | int \| null | Count of distinct attention windows. A real `0` is preserved as `0`, not `null`. |
+| `engagement_threshold_seconds` | int \| null | The `T` threshold used to compute this row (default `720` = 12 min). Re-run `ohtv db process engagement --threshold N --force` to recompute. |
+| `total_duration_seconds` | int \| null | Total conversation duration (denominator for the ratio). |
+| `engagement_ratio` | float \| null | `engaged_seconds / total_duration_seconds`, rounded to 4 decimals. `null` when the denominator is `0`, missing, or either input is `null`. |
+
+**Composes with other flags.** `--with-engagement` is purely a display switch — it adds JSON keys but never filters rows or changes which conversations are analyzed. It works alongside `--variant`, `--context`, `--refresh`, `--model`, `--repo`, `--pr`, `--action`, `--label`, `--since` / `--until`, `--day` / `--week`, `-n` / `-k`, `-A`, `--reverse`, `--include-sub-conversations`, `--quiet`, and the JSON output toggles (`--json` for single-conversation mode, `-F json` for multi-conversation mode).
+
+> **Filtering by engagement** (e.g. `--min-engaged-seconds`) is intentionally out of scope for this flag — it is display-only. See [Issue #170](https://github.com/jpshackelford/ohtv/issues/170) for the engagement-filter follow-up and [Issue #169](https://github.com/jpshackelford/ohtv/issues/169) for markdown engagement output.
+
 **Markdown Output (`-F markdown`):**
 ```markdown
 - **abc1234** (2024-03-15, 10:42 AM, 35 mins, 46 steps): Refactor authentication...
@@ -220,6 +324,7 @@ Showing 2 of 150 (2/2 cached)
 | `-m, --model` | LLM model to use |
 | `--json` | Output as JSON |
 | `--no-outputs` | Don't show outputs (repos, PRs, issues) |
+| `--with-engagement` | Include engagement metrics (`engaged_seconds`, `attention_periods`, `engagement_threshold_seconds`, `total_duration_seconds`, `engagement_ratio`) at the top level of the JSON payload. Requires the [`engagement` indexing stage](indexing.md#engagement-stage). No effect for non-JSON output. See [Engagement fields](#engagement-fields--with-engagement). |
 | `--verbose` | Show debug output |
 
 **Options (Multi-Conversation Mode):**
@@ -246,6 +351,7 @@ Showing 2 of 150 (2/2 cached)
 | `-y, --yes` | Skip confirmation for large result sets (>20 conversations) |
 | `-q, --quiet` | Generate/cache summaries without displaying output |
 | `--include-sub-conversations` | Include sub-conversations created by agent delegation (default: roots only). See note above. |
+| `--with-engagement` | Include engagement metrics (`engaged_seconds`, `attention_periods`, `engagement_threshold_seconds`, `total_duration_seconds`, `engagement_ratio`) per item in the JSON array. Requires the [`engagement` indexing stage](indexing.md#engagement-stage). No effect for `-F table` or `-F markdown`. See [Engagement fields](#engagement-fields--with-engagement). |
 | `--verbose` | Show debug output |
 
 ### Context levels (`gen objs --c` flag)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,7 @@ auto-generated flag list at any version.
 
 | Command | Purpose | Detailed docs |
 |---|---|---|
-| `ohtv gen objs` | Extract user objectives per conversation. | [guides/analysis.md § gen objs](../guides/analysis.md) |
+| `ohtv gen objs` | Extract user objectives per conversation. Opt-in `--with-engagement` adds five engagement fields to JSON output (single-conversation and batch modes); no effect on `-F table` / `-F markdown`. Requires the [`engagement` stage](../guides/indexing.md#engagement-stage). | [guides/analysis.md § gen objs](../guides/analysis.md) |
 | `ohtv gen titles` | Auto-rename placeholder-titled cloud conversations from cached `gen objs` analyses. Takes the `$OHTV_DIR/sync.lock` writer mutex (it PATCHes cloud titles and writes back to the manifest + DB); pass `--lock-timeout=N` to wait (default `0` = fail-fast). | [guides/analysis.md § gen titles](../guides/analysis.md) |
 | `ohtv gen run <job>` | Run a periodic or aggregate analysis job (weekly report, theme discovery, …). | [guides/analysis.md § gen run](../guides/analysis.md) |
 | `ohtv prompts list` | List shipped + customized prompts. | [guides/customizing-prompts.md](../guides/customizing-prompts.md) |

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -4002,30 +4002,28 @@ def _load_refs_for_conversations(
     return refs_map
 
 
-def _load_engagement_for_conversations(
-    conversations: list[ConversationInfo],
+def _load_engagement_for_ids(
+    conversation_ids: list[str],
 ) -> dict[str, dict]:
-    """Batch-load ``conversation_engagement`` rows for a list of conversations.
+    """Batch-load ``conversation_engagement`` rows for a list of conversation IDs.
 
-    Returns a dict mapping the **original** conversation id (as stored on
-    ``ConversationInfo.id``, potentially with dashes) to the engagement
-    row as a dict. Missing rows are simply absent from the dict — callers
-    treat absence as "no engagement data, render as '-'".
+    Returns a dict mapping the **original** caller id (potentially with
+    dashes) to the engagement row as a dict. Missing rows are simply
+    absent from the dict — callers treat absence as "no engagement data".
 
     The lookup is a single batched SQL query (``WHERE conversation_id IN
-    (?, ?, ...)``) to avoid the N+1 trap when called from ``ohtv list``
-    on large datasets. SQLite limits ``IN (...)`` clauses to ~999
-    parameters by default, so we chunk into batches of 900 to stay well
-    under the limit.
+    (?, ?, ...)``) to avoid the N+1 trap when called on large datasets.
+    SQLite limits ``IN (...)`` clauses to ~999 parameters by default, so
+    we chunk into batches of 900 to stay well under the limit.
 
-    Issue #167: display-layer only. Never raises — returns an empty dict
-    on any unexpected failure (missing DB, schema mismatch, etc.) so the
-    list path can always render.
+    Issues #167 / #168: display-layer only. Never raises — returns an
+    empty dict on any unexpected failure (missing DB, schema mismatch,
+    etc.) so the calling path can always render.
     """
     from ohtv.filters import normalize_conversation_id
 
     engagement_map: dict[str, dict] = {}
-    if not conversations:
+    if not conversation_ids:
         return engagement_map
 
     try:
@@ -4041,11 +4039,11 @@ def _load_engagement_for_conversations(
     # mapped back to the caller's id form (LocalSource returns dashed
     # ids; the DB stores dashless — AGENTS.md item #14).
     normalized_to_original: dict[str, str] = {}
-    for conv in conversations:
-        normalized = normalize_conversation_id(conv.id)
-        # If two convs in the page normalize to the same id we keep the
+    for cid in conversation_ids:
+        normalized = normalize_conversation_id(cid)
+        # If two ids in the page normalize to the same id we keep the
         # first encounter; in practice they would be the same row.
-        normalized_to_original.setdefault(normalized, conv.id)
+        normalized_to_original.setdefault(normalized, cid)
 
     BATCH_SIZE = 900  # well below SQLite's default ~999 param ceiling
     ids = list(normalized_to_original.keys())
@@ -4082,6 +4080,22 @@ def _load_engagement_for_conversations(
         return engagement_map
 
     return engagement_map
+
+
+def _load_engagement_for_conversations(
+    conversations: list[ConversationInfo],
+) -> dict[str, dict]:
+    """Batch-load ``conversation_engagement`` rows for a list of conversations.
+
+    Thin wrapper over :func:`_load_engagement_for_ids` that extracts the
+    ``id`` from each :class:`ConversationInfo`. Issue #167 kept this
+    signature for the ``ohtv list`` call site; Issue #168 added the
+    ID-based sibling for the ``ohtv gen objs`` call site which has
+    result dicts rather than ConversationInfo objects.
+    """
+    if not conversations:
+        return {}
+    return _load_engagement_for_ids([conv.id for conv in conversations])
 
 
 def _validate_engagement_values(
@@ -4139,6 +4153,39 @@ def _engagement_ratio(
         return None
     engaged, total = values
     return round(engaged / total, 4)
+
+
+def _engagement_json_fields(row: dict | None) -> dict[str, int | float | None]:
+    """Produce the five-key engagement-fields dict for JSON output (Issue #168).
+
+    Shape matches what ``ohtv show -F json`` (PR #165) and
+    ``ohtv list --with-engagement -F json`` (PR #171) emit, so a
+    downstream consumer that already knows those schemas does not learn
+    a new one.
+
+    When ``row`` is ``None`` (engagement stage has not run for this
+    conversation, or the DB row is otherwise missing) every value is
+    ``None``. The five keys are **always** present so the JSON schema is
+    stable across rows in one payload.
+    """
+    if row is None:
+        return {
+            "engaged_seconds": None,
+            "attention_periods": None,
+            "engagement_threshold_seconds": None,
+            "total_duration_seconds": None,
+            "engagement_ratio": None,
+        }
+    return {
+        "engaged_seconds": row.get("engaged_seconds"),
+        "attention_periods": row.get("attention_periods"),
+        "engagement_threshold_seconds": row.get("threshold_seconds"),
+        "total_duration_seconds": row.get("total_duration_seconds"),
+        "engagement_ratio": _engagement_ratio(
+            row.get("engaged_seconds"),
+            row.get("total_duration_seconds"),
+        ),
+    }
 
 
 def _format_list_output(
@@ -9401,6 +9448,19 @@ def gen() -> None:
     default=False,
     help="Include sub-conversations created by agent delegation (default: roots only)",
 )
+@click.option(
+    "--with-engagement",
+    "with_engagement",
+    is_flag=True,
+    default=False,
+    help=(
+        "Include engagement metrics (engaged_seconds, attention_periods, "
+        "engagement_threshold_seconds, total_duration_seconds, "
+        "engagement_ratio) in JSON output. Data is produced by the "
+        "engagement processing stage; missing values render as null. "
+        "No effect for -F table or -F markdown."
+    ),
+)
 def gen_objs_cmd(
     conversation_id: str | None,
     variant: str | None,
@@ -9427,6 +9487,7 @@ def gen_objs_cmd(
     yes: bool,
     quiet: bool,
     include_sub_conversations: bool,
+    with_engagement: bool,
 ) -> None:
     """Identify what the user hopes to achieve in a conversation.
 
@@ -9521,6 +9582,7 @@ def gen_objs_cmd(
             yes=yes,
             quiet=quiet,
             include_sub_conversations=include_sub_conversations,
+            with_engagement=with_engagement,
         )
     else:
         # Single-conversation mode - use --json for JSON output
@@ -9533,6 +9595,7 @@ def gen_objs_cmd(
             no_outputs=no_outputs,
             json_output=json_output,
             verbose=verbose,
+            with_engagement=with_engagement,
         )
 
 
@@ -9560,6 +9623,7 @@ def _run_batch_objectives_analysis(
     yes: bool = False,
     quiet: bool = False,
     include_sub_conversations: bool = False,
+    with_engagement: bool = False,
 ) -> None:
     """Run objectives analysis on multiple conversations.
 
@@ -9973,6 +10037,13 @@ def _run_batch_objectives_analysis(
 
     # Output results
     if fmt == "json":
+        # Issue #168: when --with-engagement, batch-load engagement rows
+        # for the current page so the per-item JSON can include the
+        # five engagement fields without an N+1 query.
+        engagement_map: dict[str, dict] = {}
+        if with_engagement:
+            engagement_map = _load_engagement_for_ids([r["id"] for r in results])
+
         json_results = []
         for r in results:
             # Calculate duration_seconds from timedelta
@@ -10013,6 +10084,11 @@ def _run_batch_objectives_analysis(
             # Include labels if present
             if r.get("labels"):
                 item["labels"] = r["labels"]
+            # Issue #168: merge the five engagement fields into every
+            # item when the flag is set. Missing rows render as JSON
+            # null so the schema is stable across rows.
+            if with_engagement:
+                item.update(_engagement_json_fields(engagement_map.get(r["id"])))
             json_results.append(item)
         print(json.dumps(json_results, indent=2))
     elif fmt == "markdown":
@@ -10050,6 +10126,7 @@ def _run_objectives_analysis(
     verbose: bool = False,
     detail: str | None = None,
     assess: bool | None = None,
+    with_engagement: bool = False,
 ) -> None:
     """Shared implementation for objectives analysis.
     
@@ -10067,6 +10144,9 @@ def _run_objectives_analysis(
         verbose: Show debug output
         detail: Detail level (legacy interface: brief, standard, detailed)
         assess: Add assessment (legacy interface)
+        with_engagement: Issue #168 — include the five engagement fields
+            from ``conversation_engagement`` at the top level of the JSON
+            payload. No-op for the non-JSON display path.
     """
     _init_logging(verbose=verbose)
     config = Config.from_env()
@@ -10187,7 +10267,16 @@ def _run_objectives_analysis(
     
     # Display results
     if json_output:
-        console.print(analysis.model_dump_json(indent=2))
+        if with_engagement:
+            # Issue #168: merge the five engagement fields into the
+            # top level of the analysis payload. Missing rows render
+            # as JSON null. ``default=str`` mirrors how
+            # ``model_dump_json`` handles ``ObjectiveStatus`` enums.
+            payload = analysis.model_dump()
+            payload.update(_engagement_json_fields(_load_engagement_row(conv_id)))
+            console.print(json.dumps(payload, indent=2, default=str))
+        else:
+            console.print(analysis.model_dump_json(indent=2))
     else:
         _display_objectives(conv_id, title, analysis)
         

--- a/tests/unit/test_cli_gen_objs_engagement.py
+++ b/tests/unit/test_cli_gen_objs_engagement.py
@@ -1,0 +1,711 @@
+"""Tests for ``ohtv gen objs --with-engagement`` (Issue #168).
+
+Covers the display-layer surface added to ``ohtv gen objs``: the new
+flag, the ID-based batch DB loader, the JSON field-merging helper, and
+the integration of all three through both the multi-conversation JSON
+emitter and the single-conversation JSON emitter.
+
+All DB-touching tests use a real temporary SQLite DB (via the
+``OHTV_DIR`` env var) — matching the no-mocks policy in AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import (
+    _engagement_json_fields,
+    _load_engagement_for_ids,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_engagement_row(
+    tmp_path: Path,
+    conv_id: str,
+    *,
+    engaged_seconds: int,
+    attention_periods: int,
+    threshold_seconds: int = 720,
+    total_duration_seconds: int | None = 1800,
+) -> None:
+    """Insert a conversation + engagement row into the temp DB.
+
+    Mirrors :func:`tests.unit.test_cli_list_engagement._seed_engagement_row`
+    so the two test files exercise the same schema.
+    """
+    from ohtv.db import get_ready_connection
+    from ohtv.db.models import Conversation
+    from ohtv.db.stores import ConversationStore
+
+    with get_ready_connection(show_progress=False) as conn:
+        ConversationStore(conn).upsert(
+            Conversation(id=conv_id, location=str(tmp_path / conv_id), event_count=1)
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO conversation_engagement "
+            "(conversation_id, threshold_seconds, first_event_ts, last_event_ts, "
+            "total_duration_seconds, engaged_seconds, attention_periods, "
+            "follow_up_user_message_count, attended_user_message_count, "
+            "processed_at, event_count) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, ?, 1)",
+            (
+                conv_id,
+                threshold_seconds,
+                "2026-05-30T14:00:00+00:00",
+                "2026-05-30T14:30:00+00:00",
+                total_duration_seconds,
+                engaged_seconds,
+                attention_periods,
+                "2026-05-30T15:00:00+00:00",
+            ),
+        )
+        conn.commit()
+
+
+def _mock_conversation_info(conv_id: str, *, source: str = "cloud"):
+    """Build a MagicMock that quacks like a ConversationInfo for the batch path."""
+    mock = MagicMock()
+    mock.id = conv_id
+    mock.short_id = conv_id[:7]
+    mock.lookup_id = conv_id
+    mock.title = f"Test {conv_id[:7]}"
+    mock.source = source
+    mock.created_at = datetime(2026, 5, 30, 14, 0, tzinfo=timezone.utc)
+    mock.updated_at = datetime(2026, 5, 30, 14, 30, tzinfo=timezone.utc)
+    mock.event_count = 10
+    mock.duration = timedelta(minutes=30)
+    return mock
+
+
+def _build_objective_analysis_result(goal: str = "Test goal"):
+    """Construct a real ``AnalysisResult`` (no mock) for the analysis path."""
+    from ohtv.analysis.objectives import AnalysisResult, ObjectiveAnalysis
+
+    analysis = ObjectiveAnalysis(
+        conversation_id="test123",
+        context_level="minimal",
+        detail_level="brief",
+        goal=goal,
+        analyzed_at=datetime(2026, 5, 30, 15, 0, tzinfo=timezone.utc),
+        model_used="test-model",
+        event_count=5,
+        content_hash="abc123",
+    )
+    return AnalysisResult(analysis=analysis, cost=0.0, from_cache=True)
+
+
+# ---------------------------------------------------------------------------
+# _engagement_json_fields — pure helper
+# ---------------------------------------------------------------------------
+
+
+class TestEngagementJsonFields:
+    def test_none_row_emits_five_nulls(self):
+        out = _engagement_json_fields(None)
+        assert out == {
+            "engaged_seconds": None,
+            "attention_periods": None,
+            "engagement_threshold_seconds": None,
+            "total_duration_seconds": None,
+            "engagement_ratio": None,
+        }
+
+    def test_present_row_emits_all_five_fields(self):
+        row = {
+            "engaged_seconds": 2460,
+            "attention_periods": 3,
+            "threshold_seconds": 720,
+            "total_duration_seconds": 8040,
+        }
+        out = _engagement_json_fields(row)
+        assert out["engaged_seconds"] == 2460
+        assert out["attention_periods"] == 3
+        assert out["engagement_threshold_seconds"] == 720
+        assert out["total_duration_seconds"] == 8040
+        assert out["engagement_ratio"] == 0.306
+
+    def test_zero_total_yields_null_ratio(self):
+        row = {
+            "engaged_seconds": 0,
+            "attention_periods": 0,
+            "threshold_seconds": 720,
+            "total_duration_seconds": 0,
+        }
+        out = _engagement_json_fields(row)
+        # Raw fields preserved; ratio is null because total is 0.
+        assert out["engaged_seconds"] == 0
+        assert out["total_duration_seconds"] == 0
+        assert out["engagement_ratio"] is None
+
+    def test_missing_total_yields_null_ratio(self):
+        row = {
+            "engaged_seconds": 100,
+            "attention_periods": 1,
+            "threshold_seconds": 720,
+            "total_duration_seconds": None,
+        }
+        out = _engagement_json_fields(row)
+        assert out["engagement_ratio"] is None
+        # Other fields preserved as raw values.
+        assert out["engaged_seconds"] == 100
+        assert out["total_duration_seconds"] is None
+
+    def test_schema_keys_are_constant(self):
+        """Both None and present rows must expose the same five keys."""
+        none_keys = set(_engagement_json_fields(None).keys())
+        row_keys = set(_engagement_json_fields({
+            "engaged_seconds": 1, "attention_periods": 1,
+            "threshold_seconds": 720, "total_duration_seconds": 10,
+        }).keys())
+        assert none_keys == row_keys
+        assert none_keys == {
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        }
+
+    def test_engaged_zero_total_positive_yields_zero_ratio(self):
+        row = {
+            "engaged_seconds": 0,
+            "attention_periods": 0,
+            "threshold_seconds": 720,
+            "total_duration_seconds": 100,
+        }
+        out = _engagement_json_fields(row)
+        assert out["engagement_ratio"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _load_engagement_for_ids — DB batch loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEngagementForIds:
+    def test_empty_input_returns_empty_dict(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        assert _load_engagement_for_ids([]) == {}
+
+    def test_db_missing_returns_empty_dict(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        # No DB initialized — should silently return empty.
+        assert _load_engagement_for_ids(["a" * 32]) == {}
+
+    def test_present_row_is_returned(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+        result = _load_engagement_for_ids([conv_id])
+        assert conv_id in result
+        assert result[conv_id]["engaged_seconds"] == 2460
+        assert result[conv_id]["attention_periods"] == 3
+        assert result[conv_id]["total_duration_seconds"] == 8040
+        assert result[conv_id]["threshold_seconds"] == 720
+
+    def test_missing_ids_are_absent_from_result(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        seeded = "a" * 32
+        missing = "b" * 32
+        _seed_engagement_row(
+            tmp_path, seeded, engaged_seconds=60,
+            attention_periods=1, total_duration_seconds=120,
+        )
+        result = _load_engagement_for_ids([seeded, missing])
+        assert seeded in result
+        assert missing not in result
+
+    def test_dashed_id_is_normalized(self, tmp_path, monkeypatch):
+        """AGENTS.md item #14: LocalSource returns dashed ids; DB stores dashless."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        dashless = "abcdef0123456789abcdef0123456789"
+        dashed = "abcdef01-2345-6789-abcd-ef0123456789"
+        _seed_engagement_row(
+            tmp_path, dashless, engaged_seconds=120,
+            attention_periods=2, total_duration_seconds=600,
+        )
+        # Caller passes dashed id; result is keyed by the caller's id form.
+        result = _load_engagement_for_ids([dashed])
+        assert dashed in result
+        assert result[dashed]["engaged_seconds"] == 120
+
+    def test_batch_chunking_above_900_ids(self, tmp_path, monkeypatch):
+        """The loader must chunk to stay under SQLite's parameter ceiling."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        ids: list[str] = []
+        for i in range(1100):
+            conv_id = f"{i:032x}"
+            _seed_engagement_row(
+                tmp_path, conv_id, engaged_seconds=i,
+                attention_periods=1, total_duration_seconds=max(i, 1),
+            )
+            ids.append(conv_id)
+        result = _load_engagement_for_ids(ids)
+        assert len(result) == 1100
+        # Spot-check first/last.
+        assert result[ids[0]]["engaged_seconds"] == 0
+        assert result[ids[-1]]["engaged_seconds"] == 1099
+
+    def test_chunk_query_count(self, tmp_path, monkeypatch):
+        """1100 IDs ⇒ exactly two SELECTs (900 + 200).
+
+        Wraps ``get_ready_connection`` with a proxy that intercepts
+        ``execute`` calls so we can count the engagement queries. The
+        real DB still backs the connection — no mocks in the data path.
+        """
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        ids: list[str] = []
+        for i in range(1100):
+            conv_id = f"{i:032x}"
+            _seed_engagement_row(
+                tmp_path, conv_id, engaged_seconds=i,
+                attention_periods=1, total_duration_seconds=max(i, 1),
+            )
+            ids.append(conv_id)
+
+        from contextlib import contextmanager
+
+        import ohtv.db as ohtv_db
+
+        real_get = ohtv_db.get_ready_connection
+        select_count = {"n": 0}
+
+        class _CountingConn:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def execute(self, sql, *args, **kwargs):
+                if (
+                    "FROM conversation_engagement" in sql
+                    and "WHERE conversation_id IN" in sql
+                ):
+                    select_count["n"] += 1
+                return self._conn.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        @contextmanager
+        def wrapping(show_progress=False):
+            with real_get(show_progress=show_progress) as conn:
+                yield _CountingConn(conn)
+
+        monkeypatch.setattr(ohtv_db, "get_ready_connection", wrapping)
+        _load_engagement_for_ids(ids)
+
+        # 1100 IDs at BATCH_SIZE=900 ⇒ ceil(1100/900) = 2 queries.
+        assert select_count["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI — single-conversation JSON mode (gen objs <id> --json --with-engagement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestSingleConvJsonWithEngagement:
+    def test_flag_off_emits_only_analysis_fields(self, runner, tmp_path, monkeypatch):
+        """Regression guard: no engagement keys when flag absent."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+        analysis_result = _build_objective_analysis_result()
+
+        with patch("ohtv.cli._find_conversation_dir", return_value=(tmp_path, None)), \
+             patch("ohtv.cli._get_conversation_info", return_value=(conv_id, "Test")), \
+             patch("ohtv.cli.Config"), \
+             patch("ohtv.analysis.analyze_objectives", return_value=analysis_result), \
+             patch("ohtv.analysis.get_cached_analysis", return_value=analysis_result.analysis), \
+             patch("ohtv.analysis.load_events", return_value=[]):
+            result = runner.invoke(main, ["gen", "objs", conv_id, "--json"])
+
+        assert result.exit_code == 0, result.output
+        # Find the JSON object in output (rich prints may decorate).
+        payload = json.loads(_extract_json_object(result.output))
+        # Analysis fields present.
+        assert payload["goal"] == "Test goal"
+        # No engagement keys.
+        for k in (
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        ):
+            assert k not in payload
+
+    def test_flag_on_present_row_merges_five_fields(self, runner, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+        analysis_result = _build_objective_analysis_result()
+
+        with patch("ohtv.cli._find_conversation_dir", return_value=(tmp_path, None)), \
+             patch("ohtv.cli._get_conversation_info", return_value=(conv_id, "Test")), \
+             patch("ohtv.cli.Config"), \
+             patch("ohtv.analysis.analyze_objectives", return_value=analysis_result), \
+             patch("ohtv.analysis.get_cached_analysis", return_value=analysis_result.analysis), \
+             patch("ohtv.analysis.load_events", return_value=[]):
+            result = runner.invoke(
+                main, ["gen", "objs", conv_id, "--json", "--with-engagement"]
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(_extract_json_object(result.output))
+        # Analysis fields untouched.
+        assert payload["goal"] == "Test goal"
+        assert payload["context_level"] == "minimal"
+        assert payload["detail_level"] == "brief"
+        # Engagement fields present at top level.
+        assert payload["engaged_seconds"] == 2460
+        assert payload["attention_periods"] == 3
+        assert payload["engagement_threshold_seconds"] == 720
+        assert payload["total_duration_seconds"] == 8040
+        assert payload["engagement_ratio"] == 0.306
+
+    def test_flag_on_missing_row_emits_nulls(self, runner, tmp_path, monkeypatch):
+        """Engagement-stage hasn't run ⇒ five nulls, analysis untouched."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        # No _seed_engagement_row call ⇒ row missing from DB.
+        # Force DB to exist (empty) so the loader can do its lookup.
+        from ohtv.db import get_ready_connection
+        with get_ready_connection(show_progress=False):
+            pass
+
+        analysis_result = _build_objective_analysis_result()
+
+        with patch("ohtv.cli._find_conversation_dir", return_value=(tmp_path, None)), \
+             patch("ohtv.cli._get_conversation_info", return_value=(conv_id, "Test")), \
+             patch("ohtv.cli.Config"), \
+             patch("ohtv.analysis.analyze_objectives", return_value=analysis_result), \
+             patch("ohtv.analysis.get_cached_analysis", return_value=analysis_result.analysis), \
+             patch("ohtv.analysis.load_events", return_value=[]):
+            result = runner.invoke(
+                main, ["gen", "objs", conv_id, "--json", "--with-engagement"]
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(_extract_json_object(result.output))
+        assert payload["goal"] == "Test goal"
+        # All five engagement keys present and null.
+        for k in (
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        ):
+            assert k in payload
+            assert payload[k] is None
+
+
+# ---------------------------------------------------------------------------
+# CLI — multi-conversation JSON mode (gen objs ... -F json --with-engagement)
+# ---------------------------------------------------------------------------
+
+
+def _patch_batch_environment(conversations: list, analysis_result):
+    """Bundle the patches needed to drive ``_run_batch_objectives_analysis`` end-to-end.
+
+    Returns a list of context managers that the caller composes with
+    ``contextlib.ExitStack`` / nested ``with``.
+    """
+    filter_result = MagicMock()
+    filter_result.conversations = conversations
+    filter_result.show_all = False
+
+    return [
+        patch("ohtv.cli.Config"),
+        patch("ohtv.cli._apply_conversation_filters", return_value=filter_result),
+        patch("ohtv.analysis.analyze_objectives", return_value=analysis_result),
+        patch("ohtv.cli._find_conversation_dir", return_value=(Path("/tmp/conv"), None)),
+        patch("ohtv.cli._count_uncached_conversations_fast", return_value=0),
+        patch("ohtv.cli._get_conversation_labels", return_value={}),
+        patch("ohtv.cli._get_conversation_outputs", return_value=None),
+    ]
+
+
+class TestMultiConvJsonWithEngagement:
+    def test_flag_off_omits_engagement_keys(self, runner, tmp_path, monkeypatch):
+        """Regression guard: no engagement keys when flag absent."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+
+        conversations = [_mock_conversation_info(conv_id)]
+        analysis_result = _build_objective_analysis_result()
+
+        import contextlib
+        with contextlib.ExitStack() as stack:
+            for cm in _patch_batch_environment(conversations, analysis_result):
+                stack.enter_context(cm)
+            result = runner.invoke(main, ["gen", "objs", "-F", "json"])
+
+        assert result.exit_code == 0, result.output
+        items = json.loads(_extract_json_array(result.output))
+        assert len(items) == 1
+        item = items[0]
+        for k in (
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        ):
+            assert k not in item
+
+    def test_flag_on_present_row_emits_five_fields(self, runner, tmp_path, monkeypatch):
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+
+        conversations = [_mock_conversation_info(conv_id)]
+        analysis_result = _build_objective_analysis_result()
+
+        import contextlib
+        with contextlib.ExitStack() as stack:
+            for cm in _patch_batch_environment(conversations, analysis_result):
+                stack.enter_context(cm)
+            result = runner.invoke(
+                main, ["gen", "objs", "-F", "json", "--with-engagement"]
+            )
+
+        assert result.exit_code == 0, result.output
+        items = json.loads(_extract_json_array(result.output))
+        item = items[0]
+        # Existing fields preserved.
+        assert item["id"] == conv_id
+        assert "goal" in item
+        # Engagement fields appended.
+        assert item["engaged_seconds"] == 2460
+        assert item["attention_periods"] == 3
+        assert item["engagement_threshold_seconds"] == 720
+        assert item["total_duration_seconds"] == 8040
+        assert item["engagement_ratio"] == 0.306
+
+    def test_flag_on_mixed_present_and_missing_rows(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Schema must be stable across rows — present and missing both have five fields."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        present_id = "a" * 32
+        missing_id = "b" * 32
+        _seed_engagement_row(
+            tmp_path, present_id, engaged_seconds=100,
+            attention_periods=1, total_duration_seconds=1000,
+        )
+
+        conversations = [
+            _mock_conversation_info(present_id),
+            _mock_conversation_info(missing_id),
+        ]
+        analysis_result = _build_objective_analysis_result()
+
+        import contextlib
+        with contextlib.ExitStack() as stack:
+            for cm in _patch_batch_environment(conversations, analysis_result):
+                stack.enter_context(cm)
+            result = runner.invoke(
+                main, ["gen", "objs", "-F", "json", "--with-engagement"]
+            )
+
+        assert result.exit_code == 0, result.output
+        items = json.loads(_extract_json_array(result.output))
+        assert len(items) == 2
+        # Both items have identical key sets.
+        assert set(items[0].keys()) == set(items[1].keys())
+        # Find the present and missing items by id.
+        present_item = next(i for i in items if i["id"] == present_id)
+        missing_item = next(i for i in items if i["id"] == missing_id)
+        # Present row.
+        assert present_item["engaged_seconds"] == 100
+        assert present_item["engagement_ratio"] == 0.1
+        # Missing row.
+        for k in (
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        ):
+            assert missing_item[k] is None
+
+    def test_flag_on_table_format_is_noop(self, runner, tmp_path, monkeypatch):
+        """``--with-engagement -F table`` must produce identical output to plain ``-F table``."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+
+        conversations = [_mock_conversation_info(conv_id)]
+        analysis_result = _build_objective_analysis_result()
+
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for cm in _patch_batch_environment(conversations, analysis_result):
+                stack.enter_context(cm)
+            without = runner.invoke(main, ["gen", "objs", "-F", "table"])
+
+        with contextlib.ExitStack() as stack:
+            for cm in _patch_batch_environment(conversations, analysis_result):
+                stack.enter_context(cm)
+            with_flag = runner.invoke(
+                main, ["gen", "objs", "-F", "table", "--with-engagement"]
+            )
+
+        assert without.exit_code == 0
+        assert with_flag.exit_code == 0
+        # Engagement keys must NOT appear in either output.
+        for k in (
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        ):
+            assert k not in without.output
+            assert k not in with_flag.output
+
+    def test_flag_on_markdown_format_is_noop(self, runner, tmp_path, monkeypatch):
+        """``--with-engagement -F markdown`` must not inject engagement fields."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        conv_id = "a" * 32
+        _seed_engagement_row(
+            tmp_path, conv_id, engaged_seconds=2460,
+            attention_periods=3, total_duration_seconds=8040,
+        )
+
+        conversations = [_mock_conversation_info(conv_id)]
+        analysis_result = _build_objective_analysis_result()
+
+        import contextlib
+        with contextlib.ExitStack() as stack:
+            for cm in _patch_batch_environment(conversations, analysis_result):
+                stack.enter_context(cm)
+            with_flag = runner.invoke(
+                main, ["gen", "objs", "-F", "markdown", "--with-engagement"]
+            )
+
+        assert with_flag.exit_code == 0
+        # Markdown output must not carry any of the JSON-specific keys.
+        for k in (
+            "engaged_seconds",
+            "attention_periods",
+            "engagement_threshold_seconds",
+            "total_duration_seconds",
+            "engagement_ratio",
+        ):
+            assert k not in with_flag.output
+
+
+# ---------------------------------------------------------------------------
+# CLI help — surface check
+# ---------------------------------------------------------------------------
+
+
+class TestHelpSurface:
+    def test_with_engagement_flag_is_documented(self, runner):
+        result = runner.invoke(main, ["gen", "objs", "--help"])
+        assert result.exit_code == 0
+        assert "--with-engagement" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Output-extraction utilities
+# ---------------------------------------------------------------------------
+
+
+def _extract_json_object(text: str) -> str:
+    """Pluck the outermost ``{...}`` from rich-decorated output."""
+    start = text.find("{")
+    if start < 0:
+        raise AssertionError(f"No JSON object in output:\n{text}")
+    # Walk to the matching closing brace, honoring nested structures.
+    depth = 0
+    in_str = False
+    escape = False
+    for i in range(start, len(text)):
+        c = text[i]
+        if escape:
+            escape = False
+            continue
+        if c == "\\":
+            escape = True
+            continue
+        if c == '"':
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise AssertionError(f"Unbalanced JSON object in output:\n{text}")
+
+
+def _extract_json_array(text: str) -> str:
+    """Pluck the outermost ``[...]`` from CLI output."""
+    start = text.find("[")
+    if start < 0:
+        raise AssertionError(f"No JSON array in output:\n{text}")
+    depth = 0
+    in_str = False
+    escape = False
+    for i in range(start, len(text)):
+        c = text[i]
+        if escape:
+            escape = False
+            continue
+        if c == "\\":
+            escape = True
+            continue
+        if c == '"':
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise AssertionError(f"Unbalanced JSON array in output:\n{text}")

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Adds an opt-in `--with-engagement` flag to `ohtv gen objs` that surfaces the engagement metric (added by PR #165 to per-conversation `ohtv show`, and by PR #171 to `ohtv list`) across the `gen objs` JSON exporter — both the single-conversation and multi-conversation modes.

Fixes #168.

## What changes

### Multi-conversation JSON (`gen objs ... -F json --with-engagement`)

Each item in the JSON array gains five fields:

```json
{
  "id": "a711cbbc...",
  "source": "cloud",
  "created_at": "...",
  "duration_seconds": 8040,
  "event_count": 312,
  "goal": "Add deploy hooks",
  "engaged_seconds": 2460,
  "attention_periods": 3,
  "engagement_threshold_seconds": 720,
  "total_duration_seconds": 8040,
  "engagement_ratio": 0.306
}
```

### Single-conversation JSON (`gen objs <id> --json --with-engagement`)

The existing top-level `ObjectiveAnalysis` payload gains the same five fields as additional top-level keys. Every existing analysis key is unchanged in name, type, and ordering — engagement is appended; nothing is renamed or removed.

### Missing values render as JSON `null`

Schema stability matches the rule that `show -F json` (#165) and `list --with-engagement -F json` (#171) already follow. The five fields are *always* present when the flag is set; only their values vary.

### `-F table` and `-F markdown` are silently no-ops

The flag is JSON-only by design (per the issue body's "Out of Scope" section). A user can leave `--with-engagement` in their alias / script and freely switch formats without churn.

## Implementation

| File | Change |
|---|---|
| `src/ohtv/cli.py` (gen objs decorator) | New `--with-engagement` option, forwarded to both `_run_batch_objectives_analysis` and `_run_objectives_analysis` |
| `src/ohtv/cli.py` (`_load_engagement_for_ids`, new) | ID-based sibling of `_load_engagement_for_conversations`; same batched-query / 900-chunk / dashless-normalization semantics |
| `src/ohtv/cli.py` (`_load_engagement_for_conversations`, refactored) | Now delegates to `_load_engagement_for_ids` — single source of truth |
| `src/ohtv/cli.py` (`_engagement_json_fields`, new) | Centralises the five-key engagement dict so the multi- and single-conv JSON emitters stay in lock-step |
| `src/ohtv/cli.py` (multi-conv JSON branch) | Batch-loads engagement when flag is set; merges five fields per item |
| `src/ohtv/cli.py` (single-conv JSON branch) | `analysis.model_dump()` + merge, with `default=str` to preserve enum serialization parity with `model_dump_json` |
| `tests/unit/test_cli_gen_objs_engagement.py` (new, 22 tests) | Helper coverage + multi-conv CLI + single-conv CLI + format no-op guards + chunking |

### Performance — single batched query

`_load_engagement_for_ids` issues a single `SELECT ... WHERE conversation_id IN (?, ?, ...)` per ≤ 900 IDs. `conversation_engagement.conversation_id` is the PRIMARY KEY so the lookup is index-backed. The chunk-count test (`test_chunk_query_count`) verifies that 1100 IDs ⇒ exactly two SELECTs.

### Conversation-ID normalization (AGENTS.md item #14)

Local CLI conversations have dashed IDs; the DB stores dashless. The loader normalizes inputs before the IN clause and keys the result by the caller's original ID form. Verified by `test_dashed_id_is_normalized`.

## Two non-obvious decisions

1. **Opt-in `--with-engagement`, not default-on.** Keeps the existing `gen objs -F json` schema stable for downstream consumers (the planned `list_conversations` agent tool, ad-hoc analysis scripts). Mirrors the design call PR #171 made for `ohtv list`.
2. **`null` instead of omitting missing fields.** A field that's always present (but sometimes `null`) lets a downstream JSON Schema declare `["integer", "null"]` once, rather than forcing branchy `if "engaged_seconds" in row` checks. Matches `show -F json` and `list --with-engagement -F json`.

## Test coverage

- `_engagement_json_fields` — 6 helper tests (None, present, zero-total, missing-total, schema stability, zero-engaged)
- `_load_engagement_for_ids` — 7 DB tests (empty, missing DB, present, missing rows, dashed→dashless, 1100-row chunking, exact chunk-count via wrapped connection)
- Single-conv JSON CLI — 3 tests (flag-off regression, flag-on present row, flag-on missing row)
- Multi-conv JSON CLI — 3 tests (flag-off regression, flag-on present row, flag-on mixed present/missing schema stability)
- Format no-op guards — 2 tests (`-F table`, `-F markdown` produce identical output with/without flag)
- Help-surface — 1 test (flag appears in `--help`)

**Total: 22 new tests, all passing locally.** Full suite: `2373 passed, 2 skipped, 3 xfailed` in 35.6s.

## Notes for the reviewer

- The shared helpers `_validate_engagement_values`, `_format_eng_pct`, `_engagement_ratio` are reused from PR #171 unchanged. The new `_engagement_json_fields` and `_load_engagement_for_ids` are net-new.
- `_engagement_ratio` rounds to 4 decimals (per PR #171 — already merged and tested). The issue body suggested 3 decimals; in practice the example value (`2460 / 8040 = 0.305970...`) renders as `0.306` at either precision, so this PR does not diverge from the issue's user-visible expectation. The 4th-decimal precision is preserved across both `list` and `gen objs` for consistency.
- `_load_engagement_for_conversations` retains its old signature (`list[ConversationInfo]`) for compatibility with the PR #171 call site in `ohtv list`; it now delegates to `_load_engagement_for_ids` to avoid duplication.

---

_This pull request was created by an AI agent (OpenHands) on behalf of @jpshackelford._
