### PR TITLE
docs: Add engagement threshold empirical tuning analysis

### DIFF
--- a/docs/design/engagement-threshold-analysis.md
+++ b/docs/design/engagement-threshold-analysis.md
@@ -1,0 +1,330 @@
+# Engagement Threshold Analysis: Empirical Tuning Study
+
+**Date:** 2026-05-27  
+**Analyst:** OpenHands AI Agent on behalf of @jpshackelford  
+**Related Issues:** [#163](https://github.com/jpshackelford/ohtv/issues/163), [#165](https://github.com/jpshackelford/ohtv/pull/165), [#167](https://github.com/jpshackelford/ohtv/issues/167), [#168](https://github.com/jpshackelford/ohtv/issues/168), [#169](https://github.com/jpshackelford/ohtv/issues/169), [#170](https://github.com/jpshackelford/ohtv/issues/170)
+
+---
+
+## Executive Summary
+
+This document records the empirical analysis conducted to determine the optimal sustained-attention threshold (T) for the "engaged human minutes" metric in ohtv. The analysis processed 4,791 conversations containing 9,935 follow-up user message gaps across 11 candidate thresholds (6-28 minutes).
+
+**Key Findings:**
+1. ~70% of all follow-up user messages occur within 30 seconds of the preceding event
+2. 92.9% occur within 6 minutes; 96.1% within 12 minutes
+3. The distribution shows a cliff at ~10 minutes where gap counts drop sharply
+4. Content analysis reveals ~65% of gaps in the 8-12 minute range are likely inattention (low content on both sides)
+5. **The 12-minute default chosen in PR #165 is reasonable**, though 10 minutes is slightly more defensible empirically
+
+**Recommendation:** For the intended use case (measuring orchestration impact on throughput), threshold choice matters less than consistency. Focus on unambiguous metrics (completely unattended conversations) and ratio analysis (PRs per attention-minute) with a consistent threshold.
+
+---
+
+## 1. Background
+
+### 1.1 The Engagement Metric (PR #165)
+
+[PR #165](https://github.com/jpshackelford/ohtv/pull/165) introduced a per-conversation "engaged human minutes" metric to ohtv, addressing [Issue #163](https://github.com/jpshackelford/ohtv/issues/163). The metric estimates how long a human was actively monitoring/steering each conversation, inferred from temporal gaps around user messages.
+
+**Algorithm (from Issue #163):**
+
+1. Order events by timestamp ascending; find user-message indices `Uᵢ`
+2. For each follow-up `Uᵢ` (i ≥ 1), examine gap from preceding event `Pᵢ`. If `Uᵢ.ts - Pᵢ.ts ≤ T`, record attended block `(Uᵢ₋₁.ts, Uᵢ.ts)`
+3. Merge adjacent blocks with seam ≤ T into attention periods
+4. `engaged_seconds = Σ (period.end - period.start)`
+
+**Key Design Decisions:**
+- Threshold T stored per-row in `conversation_engagement` table for distinguishability
+- Fire-and-forget conversations (0-1 user messages) get `engaged_seconds = 0` (not NULL)
+- Tail events after last user message do NOT extend attention periods
+
+### 1.2 The Threshold Question
+
+PR #165 shipped with T = 12 minutes as the default, based on the issue author's intuition ("noticed the message → read response → composed reply"). The issue explicitly called for empirical tuning:
+
+> "Rather than guess: implement the algorithm parameterized on T, run it across the corpus at T ∈ {6, 8, 12, 14, 16, 18, 20, 22, 24, 26, 28} minutes, plot the gap histogram to find the trough between 'human reaction time' and 'came back later' modes."
+
+**This tuning was not performed before merging PR #165.** The sweep script (`scripts/engagement_threshold_sweep.py`) was created but the results were never analyzed.
+
+---
+
+## 2. Methodology
+
+### 2.1 Data Collection
+
+We ran the engagement threshold sweep against the full ohtv corpus:
+
+```bash
+uv tool run --from git+https://github.com/jpshackelford/ohtv.git@main \
+  python scripts/engagement_threshold_sweep.py \
+  --out engagement_totals.csv \
+  --gap-histogram engagement_gaps.csv
+```
+
+**Corpus Statistics:**
+- Total conversations: 4,791 (4,777 roots + 14 sub-conversations)
+- Conversations with follow-up gaps: 1,505
+- Total follow-up user message gaps: 9,935
+
+### 2.2 Analysis Scripts
+
+Two analysis scripts were developed:
+
+1. **`scripts/analyze_engagement.py`** — Basic analysis of totals and gap distribution
+2. **`scripts/analyze_gaps_with_content.py`** — Content-aware analysis correlating gaps with word counts
+
+The content-aware script enriches each gap with:
+- `agent_words_between`: Total words in agent messages between the previous user message and this one
+- `user_response_words`: Word count of the user's follow-up message
+- `immediate_prev_words`: Word count of the immediately preceding event
+
+---
+
+## 3. Findings
+
+### 3.1 Gap Distribution Overview
+
+The gap distribution is heavily front-loaded:
+
+| Range | Count | % | Cumulative % |
+|-------|-------|---|--------------|
+| 0-30s | 6,911 | 69.6% | 69.6% |
+| 30s-1m | 495 | 5.0% | 74.6% |
+| 1-2m | 807 | 8.1% | 82.7% |
+| 2-3m | 426 | 4.3% | 87.0% |
+| 3-5m | 461 | 4.6% | 91.6% |
+| 5-8m | 282 | 2.8% | 94.4% |
+| 8-10m | 108 | 1.1% | 95.5% |
+| 10-12m | 57 | 0.6% | 96.1% |
+| 12-15m | 70 | 0.7% | 96.8% |
+| 15-20m | 54 | 0.5% | 97.3% |
+| 20-30m | 60 | 0.6% | 97.9% |
+| 30-60m | 68 | 0.7% | 98.6% |
+| 1-2hr | 51 | 0.5% | 99.1% |
+| 2hr+ | 85 | 0.9% | 100.0% |
+
+**Key Observation:** The median gap is essentially 0 seconds. Most human steering happens in real-time — users are actively watching the agent work.
+
+### 3.2 Threshold Sweep Totals
+
+| Threshold | Engaged Convs | Engaged Hours | Periods | Attended Msgs | Ratio |
+|-----------|---------------|---------------|---------|---------------|-------|
+| 6 min | 1,459 | 2,604.3 | 1,771 | 9,226 | 23.12% |
+| 8 min | 1,467 | 2,627.5 | 1,726 | 9,382 | 23.32% |
+| 12 min | 1,480 | 2,659.3 | 1,675 | 9,547 | 23.60% |
+| 14 min | 1,481 | 2,672.7 | 1,653 | 9,600 | 23.72% |
+| 16 min | 1,483 | 2,682.2 | 1,644 | 9,632 | 23.81% |
+| 20 min | 1,484 | 2,695.2 | 1,628 | 9,671 | 23.92% |
+| 28 min | 1,487 | 2,717.3 | 1,607 | 9,720 | 24.12% |
+
+**Observation:** Engagement metrics stabilize quickly. Moving from T=6 to T=8 adds only 0.9% more engaged time; T=8 to T=12 adds another 1.2%. Beyond 12 minutes, gains are marginal (<0.5% per step).
+
+### 3.3 Derivative Analysis: Finding the Cliff
+
+We examined the rate of change in gap counts to identify where the distribution transitions from "still watching" to "came back later":
+
+| Bin | Count | Δ from prev | Signal |
+|-----|-------|-------------|--------|
+| 5-6 min | 126 | (baseline) | |
+| 6-7 min | 89 | -37 | **SIGNIFICANT DROP** |
+| 7-8 min | 67 | -22 | **SIGNIFICANT DROP** |
+| 8-9 min | 57 | -10 | moderate drop |
+| 9-10 min | 51 | -6 | moderate drop |
+| 10-11 min | 31 | -20 | **SIGNIFICANT DROP** |
+| 11-12 min | 26 | -5 | stable |
+| 12-13 min | 28 | +2 | stable |
+| 13-14 min | 25 | -3 | stable |
+
+**Finding:** The counts show significant drops at 6-7, 7-8, and 10-11 minutes. After 10 minutes, the distribution flattens into a plateau (~25-28 gaps per minute), suggesting this is the "came back later" territory.
+
+### 3.4 Marginal Analysis: 8-12 Minute Range
+
+| Threshold Change | Gaps Added | % of Total | Assessment |
+|-----------------|------------|------------|------------|
+| 6→8 min | 156 | 1.57% | Likely still watching |
+| 8→10 min | 108 | 1.09% | Likely still watching |
+| 10→12 min | 57 | 0.57% | Borderline |
+| 12→14 min | 53 | 0.53% | Diminishing returns |
+| 14→16 min | 32 | 0.32% | Noise |
+
+### 3.5 Content-Aware Analysis
+
+To test whether long gaps are justified by content volume (reading/composing time) vs. inattention, we correlated gaps with word counts.
+
+**Definition of "low content" (likely inattention):**
+- Agent words between messages < 300 AND
+- User response words < 50
+
+**Results for 8-12 minute gaps:**
+
+| Metric | Value |
+|--------|-------|
+| Total gaps in range | 165 |
+| Low agent content (<300 words) | 147 (89%) |
+| Low agent + low user | 108 (65%) ← **likely inattention** |
+| High agent content (≥700 words) | 4 (2%) ← likely reading |
+
+**Inattention rate by gap range:**
+
+| Gap Range | Total | Low Content | % Inattention |
+|-----------|-------|-------------|---------------|
+| 5-6 min | 126 | 85 | 67.5% |
+| 6-7 min | 89 | 55 | 61.8% |
+| 7-8 min | 67 | 41 | 61.2% |
+| 8-9 min | 57 | 36 | 63.2% |
+| 9-10 min | 51 | 33 | 64.7% |
+| 10-11 min | 31 | 21 | 67.7% |
+| 11-12 min | 26 | 18 | 69.2% |
+| 12-15 min | 70 | 45 | 64.3% |
+| 15-20 min | 54 | 31 | 57.4% |
+
+**Key Finding:** The inattention rate is remarkably consistent (~61-69%) across the 5-15 minute range. There is no clear content-based breakpoint that would distinguish 8 from 10 from 12 minutes. About 1/3 of gaps in this range are legitimate reading/composing time; 2/3 are likely brief inattention.
+
+---
+
+## 4. Conclusions
+
+### 4.1 Threshold Recommendation
+
+Based on the analysis:
+
+1. **The 12-minute default is reasonable.** It captures 96.1% of all follow-up gaps and sits in a stable region of the distribution.
+
+2. **10 minutes is slightly more defensible empirically.** It sits right at the second significant drop (10-11 min shows -20 gap drop) and captures 95.5% of gaps.
+
+3. **8 minutes would be conservative.** It captures 94.4% and is just before the distribution fully stabilizes.
+
+**For academic rigor, we recommend:**
+- Use 10 or 12 minutes as the primary threshold
+- Show sensitivity analysis at 8, 10, and 12 minutes to demonstrate robustness
+
+### 4.2 Intended Use Case: Orchestration Impact Analysis
+
+The primary use case is demonstrating that AI orchestration increases PR throughput without increasing (or while decreasing) human attention time.
+
+**Recommended Metrics:**
+
+1. **Completely Unattended Conversations** (threshold-independent)
+   - Definition: Zero follow-up user messages OR zero attention periods
+   - This is unambiguous and the cleanest metric
+
+2. **Efficiency Ratios** (threshold-dependent but consistent)
+   - Merged PRs per attention-hour
+   - Merged LOC per attention-hour
+   - Use same threshold for all time periods being compared
+
+**Why Threshold Choice Matters Less:**
+- For unattended conversations: No dependency on T
+- For ratio analysis: Consistency matters more than absolute value
+- A higher T is actually more conservative (counts more attention time, understating efficiency gains)
+
+### 4.3 Robustness Considerations
+
+To make the orchestration impact argument bulletproof:
+
+1. **Lead with unambiguous metrics** — % of completely unattended conversations
+2. **Show ratio trends** — PRs/LOC per attention-minute over time
+3. **Demonstrate threshold robustness** — Show conclusions hold at T=8, 10, and 12
+4. **Control for confounds** — Compare similar conversation types (same repos, similar complexity)
+
+---
+
+## 5. Artifacts and Data
+
+### 5.1 Generated Files
+
+| File | Location | Description |
+|------|----------|-------------|
+| `engagement_totals.csv` | `~/engagement_totals.csv` | Per-threshold aggregate stats |
+| `engagement_gaps.csv` | `~/engagement_gaps.csv` | All 9,935 follow-up gaps with timestamps |
+| `enriched_gaps.csv` | `~/enriched_gaps.csv` | Gaps enriched with word counts |
+
+### 5.2 Analysis Scripts
+
+| Script | Location | Purpose |
+|--------|----------|---------|
+| `engagement_threshold_sweep.py` | `scripts/` | Run threshold sweep (from ohtv repo) |
+| `analyze_engagement.py` | `scripts/` | Basic gap distribution analysis |
+| `analyze_gaps_with_content.py` | `scripts/` | Content-aware gap analysis |
+
+### 5.3 Filed Issues
+
+| Issue | Title | Purpose |
+|-------|-------|---------|
+| [#167](https://github.com/jpshackelford/ohtv/issues/167) | Add engagement columns to `ohtv list` | Show engagement in list output |
+| [#168](https://github.com/jpshackelford/ohtv/issues/168) | Add engagement fields to `ohtv gen objs` JSON | Include in JSON export |
+| [#169](https://github.com/jpshackelford/ohtv/issues/169) | Add engagement to `gen objs` markdown | Show below Duration line |
+| [#170](https://github.com/jpshackelford/ohtv/issues/170) | Filter by engagement level | `--engaged`, `--min-engaged` flags |
+
+---
+
+## 6. Next Steps
+
+For the follow-up session:
+
+1. **Compute LOC / Merged PR Analysis**
+   - Query `change_refs` table for merged PRs with LOC
+   - Join with `conversation_engagement` for attention minutes
+   - Aggregate by time period (weekly/monthly)
+
+2. **Track Orchestration Rollout**
+   - Identify when orchestration features were deployed
+   - Compare pre/post metrics
+
+3. **Build Visualization**
+   - Time series of:
+     - % unattended conversations
+     - PRs per attention-hour
+     - LOC per attention-hour
+   - Annotate with orchestration milestones
+
+4. **Sensitivity Analysis**
+   - Repeat analysis at T=8, 10, 12 minutes
+   - Confirm conclusions are robust
+
+---
+
+## Appendix A: Statistical Summary
+
+```
+Corpus: 4,791 conversations, 9,935 follow-up user message gaps
+
+Gap Distribution Percentiles:
+  p25:    0.0 seconds (0.0 min)
+  p50:    0.0 seconds (0.0 min)  [median]
+  p75:   62.8 seconds (1.0 min)
+  p90:  249.0 seconds (4.1 min)
+  p95:  539.8 seconds (9.0 min)
+  p99: 5825.2 seconds (97.1 min)
+
+  Min:     0.0 seconds
+  Max: 2,063,018.9 seconds (34,383 min ≈ 24 days)
+  Mean:  959.8 seconds (16.0 min)
+```
+
+---
+
+## Appendix B: Raw Threshold Sweep Output
+
+```
+threshold_seconds,threshold_minutes,conversations_total,engaged_conversations,
+engaged_seconds_total,total_duration_seconds,engagement_ratio,attention_periods_total,
+follow_up_user_message_total,attended_user_message_total,generated_at
+
+360,6.0,4791,1459,9375526,40551997,0.2312,1771,9935,9226,2026-05-27T...
+480,8.0,4791,1467,9459058,40551997,0.2332,1726,9935,9382,...
+720,12.0,4791,1480,9573593,40551997,0.2360,1675,9935,9547,...
+840,14.0,4791,1481,9621773,40551997,0.2372,1653,9935,9600,...
+960,16.0,4791,1483,9656059,40551997,0.2381,1644,9935,9632,...
+1080,18.0,4791,1483,9680885,40551997,0.2387,1636,9935,9653,...
+1200,20.0,4791,1484,9702688,40551997,0.2392,1628,9935,9671,...
+1320,22.0,4791,1484,9720984,40551997,0.2397,1621,9935,9684,...
+1440,24.0,4791,1485,9749265,40551997,0.2404,1616,9935,9701,...
+1560,26.0,4791,1486,9764237,40551997,0.2407,1612,9935,9710,...
+1680,28.0,4791,1487,9782268,40551997,0.2412,1607,9935,9720,...
+```
+
+---
+
+*Document generated by OpenHands AI Agent. For questions or clarifications, refer to the original conversation or contact @jpshackelford.*

--- a/scripts/analyze_engagement.py
+++ b/scripts/analyze_engagement.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Analyze engagement threshold sweep results.
+
+Usage:
+    python scripts/analyze_engagement.py engagement_totals.csv engagement_gaps.csv
+    python scripts/analyze_engagement.py --totals engagement_totals.csv --gaps engagement_gaps.csv
+"""
+
+import argparse
+import csv
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def analyze_totals(totals_path: Path) -> None:
+    """Analyze the per-threshold totals CSV."""
+    print("\n" + "=" * 70)
+    print("THRESHOLD SWEEP TOTALS")
+    print("=" * 70)
+    
+    rows = []
+    with open(totals_path) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    
+    if not rows:
+        print("No data in totals file.")
+        return
+    
+    # Print header
+    print(f"\n{'Threshold':>10} {'Engaged':>12} {'Engaged':>10} {'Periods':>10} {'Attended':>10} {'Ratio':>8}")
+    print(f"{'(min)':>10} {'Convs':>12} {'Hours':>10} {'Total':>10} {'Msgs':>10} {'':>8}")
+    print("-" * 70)
+    
+    for row in rows:
+        t_min = float(row.get('threshold_minutes', 0))
+        engaged_convs = int(row.get('engaged_conversations', 0))
+        engaged_secs = int(row.get('engaged_seconds_total', 0))
+        engaged_hrs = engaged_secs / 3600
+        periods = int(row.get('attention_periods_total', 0))
+        attended = int(row.get('attended_user_message_total', 0))
+        ratio = float(row.get('engagement_ratio', 0))
+        
+        print(f"{t_min:>10.0f} {engaged_convs:>12,} {engaged_hrs:>10.1f} {periods:>10,} {attended:>10,} {ratio:>8.2%}")
+    
+    # Find where metrics stabilize
+    print("\n" + "-" * 70)
+    print("ANALYSIS:")
+    
+    if len(rows) >= 2:
+        # Look for where engaged_seconds stops growing significantly
+        prev_engaged = int(rows[0].get('engaged_seconds_total', 0))
+        for i, row in enumerate(rows[1:], 1):
+            curr_engaged = int(row.get('engaged_seconds_total', 0))
+            pct_change = (curr_engaged - prev_engaged) / prev_engaged * 100 if prev_engaged > 0 else 0
+            t_min = float(row.get('threshold_minutes', 0))
+            if pct_change < 5:  # Less than 5% growth
+                print(f"  • Engagement stabilizes around T={t_min:.0f} min (only {pct_change:.1f}% increase from previous)")
+                break
+            prev_engaged = curr_engaged
+
+
+def analyze_gaps(gaps_path: Path) -> None:
+    """Analyze the gap histogram CSV."""
+    print("\n" + "=" * 70)
+    print("GAP DISTRIBUTION ANALYSIS")
+    print("=" * 70)
+    
+    gaps = []
+    with open(gaps_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                gaps.append(float(row['gap_seconds']))
+            except (KeyError, ValueError):
+                continue
+    
+    if not gaps:
+        print("No gap data found.")
+        return
+    
+    gaps.sort()
+    n = len(gaps)
+    
+    # Basic stats
+    print(f"\nBasic Statistics (n={n:,} follow-up user messages):")
+    print(f"  Min:    {gaps[0]:>10.1f}s ({gaps[0]/60:.1f} min)")
+    print(f"  Max:    {gaps[-1]:>10.1f}s ({gaps[-1]/60:.1f} min)")
+    print(f"  Mean:   {sum(gaps)/n:>10.1f}s ({sum(gaps)/n/60:.1f} min)")
+    print(f"  Median: {gaps[n//2]:>10.1f}s ({gaps[n//2]/60:.1f} min)")
+    
+    # Percentiles
+    print(f"\nPercentiles:")
+    for p in [25, 50, 75, 90, 95, 99]:
+        idx = int(n * p / 100)
+        val = gaps[idx]
+        print(f"  p{p:02d}:    {val:>10.1f}s ({val/60:>6.1f} min)")
+    
+    # Histogram with finer bins for finding the trough
+    print(f"\n" + "-" * 70)
+    print("GAP HISTOGRAM (looking for bimodal distribution)")
+    print("-" * 70)
+    
+    # Define bins in seconds
+    bin_edges = [
+        (0, 30, "0-30s"),
+        (30, 60, "30s-1m"),
+        (60, 120, "1-2m"),
+        (120, 180, "2-3m"),
+        (180, 300, "3-5m"),
+        (300, 480, "5-8m"),
+        (480, 600, "8-10m"),
+        (600, 720, "10-12m"),
+        (720, 900, "12-15m"),
+        (900, 1200, "15-20m"),
+        (1200, 1800, "20-30m"),
+        (1800, 3600, "30-60m"),
+        (3600, 7200, "1-2hr"),
+        (7200, float('inf'), "2hr+"),
+    ]
+    
+    counts = []
+    for low, high, label in bin_edges:
+        count = sum(1 for g in gaps if low <= g < high)
+        counts.append((low, high, label, count))
+    
+    max_count = max(c[3] for c in counts) if counts else 1
+    bar_width = 40
+    
+    print(f"\n{'Bin':>10} {'Count':>8} {'%':>6}  Distribution")
+    print("-" * 70)
+    
+    for low, high, label, count in counts:
+        pct = count / n * 100
+        bar_len = int(count / max_count * bar_width)
+        bar = "█" * bar_len
+        print(f"{label:>10} {count:>8,} {pct:>5.1f}%  {bar}")
+    
+    # Find potential troughs (local minima)
+    print(f"\n" + "-" * 70)
+    print("TROUGH DETECTION (potential threshold candidates)")
+    print("-" * 70)
+    
+    # Smooth the histogram and find local minima
+    smoothed = []
+    for i in range(len(counts)):
+        # Simple 3-point smoothing
+        start = max(0, i - 1)
+        end = min(len(counts), i + 2)
+        avg = sum(c[3] for c in counts[start:end]) / (end - start)
+        smoothed.append(avg)
+    
+    troughs = []
+    for i in range(1, len(smoothed) - 1):
+        if smoothed[i] < smoothed[i-1] and smoothed[i] < smoothed[i+1]:
+            low, high, label, count = counts[i]
+            # Trough is at the upper edge of this bin
+            troughs.append((high, label, count))
+    
+    if troughs:
+        print("\nLocal minima found at:")
+        for edge_sec, label, count in troughs:
+            print(f"  • {label} bin (upper edge: {edge_sec/60:.0f} min) - count: {count}")
+        
+        # Recommend the first significant trough
+        best = troughs[0]
+        print(f"\n  ➤ RECOMMENDED THRESHOLD: ~{best[0]/60:.0f} minutes")
+        print(f"    (trough at {best[1]} bin suggests human attention drops off here)")
+    else:
+        print("\nNo clear trough detected. Distribution may be:")
+        print("  • Unimodal (most gaps cluster in one range)")
+        print("  • The current bin resolution may be too coarse")
+    
+    # Cumulative analysis
+    print(f"\n" + "-" * 70)
+    print("CUMULATIVE ANALYSIS (what % of gaps are captured at each threshold)")
+    print("-" * 70)
+    
+    thresholds_min = [6, 8, 10, 12, 14, 16, 18, 20, 25, 30]
+    print(f"\n{'Threshold':>12} {'Gaps Below':>12} {'% Captured':>12}")
+    print("-" * 40)
+    
+    for t_min in thresholds_min:
+        t_sec = t_min * 60
+        below = sum(1 for g in gaps if g <= t_sec)
+        pct = below / n * 100
+        print(f"{t_min:>10} min {below:>12,} {pct:>11.1f}%")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('totals', nargs='?', help='Path to engagement_totals.csv')
+    parser.add_argument('gaps', nargs='?', help='Path to engagement_gaps.csv')
+    parser.add_argument('--totals', dest='totals_flag', help='Path to engagement_totals.csv')
+    parser.add_argument('--gaps', dest='gaps_flag', help='Path to engagement_gaps.csv')
+    
+    args = parser.parse_args()
+    
+    totals_path = args.totals_flag or args.totals
+    gaps_path = args.gaps_flag or args.gaps
+    
+    if not totals_path and not gaps_path:
+        # Try default paths
+        totals_path = 'engagement_totals.csv'
+        gaps_path = 'engagement_gaps.csv'
+    
+    if totals_path and Path(totals_path).exists():
+        analyze_totals(Path(totals_path))
+    elif totals_path:
+        print(f"Warning: {totals_path} not found, skipping totals analysis")
+    
+    if gaps_path and Path(gaps_path).exists():
+        analyze_gaps(Path(gaps_path))
+    elif gaps_path:
+        print(f"Warning: {gaps_path} not found, skipping gaps analysis")
+    
+    print("\n" + "=" * 70)
+    print("NEXT STEPS")
+    print("=" * 70)
+    print("""
+1. Look at the TROUGH DETECTION section - that's where human attention
+   typically drops off (the gap between "still watching" and "came back later")
+
+2. Check the CUMULATIVE ANALYSIS - pick a threshold that captures most
+   "quick response" gaps without including too many "came back later" gaps
+
+3. Once you've chosen a threshold, update your corpus:
+   
+   ohtv db process engagement --threshold <SECONDS> --force
+   
+   (e.g., --threshold 720 for 12 minutes)
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_gaps_with_content.py
+++ b/scripts/analyze_gaps_with_content.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Analyze gaps with content context (word counts).
+
+Enriches gap analysis by looking at:
+1. Word count of agent message(s) preceding the user's response
+2. Word count of the user's follow-up message
+
+Hypothesis: Long gaps with high preceding word counts = reading time (justified)
+            Long gaps with low preceding word counts = inattention (not engaged)
+
+Usage:
+    python scripts/analyze_gaps_with_content.py
+    python scripts/analyze_gaps_with_content.py --out enriched_gaps.csv
+"""
+
+import argparse
+import csv
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from collections import defaultdict
+
+
+def count_words(text: str) -> int:
+    """Count words in text, handling None and non-strings."""
+    if not text or not isinstance(text, str):
+        return 0
+    # Simple word count - split on whitespace
+    return len(text.split())
+
+
+def parse_timestamp(ts) -> datetime | None:
+    """Parse ISO timestamp string to datetime."""
+    if not ts or not isinstance(ts, str):
+        return None
+    try:
+        # Handle various ISO formats
+        ts = ts.replace('Z', '+00:00')
+        if '.' in ts:
+            # Truncate microseconds if too long
+            parts = ts.split('.')
+            if len(parts) == 2:
+                frac, tz = parts[1][:6], parts[1][6:]
+                ts = f"{parts[0]}.{frac}{tz}"
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+def get_message_content(event: dict) -> str:
+    """Extract message content from an event."""
+    # Primary location: llm_message.content[].text (OpenHands format)
+    llm_message = event.get('llm_message')
+    if isinstance(llm_message, dict):
+        content_list = llm_message.get('content', [])
+        if isinstance(content_list, list):
+            texts = []
+            for item in content_list:
+                if isinstance(item, dict) and 'text' in item:
+                    texts.append(item['text'])
+                elif isinstance(item, str):
+                    texts.append(item)
+            if texts:
+                return ' '.join(texts)
+        elif isinstance(content_list, str):
+            return content_list
+    
+    # Fallback: direct content field
+    content = event.get('content', '')
+    if not content:
+        content = event.get('message', '')
+    if not content:
+        content = event.get('output', '')
+    if isinstance(content, dict):
+        content = content.get('text', '') or content.get('content', '')
+    return content if isinstance(content, str) else ''
+
+
+def load_events(conv_location: str) -> list[dict]:
+    """Load events from a conversation directory."""
+    events_dir = Path(conv_location) / "events"
+    if not events_dir.exists():
+        return []
+    
+    events = []
+    for f in sorted(events_dir.glob("event-*.json")):
+        try:
+            data = json.loads(f.read_text())
+            if isinstance(data, dict):
+                events.append(data)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return events
+
+
+def analyze_conversation_gaps(events: list[dict]) -> list[dict]:
+    """Analyze gaps with content context for one conversation."""
+    results = []
+    
+    # Parse all events with timestamps
+    parsed = []
+    for event in events:
+        ts = parse_timestamp(event.get('timestamp'))
+        kind = event.get('kind', '')
+        source = event.get('source', '')
+        content = get_message_content(event)
+        word_count = count_words(content)
+        
+        parsed.append({
+            'ts': ts,
+            'kind': kind,
+            'source': source,
+            'content': content,
+            'word_count': word_count,
+            'is_user_msg': kind == 'MessageEvent' and source == 'user',
+            'is_agent_msg': kind == 'MessageEvent' and source == 'agent',
+        })
+    
+    # Find user message indices
+    user_indices = [i for i, p in enumerate(parsed) if p['is_user_msg'] and p['ts']]
+    
+    if len(user_indices) < 2:
+        return []
+    
+    # For each follow-up user message, compute gap and context
+    for k in range(1, len(user_indices)):
+        u_idx = user_indices[k]
+        prev_u_idx = user_indices[k - 1]
+        
+        user_event = parsed[u_idx]
+        user_ts = user_event['ts']
+        user_words = user_event['word_count']
+        
+        # Find preceding event timestamp
+        prev_ts = None
+        prev_idx = None
+        for j in range(u_idx - 1, -1, -1):
+            if parsed[j]['ts']:
+                prev_ts = parsed[j]['ts']
+                prev_idx = j
+                break
+        
+        if not prev_ts or not user_ts:
+            continue
+        
+        gap_seconds = (user_ts - prev_ts).total_seconds()
+        
+        # Count agent words between previous user message and this one
+        agent_words_between = 0
+        agent_msg_count = 0
+        for j in range(prev_u_idx + 1, u_idx):
+            if parsed[j]['is_agent_msg']:
+                agent_words_between += parsed[j]['word_count']
+                agent_msg_count += 1
+        
+        # Also get the immediate preceding message if it's from agent
+        immediate_prev_words = 0
+        immediate_prev_kind = ''
+        if prev_idx is not None:
+            immediate_prev_words = parsed[prev_idx]['word_count']
+            immediate_prev_kind = parsed[prev_idx]['kind']
+        
+        results.append({
+            'gap_seconds': gap_seconds,
+            'gap_minutes': gap_seconds / 60,
+            'user_response_words': user_words,
+            'agent_words_between': agent_words_between,
+            'agent_msg_count': agent_msg_count,
+            'immediate_prev_words': immediate_prev_words,
+            'immediate_prev_kind': immediate_prev_kind,
+        })
+    
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--out', type=Path, help='Output enriched CSV')
+    parser.add_argument('--gaps-csv', type=Path, default=Path.home() / 'engagement_gaps.csv',
+                        help='Input gaps CSV (to get conversation IDs)')
+    args = parser.parse_args()
+    
+    # Get unique conversation IDs from gaps CSV
+    conv_ids = set()
+    with open(args.gaps_csv) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            conv_ids.add(row['conversation_id'])
+    
+    print(f"Analyzing {len(conv_ids)} conversations with gaps...", file=sys.stderr)
+    
+    # Get conversation locations from DB
+    from ohtv.db import get_ready_connection
+    
+    conv_locations = {}
+    with get_ready_connection(show_progress=False) as conn:
+        for conv_id in conv_ids:
+            cur = conn.execute(
+                "SELECT location FROM conversations WHERE id = ?",
+                (conv_id,)
+            )
+            row = cur.fetchone()
+            if row and row[0]:
+                conv_locations[conv_id] = row[0]
+    
+    print(f"Found locations for {len(conv_locations)} conversations", file=sys.stderr)
+    
+    # Analyze each conversation
+    all_gaps = []
+    for i, (conv_id, location) in enumerate(conv_locations.items()):
+        if (i + 1) % 100 == 0:
+            print(f"  Processing {i+1}/{len(conv_locations)}...", file=sys.stderr)
+        
+        events = load_events(location)
+        if not events:
+            continue
+        
+        gaps = analyze_conversation_gaps(events)
+        for gap in gaps:
+            gap['conversation_id'] = conv_id
+            all_gaps.append(gap)
+    
+    print(f"\nAnalyzed {len(all_gaps)} gaps with content context", file=sys.stderr)
+    
+    # Output enriched CSV if requested
+    if args.out:
+        with open(args.out, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=[
+                'conversation_id', 'gap_seconds', 'gap_minutes',
+                'user_response_words', 'agent_words_between', 'agent_msg_count',
+                'immediate_prev_words', 'immediate_prev_kind'
+            ])
+            writer.writeheader()
+            writer.writerows(all_gaps)
+        print(f"Wrote enriched gaps to {args.out}", file=sys.stderr)
+    
+    # Analyze the data
+    print("\n" + "=" * 70)
+    print("GAP ANALYSIS WITH CONTENT CONTEXT")
+    print("=" * 70)
+    
+    # Focus on the 8-12 minute range
+    gaps_8_12 = [g for g in all_gaps if 8*60 <= g['gap_seconds'] <= 12*60]
+    
+    print(f"\nGaps in 8-12 minute range: {len(gaps_8_12)}")
+    
+    # Categorize by agent word count
+    print("\n" + "-" * 70)
+    print("GAPS BY PRECEDING AGENT CONTENT VOLUME (8-12 min range)")
+    print("-" * 70)
+    
+    buckets = [
+        (0, 100, "0-100 words", "Very short - likely inattention"),
+        (100, 300, "100-300 words", "Short - probably inattention"),
+        (300, 700, "300-700 words", "Medium - could be reading"),
+        (700, 1500, "700-1500 words", "Long - likely reading"),
+        (1500, float('inf'), "1500+ words", "Very long - definitely reading"),
+    ]
+    
+    print(f"\n{'Agent Words':>15} {'Count':>8} {'Avg Gap':>10} {'Assessment'}")
+    print("-" * 70)
+    
+    for low, high, label, assessment in buckets:
+        matching = [g for g in gaps_8_12 if low <= g['agent_words_between'] < high]
+        if matching:
+            avg_gap = sum(g['gap_minutes'] for g in matching) / len(matching)
+            print(f"{label:>15} {len(matching):>8} {avg_gap:>9.1f}m  {assessment}")
+        else:
+            print(f"{label:>15} {0:>8} {'--':>10}  {assessment}")
+    
+    # Now look at user response length
+    print("\n" + "-" * 70)
+    print("GAPS BY USER RESPONSE LENGTH (8-12 min range)")
+    print("-" * 70)
+    
+    user_buckets = [
+        (0, 20, "0-20 words", "Quick reply - was watching"),
+        (20, 50, "20-50 words", "Short reply"),
+        (50, 150, "50-150 words", "Medium reply - composing"),
+        (150, 400, "150-400 words", "Long reply - significant thought"),
+        (400, float('inf'), "400+ words", "Very long - major composition"),
+    ]
+    
+    print(f"\n{'User Words':>15} {'Count':>8} {'Avg Gap':>10} {'Assessment'}")
+    print("-" * 70)
+    
+    for low, high, label, assessment in user_buckets:
+        matching = [g for g in gaps_8_12 if low <= g['user_response_words'] < high]
+        if matching:
+            avg_gap = sum(g['gap_minutes'] for g in matching) / len(matching)
+            print(f"{label:>15} {len(matching):>8} {avg_gap:>9.1f}m  {assessment}")
+        else:
+            print(f"{label:>15} {0:>8} {'--':>10}  {assessment}")
+    
+    # Cross-tabulation: low agent words + low user words = inattention
+    print("\n" + "-" * 70)
+    print("INATTENTION DETECTION (8-12 min gaps)")
+    print("-" * 70)
+    
+    # Low content on both sides suggests inattention
+    low_agent = [g for g in gaps_8_12 if g['agent_words_between'] < 300]
+    low_both = [g for g in low_agent if g['user_response_words'] < 50]
+    high_agent = [g for g in gaps_8_12 if g['agent_words_between'] >= 700]
+    
+    print(f"\n  Total gaps 8-12 min:                    {len(gaps_8_12)}")
+    print(f"  Low agent content (<300 words):         {len(low_agent)} ({len(low_agent)/len(gaps_8_12)*100:.0f}%)")
+    print(f"  Low agent + low user (<50 words):       {len(low_both)} ({len(low_both)/len(gaps_8_12)*100:.0f}%) ← LIKELY INATTENTION")
+    print(f"  High agent content (≥700 words):        {len(high_agent)} ({len(high_agent)/len(gaps_8_12)*100:.0f}%) ← LIKELY READING")
+    
+    # Same analysis for different gap ranges
+    print("\n" + "=" * 70)
+    print("INATTENTION RATIO BY GAP RANGE")
+    print("=" * 70)
+    print("\n(Low content = <300 agent words AND <50 user words)")
+    print(f"\n{'Gap Range':>12} {'Total':>8} {'Low Content':>12} {'% Inattention':>14}")
+    print("-" * 50)
+    
+    ranges = [
+        (5, 6), (6, 7), (7, 8), (8, 9), (9, 10), (10, 11), (11, 12), (12, 15), (15, 20)
+    ]
+    
+    for low_min, high_min in ranges:
+        in_range = [g for g in all_gaps if low_min*60 <= g['gap_seconds'] < high_min*60]
+        if not in_range:
+            continue
+        low_content = [g for g in in_range 
+                       if g['agent_words_between'] < 300 and g['user_response_words'] < 50]
+        pct = len(low_content) / len(in_range) * 100
+        print(f"{low_min:>4}-{high_min:<4} min {len(in_range):>8} {len(low_content):>12} {pct:>13.1f}%")
+    
+    # Recommendation based on content analysis
+    print("\n" + "=" * 70)
+    print("CONTENT-ADJUSTED RECOMMENDATION")
+    print("=" * 70)
+    
+    # For each threshold, what % of gaps would be "false positives" (low content)
+    print("\nFalse positive rate (counting inattention as engagement):")
+    print(f"\n{'Threshold':>12} {'Gaps Added':>12} {'Low Content':>12} {'FP Rate':>10}")
+    print("-" * 50)
+    
+    for t in [8, 9, 10, 11, 12]:
+        prev_t = t - 1
+        added = [g for g in all_gaps if prev_t*60 < g['gap_seconds'] <= t*60]
+        low_content = [g for g in added 
+                       if g['agent_words_between'] < 300 and g['user_response_words'] < 50]
+        if added:
+            fp_rate = len(low_content) / len(added) * 100
+            print(f"{t:>10} min {len(added):>12} {len(low_content):>12} {fp_rate:>9.1f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds the findings from an empirical analysis of the engagement threshold (T) parameter introduced in PR #165. The tuning sweep was called for in Issue #163 but was not performed before merging — this PR addresses that gap.

## Analysis Overview

We processed **4,791 conversations** containing **9,935 follow-up user message gaps** across 11 candidate thresholds (6-28 minutes).

### Key Findings

1. **~70% of follow-up messages occur within 30 seconds** — most human steering happens in real-time
2. **96.1% of gaps occur within 12 minutes** — the current default captures nearly all "still watching" responses
3. **Content analysis shows ~65% of 8-12 minute gaps are likely inattention** (low word count on both sides)
4. **The 12-minute default is reasonable**; 10 minutes is slightly more defensible empirically
5. **For ratio analysis (PRs per attention-minute), consistency matters more than the absolute threshold value**

### Recommendation

For measuring orchestration impact on throughput:
- Lead with unambiguous metrics: % of completely unattended conversations
- Show ratio trends: PRs/LOC per attention-hour over time
- Demonstrate threshold robustness by showing conclusions hold at T=8, 10, and 12

## Files Added

| File | Purpose |
|------|---------|
| `docs/design/engagement-threshold-analysis.md` | Full findings document with methodology, data, and conclusions |
| `scripts/analyze_engagement.py` | Basic gap distribution analysis script |
| `scripts/analyze_gaps_with_content.py` | Content-aware gap analysis (correlates gaps with word counts) |

## Related Issues

- #163 — Original engagement metric design (called for empirical tuning)
- #165 — PR that implemented the metric with 12-minute default
- #167, #168, #169, #170 — Filed during this analysis for engagement UX improvements

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._