### PR TITLE
feat(telemetry): record ohtv ask sessions to ~/.ohtv/telemetry/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,20 @@ These decisions explain WHY the code is structured as it is. See [`docs/guides/`
     - **Click reentrancy note**: Rich's `Console` reads `sys.stdout` lazily at write-time (no file handle is captured at module load), so the runner's CliRunner invocations correctly capture all Rich output via the redirected stdout. No `cli.console` rebinding needed.
     - **Documentation**: `docs/guides/search-and-ask.md` §"Investigation Mode" carries the user-facing table + allow-list + browse-vs-search guidance.
 
+34. **`ohtv ask` session telemetry (Issue #162)**: Every `ohtv ask` invocation writes a self-contained JSON blob under `~/.ohtv/telemetry/sessions/{ISO8601-Z-with-hyphens}_{8-hex-uuid-prefix}.json` plus a one-line summary appended to `~/.ohtv/telemetry/sessions.jsonl`. Schema version 1; full field reference in `docs/reference/telemetry.md`.
+    - **Storage root**: `get_telemetry_dir()` in `src/ohtv/config.py` returns `$OHTV_TELEMETRY_DIR` if set, else `$OHTV_DIR/telemetry/` (consistent with item #12).
+    - **Opt-out**: `OHTV_TELEMETRY_ENABLED=0` short-circuits recorder construction in the `ask` handler — no files written.
+    - **`agent: null` (not key omission)**: plain `ohtv ask` invocations (no `--agent` / `--agent-tools` flag) land with `agent` explicitly `null` so JSON consumers see a stable key set.
+    - **`flags.agent_mode` mirrors `InvestigationResult.mode`** (#161 contract): `"cli"` for `--agent` (prompt-cookbook), `"tools"` for `--agent-tools` (legacy custom-tools), `null` for plain RAG.
+    - **Filename grammar**: hyphens replace the conventional colons in the timestamp because `:` is reserved on Windows and some cloud sync clients (Dropbox, OneDrive) misbehave. Lockdown is `tests/unit/analysis/test_telemetry.py::test_filename_grammar`.
+    - **Atomic blob writes**: `tempfile.NamedTemporaryFile(dir=sessions_dir)` + `os.replace()` (POSIX-atomic, Windows-safe). A `^C` mid-write leaves a `.tmp` file behind but never a half-written `.json`.
+    - **`sessions.jsonl` concurrency**: single `write()` per session, line is ~200 bytes (well under `PIPE_BUF=4096`), so concurrent writers from two processes interleave at line boundaries only under POSIX `O_APPEND`. No file locking. Verified by `multiprocessing.Process(2)` regression.
+    - **Graceful degradation**: `SessionRecorder.finalize()` may raise on I/O errors; the CLI handler swallows it with a `log.warning` so `ohtv ask` still exits 0 with its answer (AC).
+    - **Per-step `cost` and `tokens.{prompt,completion}` are deltas**, not cumulative reads. `StepRecorder.__enter__` snapshots the recorder's running totals; `__exit__` computes deltas and propagates the new totals. Summed deltas across all steps reconcile to `agent.total_cost` within float epsilon.
+    - **Truncation**: `chunk_text` capped at 2 KB, `observation_truncated_text` at 8 KB. Each carries a paired `_truncated` flag + `_size_bytes` counter.
+    - **No PII redaction**: ohtv has no remote storage path; telemetry stays local. If/when remote upload appears, that's a different issue.
+    - **Files**: new `src/ohtv/analysis/telemetry.py` (`SessionRecorder`, `StepRecorder`, `build_*_record` helpers); `get_telemetry_dir` in `src/ohtv/config.py`; recorder hook into `InvestigationAgent.investigate(..., recorder=None)` / `InvestigationAgentCli.investigate(..., recorder=None)`; `ask` handler builds + finalises the recorder with a `try/finally`. The agent-loop bodies use `from ohtv.analysis.telemetry import maybe_step` to keep the loop body single-branch.
+
 ## Troubleshooting
 
 ### Terminal shows `^M^M^M` when typing input

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -1,0 +1,272 @@
+# Telemetry — `ohtv ask` session capture
+
+> **Status:** Schema version **1**, introduced by Issue #162.
+> **Scope:** Local-only. Telemetry never leaves the machine — ohtv has
+> no remote storage path. No PII redaction is performed because nothing
+> is uploaded.
+
+Every `ohtv ask` invocation writes a self-contained JSON blob under
+`~/.ohtv/telemetry/sessions/` plus one summary line in
+`~/.ohtv/telemetry/sessions.jsonl`. The schema is designed so a future
+replay tool can re-run the same question against today's corpus
+(full replay), re-run only the agent loop against a captured RAG result
+(agent-loop replay), or flip the agent mode and rerun to compare
+`--agent` vs `--agent-tools` head-to-head (cross-mode replay).
+
+## On-disk layout
+
+```
+~/.ohtv/telemetry/
+  sessions.jsonl                              # append-only index
+  sessions/
+    2026-06-04T16-23-15Z_a1b2c3d4.json        # full session blob
+    2026-06-04T16-31-08Z_b2c3d4e5.json
+    ...
+```
+
+Filename grammar: `{ISO8601-Z-with-hyphens}_{8-hex-uuid-prefix}.json`.
+The hyphens replace the conventional colons because `:` is reserved on
+Windows and some cloud sync clients (Dropbox, OneDrive) misbehave with
+it. The 8-char prefix is the leading 8 hex characters of the
+session's `uuid4().hex`; the **full** 32-char UUID lives inside the
+file as `session_id`. Filenames are stable references; the index uses
+the full UUID.
+
+The directory is created lazily on the first successful write. Readers
+must tolerate its absence.
+
+## Configuration
+
+| Env var                    | Default                     | Meaning                                              |
+| -------------------------- | --------------------------- | ---------------------------------------------------- |
+| `OHTV_TELEMETRY_ENABLED`   | `1`                         | Set to `0` to disable capture entirely.              |
+| `OHTV_TELEMETRY_DIR`       | `$OHTV_DIR/telemetry/`      | Override the storage root (e.g. for tests / NAS).    |
+
+`OHTV_TELEMETRY_ENABLED=0` short-circuits recorder creation in the
+`ask` handler — no `sessions/` files are written and no `sessions.jsonl`
+line is appended.
+
+## Concurrency
+
+- **Index** (`sessions.jsonl`): single `open(path, "a") + write()` of
+  one line. Lines are ~200 bytes, well under POSIX's `PIPE_BUF`
+  (4096 bytes), so concurrent writers from two processes interleave at
+  line boundaries only. **No file locking.** Verified by a
+  `multiprocessing.Process(2)` regression test.
+- **Blobs** (`sessions/<file>.json`): each session writes to a
+  `tempfile.NamedTemporaryFile` in the same directory, then
+  `os.replace()`-renames into place. This is POSIX-atomic and also
+  correct on Windows. A `^C` mid-write leaves a `.tmp` file behind but
+  never a half-written `.json`.
+
+## Graceful degradation
+
+Telemetry writes are best-effort. A failure inside `recorder.finalize()`
+logs a warning to `~/.ohtv/logs/ohtv.log` but **never** causes
+`ohtv ask` to fail — the user has already received their answer by the
+time finalization runs. The CLI handler catches all exceptions out of
+`finalize()`; the recorder itself swallows in-memory accumulation
+failures (`record_rag` / `record_agent`) with the same policy.
+
+## Schema v1
+
+```json
+{
+  "schema_version": 1,
+  "session_id": "a1b2c3d4e5f6...32-hex...",
+  "started_at": "2026-06-04T16:23:15Z",
+  "ended_at":   "2026-06-04T16:23:42Z",
+
+  "invocation": {
+    "command": "ohtv ask",
+    "question": "what changes were made to fix the auth bug?",
+    "flags": {
+      "context": 5,
+      "min_score": 0.3,
+      "model": null,
+      "agent_mode": "cli",            // "cli" | "tools" | null
+      "max_steps": 5,
+      "since": null,
+      "until": null,
+      "no_temporal": false,
+      "explain": false,
+      "explain_only": false,
+      "show_context": false
+    }
+  },
+
+  "environment": {
+    "ohtv_version": "0.27.0",
+    "ohtv_git_sha": "abc1234",         // null if not in a checkout
+    "python": "3.13.13",
+    "platform": "linux-x86_64",
+    "hostname": "...",
+    "embedding_model": "openai/text-embedding-3-small",
+    "embedding_dim": 1536,
+    "db_schema_version": 23,            // count of applied migrations
+    "corpus": {
+      "total_conversations": 487,
+      "total_embeddings": 12453,
+      "newest_conversation_at": "2026-06-04T13:00:00Z"
+    }
+  },
+
+  "rag": {
+    "elapsed_seconds": 0.23,
+    "search_seconds": 0.12,
+    "generation_seconds": 0.11,
+    "temporal_filter_applied": true,
+    "date_range": ["2026-05-28T00:00:00Z", "2026-06-04T00:00:00Z"],
+    "retrieved_chunks": [
+      {
+        "conversation_id": "abc12345...",
+        "root_conversation_id": "abc12345...",
+        "chunk_type": "summary",
+        "score": 0.72,
+        "chunk_text": "...",             // capped at 2 KB per chunk
+        "chunk_text_size_bytes": 1843,
+        "chunk_text_truncated": false
+      }
+    ],
+    "initial_answer": "...",
+    "source_conversation_ids": ["abc12345", "def67890"],
+    "model": "openai/gpt-4o-mini",
+    "tokens": { "prompt": 1234, "completion": 456 },
+    "cost": 0.0023
+  },
+
+  "agent": {                              // null when no agent ran
+    "mode": "cli",                        // "cli" | "tools"
+    "iterations": 3,
+    "finished_normally": true,
+    "error": null,
+    "elapsed_seconds": 14.2,
+    "model": "openai/gpt-4o-mini",
+    "total_cost": 0.0097,
+    "total_tokens": 6543,
+    "conversations_examined": ["abc12345", "def67890"],
+    "final_answer": "...",
+    "steps": [
+      {
+        "iteration": 1,
+        "kind": "tool_call",              // or "think" / "finish"
+        "tool_name": "run_ohtv",          // cli mode; "show_conversation" etc. in tools mode
+        "arguments": { "argv": ["show", "abc12345", "-F", "json"] },
+        "observation_truncated_text": "...first 8 KB...",
+        "observation_size_bytes": 8432,
+        "observation_truncated": true,
+        "elapsed_seconds": 0.02,
+        "tokens": { "prompt": 1234, "completion": 56 },  // deltas, not cumulative
+        "cost": 0.0001                    // delta, not cumulative
+      }
+    ]
+  },
+
+  "totals": {
+    "tokens": { "prompt": 5432, "completion": 1234 },
+    "cost": 0.012,
+    "wall_seconds": 27.4
+  }
+}
+```
+
+### Schema lock-ins
+
+- **`agent: null` (not key omission).** Plain `ohtv ask` invocations
+  (neither `--agent` nor `--agent-tools`) land with the top-level
+  `agent` key set to `null`. `session["agent"] is None` reads cleaner
+  than `"agent" in session`, and a stable key set helps JSON consumers.
+- **`flags.agent_mode` mirrors `InvestigationResult.mode`** (#161). The
+  enum is `"cli" | "tools" | null` — `"cli"` for `--agent` (prompt-cookbook
+  mode), `"tools"` for `--agent-tools` (legacy custom-tools mode),
+  `null` for plain RAG.
+- **`steps[].arguments` is captured verbatim.** For cli mode that's
+  `{"argv": [...]}`; for tools mode it's whatever the tool's input
+  schema produced (`{"conversation_id": "..."}`, etc.). Same field,
+  different shape — that's the cross-mode comparison surface.
+- **Per-step `cost` and `tokens` are deltas.** The SDK exposes
+  `response.metrics.accumulated_cost` (cumulative across the loop);
+  the recorder subtracts a baseline so each step's record reads
+  naturally. Summed deltas reconcile to `agent.total_cost`.
+- **`db_schema_version` is the count of applied migrations.** That's
+  the natural integer proxy for "what does this DB know about" — a
+  bump means a migration landed between capture and replay.
+
+### Truncation
+
+Three fields are capped to keep blobs tractable; each carries paired
+flags so readers can detect what was dropped:
+
+| Field                                      | Cap      | Flag                                      |
+| ------------------------------------------ | -------- | ----------------------------------------- |
+| `rag.retrieved_chunks[].chunk_text`        | 2 KB     | `chunk_text_truncated` + `_size_bytes`    |
+| `agent.steps[].observation_truncated_text` | 8 KB     | `observation_truncated` + `_size_bytes`   |
+| `agent.final_answer`, `rag.initial_answer` | no cap   | (typically small — full LLM output)       |
+
+### Replay-readiness contract
+
+The schema is intentionally additive: future minor versions add fields
+without removing or renaming existing ones. A future replay tool can
+gate on `schema_version`. Three replay scenarios are supported:
+
+1. **Full replay.** Read `invocation.question` + `invocation.flags`
+   and re-run `ohtv ask` end-to-end against the current corpus. The
+   `environment.corpus` block tells the replayer whether the corpus
+   has drifted since capture.
+2. **Agent-loop replay.** Feed the recorded
+   `rag.retrieved_chunks` + `rag.initial_answer` to a fresh agent run
+   without paying for embedding retrieval again. Useful for prompt
+   iteration.
+3. **Cross-mode replay.** Take a session recorded under
+   `agent_mode="tools"`, flip to `agent_mode="cli"` (or vice versa),
+   rerun. The rest of the invocation envelope is identical.
+
+A 20-line `jq` pipeline is the v1 UI:
+
+```bash
+# Sessions today, sorted by cost
+jq -r 'select(.started_at | startswith("2026-06-04")) |
+       [.started_at, .agent_mode, .total_cost, .question]
+       | @tsv' \
+    ~/.ohtv/telemetry/sessions.jsonl | sort -k3 -rg
+```
+
+## Index-line shape
+
+Each line of `sessions.jsonl` is a JSON object with this minimal
+fingerprint:
+
+```json
+{
+  "session_id":        "<32-char hex>",
+  "started_at":        "2026-06-04T16:23:15Z",
+  "ended_at":          "2026-06-04T16:23:42Z",
+  "question":          "...",
+  "agent_mode":        "cli",     // or "tools" / null
+  "model":             "openai/gpt-4o-mini",
+  "total_cost":        0.012,
+  "total_tokens":      6666,
+  "iterations":        3,
+  "finished_normally": true,
+  "blob":              "2026-06-04T16-23-15Z_a1b2c3d4.json"
+}
+```
+
+The `blob` field is the filename of the full session JSON inside
+`sessions/`; use it to do `cat
+~/.ohtv/telemetry/sessions/$(jq -r '.blob' ...)`.
+
+## Retention
+
+No automatic deletion in v1. Sessions are 50–200 KB each; 1,000
+sessions ≈ 100–200 MB on disk. The user controls `~/.ohtv/`. A
+follow-up issue may add `ohtv telemetry prune --older-than 30d`
+once disk pressure becomes real.
+
+## See also
+
+- AGENTS.md item #33 — `ohtv ask` dual investigation modes (#161).
+- AGENTS.md item #34 — telemetry schema invariant.
+- AGENTS.md item #12 — `~/.ohtv/` data-directory separation.
+- `docs/guides/search-and-ask.md` §"Investigation Mode" — flag surface.
+- Issue #162 — the design proposal and acceptance criteria.

--- a/src/ohtv/analysis/investigator.py
+++ b/src/ohtv/analysis/investigator.py
@@ -28,6 +28,7 @@ from ohtv.analysis.agent_tools import (
 from ohtv.analysis.rag import RAGAnswer
 
 if TYPE_CHECKING:
+    from ohtv.analysis.telemetry import SessionRecorder
     from ohtv.config import Config
     from ohtv.db.stores import (
         ConversationStore,
@@ -246,12 +247,16 @@ class InvestigationAgent:
         self,
         question: str,
         initial_answer: RAGAnswer,
+        recorder: "SessionRecorder | None" = None,
     ) -> InvestigationResult:
         """Run multi-turn investigation starting from initial RAG answer.
 
         Args:
             question: The original question
             initial_answer: The initial RAG answer with context
+            recorder: Optional :class:`ohtv.analysis.telemetry.SessionRecorder`
+                that captures per-iteration metrics. Pass-through —
+                ``None`` (the default) leaves behaviour unchanged.
 
         Returns:
             InvestigationResult with final answer and metrics
@@ -293,6 +298,7 @@ class InvestigationAgent:
                 conversations_examined=conversations_examined,
                 question=question,
                 initial_answer=initial_answer,
+                recorder=recorder,
             )
 
             final_answer = result["answer"]
@@ -533,6 +539,7 @@ class InvestigationAgent:
         conversations_examined: set[str],
         question: str,
         initial_answer: "RAGAnswer",
+        recorder: "SessionRecorder | None" = None,
     ) -> dict:
         """Run the investigation loop using direct LLM calls with tools.
 
@@ -540,6 +547,8 @@ class InvestigationAgent:
         infrastructure, which is better suited for autonomous agent tasks.
         """
         from openhands.sdk.llm.message import Message
+
+        from ohtv.analysis.telemetry import maybe_step
 
         # Build tool definitions and mapping
         tool_definitions, tool_map = self._build_tool_map(custom_tools)
@@ -559,65 +568,98 @@ class InvestigationAgent:
         while not finished and iteration < self.max_iterations:
             iteration += 1
 
-            try:
-                response = llm.completion(messages, tools=tool_definitions)
+            with maybe_step(recorder, iteration) as step:
+                try:
+                    response = llm.completion(messages, tools=tool_definitions)
 
-                # Track metrics
-                if response.metrics:
-                    if response.metrics.accumulated_token_usage:
-                        usage = response.metrics.accumulated_token_usage
-                        total_tokens += usage.prompt_tokens + usage.completion_tokens
-                    total_cost += response.metrics.accumulated_cost or 0.0
+                    # Track metrics
+                    if response.metrics:
+                        if response.metrics.accumulated_token_usage:
+                            usage = response.metrics.accumulated_token_usage
+                            total_tokens += usage.prompt_tokens + usage.completion_tokens
+                            if step is not None:
+                                step.set_metrics(
+                                    response.metrics.accumulated_cost or 0.0,
+                                    usage.prompt_tokens,
+                                    usage.completion_tokens,
+                                )
+                        else:
+                            if step is not None:
+                                step.set_metrics(
+                                    response.metrics.accumulated_cost or 0.0,
+                                    0,
+                                    0,
+                                )
+                        total_cost += response.metrics.accumulated_cost or 0.0
 
-                message = response.message
-                tool_calls = message.tool_calls or []
+                    message = response.message
+                    tool_calls = message.tool_calls or []
 
-                if not tool_calls:
-                    # No tool calls - extract text response as final answer
-                    final_answer = self._extract_final_answer_from_message(message)
-                    if final_answer:
-                        finished = True
-                        investigation_steps.append("Finished with direct response")
-                    break
-
-                # Process ALL tool calls in this response before next iteration
-                # This handles cases where LLM wants to make multiple tool calls
-                pending_tool_results = []
-                for tool_call in tool_calls:
-                    tool_name = tool_call.name
-                    
-                    # Show meaningful progress based on tool type
-                    self._show_tool_progress(tool_name, tool_call.arguments)
-                    investigation_steps.append(f"Called {tool_name}: {tool_call.arguments}")
-
-                    result_text, answer, is_finished = self._process_tool_call(
-                        tool_call, tool_map, conversations_examined
-                    )
-
-                    if is_finished:
-                        final_answer = answer or ""
-                        finished = True
+                    if not tool_calls:
+                        # No tool calls - extract text response as final answer
+                        final_answer = self._extract_final_answer_from_message(message)
+                        if final_answer:
+                            finished = True
+                            investigation_steps.append("Finished with direct response")
+                            if step is not None:
+                                step.set_tool_call("finish", {"message": final_answer})
+                                step.set_observation(final_answer)
                         break
 
-                    if result_text:
-                        if tool_name == "think":
-                            thought = result_text.replace("Thought recorded: ", "")
-                            investigation_steps.append(f"Thinking: {thought[:100]}...")
-                            # Show thinking to user
-                            self.console.print(f"[dim italic]💭 {thought[:200]}{'...' if len(thought) > 200 else ''}[/dim italic]")
-                        pending_tool_results.append((tool_call, result_text))
+                    # Process ALL tool calls in this response before next iteration
+                    # This handles cases where LLM wants to make multiple tool calls
+                    pending_tool_results = []
+                    first_tool_recorded = False
+                    for tool_call in tool_calls:
+                        tool_name = tool_call.name
 
-                # Add all tool responses to messages after processing all calls
-                for tool_call, result_text in pending_tool_results:
-                    self._add_tool_response(messages, tool_call, result_text)
+                        # Show meaningful progress based on tool type
+                        self._show_tool_progress(tool_name, tool_call.arguments)
+                        investigation_steps.append(f"Called {tool_name}: {tool_call.arguments}")
+                        # Record the first tool call on the step.
+                        # The schema models one (kind, tool_name,
+                        # arguments) per step; multi-tool responses are
+                        # rare for these models and the per-tool
+                        # observation lines below still capture the
+                        # text into the step's observation slot.
+                        if step is not None and not first_tool_recorded:
+                            step.set_tool_call(tool_name, tool_call.arguments)
+                            first_tool_recorded = True
 
-                if finished:
+                        result_text, answer, is_finished = self._process_tool_call(
+                            tool_call, tool_map, conversations_examined
+                        )
+
+                        if is_finished:
+                            final_answer = answer or ""
+                            finished = True
+                            if step is not None:
+                                step.set_observation(final_answer)
+                            break
+
+                        if result_text:
+                            if tool_name == "think":
+                                thought = result_text.replace("Thought recorded: ", "")
+                                investigation_steps.append(f"Thinking: {thought[:100]}...")
+                                # Show thinking to user
+                                self.console.print(f"[dim italic]💭 {thought[:200]}{'...' if len(thought) > 200 else ''}[/dim italic]")
+                            if step is not None:
+                                step.set_observation(result_text)
+                            pending_tool_results.append((tool_call, result_text))
+
+                    # Add all tool responses to messages after processing all calls
+                    for tool_call, result_text in pending_tool_results:
+                        self._add_tool_response(messages, tool_call, result_text)
+
+                    if finished:
+                        break
+
+                except Exception as e:
+                    log.exception("Error in investigation step")
+                    investigation_steps.append(f"Error: {e}")
+                    if step is not None:
+                        step.set_observation(f"Error: {e}")
                     break
-
-            except Exception as e:
-                log.exception("Error in investigation step")
-                investigation_steps.append(f"Error: {e}")
-                break
 
         # If we hit the iteration limit, synthesize what we learned
         if not final_answer and not finished:

--- a/src/ohtv/analysis/investigator_cli.py
+++ b/src/ohtv/analysis/investigator_cli.py
@@ -18,7 +18,10 @@ import logging
 import os
 import time
 from collections.abc import Sequence
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:
+    from ohtv.analysis.telemetry import SessionRecorder
 
 from pydantic import Field, SecretStr
 from rich.console import Console
@@ -303,10 +306,17 @@ class InvestigationAgentCli:
         self,
         question: str,
         initial_answer: RAGAnswer,
+        recorder: "SessionRecorder | None" = None,
     ) -> InvestigationResult:
         """Run multi-turn investigation starting from initial RAG answer.
 
         See :class:`InvestigationAgent.investigate` for the shape contract.
+        The optional ``recorder`` argument is the #162 hook — when
+        provided, each iteration is wrapped in a
+        :class:`StepRecorder` context manager that captures
+        ``tool_call.name`` / ``tool_call.arguments`` (which in cli
+        mode is always ``run_ohtv`` with an ``argv`` payload) plus
+        per-step token / cost deltas.
         """
         start_time = time.time()
         api_key = os.environ.get("LLM_API_KEY")
@@ -336,6 +346,7 @@ class InvestigationAgentCli:
                 conversations_examined=conversations_examined,
                 question=question,
                 initial_answer=initial_answer,
+                recorder=recorder,
             )
             final_answer = loop_result["answer"]
             total_tokens = loop_result["total_tokens"]
@@ -523,9 +534,12 @@ class InvestigationAgentCli:
         conversations_examined: set[str],
         question: str,
         initial_answer: RAGAnswer,
+        recorder: "SessionRecorder | None" = None,
     ) -> dict:
         """Drive the LLM loop until finish, iteration cap, or command cap."""
         from openhands.sdk.llm.message import Message
+
+        from ohtv.analysis.telemetry import maybe_step
 
         tool_definitions, tool_map = self._build_tool_map(custom_tools)
 
@@ -543,79 +557,110 @@ class InvestigationAgentCli:
 
         while not finished and iteration < self.max_iterations:
             iteration += 1
-            try:
-                response = llm.completion(messages, tools=tool_definitions)
+            with maybe_step(recorder, iteration) as step:
+                try:
+                    response = llm.completion(messages, tools=tool_definitions)
 
-                if response.metrics:
-                    if response.metrics.accumulated_token_usage:
-                        usage = response.metrics.accumulated_token_usage
-                        total_tokens += usage.prompt_tokens + usage.completion_tokens
-                    total_cost += response.metrics.accumulated_cost or 0.0
+                    if response.metrics:
+                        if response.metrics.accumulated_token_usage:
+                            usage = response.metrics.accumulated_token_usage
+                            total_tokens += usage.prompt_tokens + usage.completion_tokens
+                            if step is not None:
+                                step.set_metrics(
+                                    response.metrics.accumulated_cost or 0.0,
+                                    usage.prompt_tokens,
+                                    usage.completion_tokens,
+                                )
+                        else:
+                            if step is not None:
+                                step.set_metrics(
+                                    response.metrics.accumulated_cost or 0.0,
+                                    0,
+                                    0,
+                                )
+                        total_cost += response.metrics.accumulated_cost or 0.0
 
-                message = response.message
-                tool_calls = message.tool_calls or []
+                    message = response.message
+                    tool_calls = message.tool_calls or []
 
-                if not tool_calls:
-                    final_answer = self._extract_final_answer_from_message(message)
-                    if final_answer:
-                        finished = True
-                        investigation_steps.append("Finished with direct response")
-                    break
-
-                pending_tool_results = []
-                for tool_call in tool_calls:
-                    tool_name = tool_call.name
-
-                    # Per-investigation command-count cap (#161 AC).
-                    # Counts only run_ohtv invocations — think/finish are
-                    # free, since they don't pay any litellm / disk cost.
-                    if tool_name == "run_ohtv":
-                        if command_count >= self.command_count_cap:
-                            cap_msg = (
-                                f"Command-count cap reached "
-                                f"({self.command_count_cap}). No more run_ohtv "
-                                "invocations are permitted; call `finish` with "
-                                "what you've learned so far."
-                            )
-                            investigation_steps.append(cap_msg)
-                            pending_tool_results.append((tool_call, cap_msg))
-                            continue
-                        command_count += 1
-
-                    self._show_tool_progress(tool_name, tool_call.arguments)
-                    investigation_steps.append(
-                        f"Called {tool_name}: {tool_call.arguments}"
-                    )
-
-                    result_text, answer, is_finished = self._process_tool_call(
-                        tool_call, tool_map, conversations_examined
-                    )
-
-                    if is_finished:
-                        final_answer = answer or ""
-                        finished = True
+                    if not tool_calls:
+                        final_answer = self._extract_final_answer_from_message(message)
+                        if final_answer:
+                            finished = True
+                            investigation_steps.append("Finished with direct response")
+                            if step is not None:
+                                step.set_tool_call("finish", {"message": final_answer})
+                                step.set_observation(final_answer)
                         break
 
-                    if result_text:
-                        if tool_name == "think":
-                            thought = result_text.replace("Thought recorded: ", "")
-                            investigation_steps.append(f"Thinking: {thought[:100]}...")
-                            self.console.print(
-                                f"[dim italic]💭 {thought[:200]}"
-                                f"{'...' if len(thought) > 200 else ''}[/dim italic]"
-                            )
-                        pending_tool_results.append((tool_call, result_text))
+                    pending_tool_results = []
+                    first_tool_recorded = False
+                    for tool_call in tool_calls:
+                        tool_name = tool_call.name
 
-                for tool_call, result_text in pending_tool_results:
-                    self._add_tool_response(messages, tool_call, result_text)
+                        # Per-investigation command-count cap (#161 AC).
+                        # Counts only run_ohtv invocations — think/finish are
+                        # free, since they don't pay any litellm / disk cost.
+                        if tool_name == "run_ohtv":
+                            if command_count >= self.command_count_cap:
+                                cap_msg = (
+                                    f"Command-count cap reached "
+                                    f"({self.command_count_cap}). No more run_ohtv "
+                                    "invocations are permitted; call `finish` with "
+                                    "what you've learned so far."
+                                )
+                                investigation_steps.append(cap_msg)
+                                pending_tool_results.append((tool_call, cap_msg))
+                                if step is not None and not first_tool_recorded:
+                                    step.set_tool_call(tool_name, tool_call.arguments)
+                                    step.set_observation(cap_msg)
+                                    first_tool_recorded = True
+                                continue
+                            command_count += 1
 
-                if finished:
+                        self._show_tool_progress(tool_name, tool_call.arguments)
+                        investigation_steps.append(
+                            f"Called {tool_name}: {tool_call.arguments}"
+                        )
+                        if step is not None and not first_tool_recorded:
+                            step.set_tool_call(tool_name, tool_call.arguments)
+                            first_tool_recorded = True
+
+                        result_text, answer, is_finished = self._process_tool_call(
+                            tool_call, tool_map, conversations_examined
+                        )
+
+                        if is_finished:
+                            final_answer = answer or ""
+                            finished = True
+                            if step is not None:
+                                step.set_observation(final_answer)
+                            break
+
+                        if result_text:
+                            if tool_name == "think":
+                                thought = result_text.replace("Thought recorded: ", "")
+                                investigation_steps.append(f"Thinking: {thought[:100]}...")
+                                self.console.print(
+                                    f"[dim italic]💭 {thought[:200]}"
+                                    f"{'...' if len(thought) > 200 else ''}[/dim italic]"
+                                )
+                            if step is not None:
+                                step.set_observation(result_text)
+                            pending_tool_results.append((tool_call, result_text))
+
+                    for tool_call, result_text in pending_tool_results:
+                        self._add_tool_response(messages, tool_call, result_text)
+
+                    if finished:
+                        break
+
+                except Exception as e:  # noqa: BLE001
+                    log.exception("Error in CLI investigation step")
+                    investigation_steps.append(f"Error: {e}")
+                    if step is not None:
+                        step.set_observation(f"Error: {e}")
                     break
-
-            except Exception as e:  # noqa: BLE001
-                log.exception("Error in CLI investigation step")
-                investigation_steps.append(f"Error: {e}")
-                break
 
         if not final_answer and not finished:
             final_answer = self._synthesize_partial_findings(

--- a/src/ohtv/analysis/telemetry.py
+++ b/src/ohtv/analysis/telemetry.py
@@ -1,0 +1,719 @@
+"""Session telemetry for ``ohtv ask`` (Issue #162).
+
+Captures each ``ohtv ask`` invocation as a self-contained, replay-friendly
+JSON blob under ``~/.ohtv/telemetry/sessions/`` plus a one-line summary in
+``~/.ohtv/telemetry/sessions.jsonl``.
+
+The recorder lives at the CLI handler layer; the agent investigators
+(:class:`ohtv.analysis.investigator.InvestigationAgent` and
+:class:`ohtv.analysis.investigator_cli.InvestigationAgentCli`) take an
+optional ``recorder`` keyword and call :meth:`SessionRecorder.begin_step`
+once per loop iteration as a context manager. If ``recorder is None`` the
+agents are unchanged (pass-through, no overhead beyond a single
+``nullcontext`` per iteration).
+
+Writes are best-effort: a failure inside :meth:`SessionRecorder.finalize`
+must never propagate to the user. The CLI handler swallows the exception
+with a ``log.warning`` so ``ohtv ask`` still prints its answer.
+
+Schema version 1 is documented in ``docs/reference/telemetry.md``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import platform
+import socket
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from ohtv.analysis.investigator import InvestigationResult
+    from ohtv.analysis.rag import RAGAnswer
+
+log = logging.getLogger("ohtv")
+
+SCHEMA_VERSION = 1
+
+# Per-field truncation caps. Each truncated field carries a paired
+# ``*_truncated`` flag and an ``observation_size_bytes``-style counter so
+# readers can detect what was dropped (#162 AC).
+OBSERVATION_CAP_BYTES = 8 * 1024  # 8 KB per step observation
+CHUNK_TEXT_CAP_BYTES = 2 * 1024  # 2 KB per retrieved chunk
+
+ENV_DISABLED = "OHTV_TELEMETRY_ENABLED"
+ENV_DIR_OVERRIDE = "OHTV_TELEMETRY_DIR"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Return ``True`` unless ``OHTV_TELEMETRY_ENABLED=0`` is set."""
+    return os.environ.get(ENV_DISABLED, "1") != "0"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _format_iso8601_z(dt: datetime) -> str:
+    """Format ``dt`` as ``YYYY-MM-DDTHH:MM:SSZ`` (UTC, no fractional)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _format_filename_timestamp(dt: datetime) -> str:
+    """Format ``dt`` for the session filename grammar.
+
+    Hyphens replace colons because ``:`` is reserved on Windows and some
+    cloud sync clients (Dropbox, OneDrive) misbehave with it. Locked
+    down by the filename-regex test.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H-%M-%SZ")
+
+
+def _truncate_bytes(text: str, cap_bytes: int) -> tuple[str, int, bool]:
+    """Truncate ``text`` to at most ``cap_bytes`` UTF-8 bytes.
+
+    Returns ``(possibly-truncated text, original-size-bytes,
+    truncated_flag)``. Encoding errors are replaced (lossy) so we never
+    crash on weird tool output.
+    """
+    encoded = text.encode("utf-8", errors="replace")
+    size = len(encoded)
+    if size <= cap_bytes:
+        return text, size, False
+    # Decode the prefix, dropping any incomplete trailing code point so
+    # the resulting string is still valid UTF-8.
+    truncated = encoded[:cap_bytes].decode("utf-8", errors="ignore")
+    return truncated, size, True
+
+
+def _git_sha() -> str | None:
+    """Best-effort current commit SHA — never raises.
+
+    Used in the ``environment.ohtv_git_sha`` field; ``None`` when ohtv is
+    installed from a wheel (no ``.git`` directory) or git is unavailable.
+    """
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=Path(__file__).resolve().parent,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            sha = result.stdout.strip()
+            return sha or None
+    except Exception:  # noqa: BLE001 - best-effort
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Environment + corpus snapshot
+# ---------------------------------------------------------------------------
+
+
+def _safe_count(fn: Any, default: int = 0) -> int:
+    try:
+        return int(fn())
+    except Exception:  # noqa: BLE001 - best-effort
+        return default
+
+
+def build_environment_record(
+    *,
+    embed_store: Any | None = None,
+    conv_store: Any | None = None,
+    conn: Any | None = None,
+) -> dict:
+    """Snapshot the corpus + tool versions at session start.
+
+    All inputs are optional so the recorder can run even before stores
+    are wired (e.g. early-exit error paths). Missing values surface as
+    ``None`` or ``0``.
+    """
+    from ohtv import __version__ as ohtv_version
+    from ohtv.analysis.embeddings import (
+        DEFAULT_EMBEDDING_MODEL,
+        get_embedding_dimension,
+    )
+
+    # ``get_effective_embedding_model`` lives in the ``config`` submodule
+    # and is not re-exported from ``ohtv.analysis.embeddings.__init__``;
+    # fall back to env / default when it's not available.
+    try:
+        from ohtv.analysis.embeddings.config import get_effective_embedding_model
+
+        embedding_model = get_effective_embedding_model() or DEFAULT_EMBEDDING_MODEL
+    except ImportError:  # pragma: no cover - belt-and-braces
+        embedding_model = (
+            os.environ.get("EMBEDDING_MODEL") or DEFAULT_EMBEDDING_MODEL
+        )
+    try:
+        embedding_dim: int | None = get_embedding_dimension(embedding_model)
+    except Exception:  # noqa: BLE001 - best-effort
+        embedding_dim = None
+
+    db_schema_version: int | None = None
+    if conn is not None:
+        try:
+            cursor = conn.execute("SELECT COUNT(*) FROM _migrations")
+            row = cursor.fetchone()
+            if row is not None:
+                db_schema_version = int(row[0])
+        except Exception:  # noqa: BLE001 - best-effort
+            db_schema_version = None
+
+    total_conversations = (
+        _safe_count(conv_store.count) if conv_store is not None else 0
+    )
+    total_embeddings = (
+        _safe_count(embed_store.count) if embed_store is not None else 0
+    )
+
+    newest_conversation_at: str | None = None
+    if conn is not None:
+        try:
+            row = conn.execute(
+                "SELECT created_at FROM conversations "
+                "WHERE created_at IS NOT NULL "
+                "ORDER BY created_at DESC LIMIT 1"
+            ).fetchone()
+            if row and row[0]:
+                # Stored as ISO string; pass through verbatim.
+                newest_conversation_at = str(row[0])
+        except Exception:  # noqa: BLE001 - best-effort
+            newest_conversation_at = None
+
+    return {
+        "ohtv_version": ohtv_version,
+        "ohtv_git_sha": _git_sha(),
+        "python": ".".join(str(p) for p in sys.version_info[:3]),
+        "platform": f"{platform.system().lower()}-{platform.machine()}",
+        "hostname": socket.gethostname(),
+        "embedding_model": embedding_model,
+        "embedding_dim": embedding_dim,
+        "db_schema_version": db_schema_version,
+        "corpus": {
+            "total_conversations": total_conversations,
+            "total_embeddings": total_embeddings,
+            "newest_conversation_at": newest_conversation_at,
+        },
+    }
+
+
+def build_invocation_record(
+    *,
+    question: str,
+    flags: dict[str, Any],
+) -> dict:
+    """Shape the ``invocation`` block.
+
+    ``flags`` must already be a JSON-serialisable dict. The CLI handler
+    is the right place to build it because that's where the resolved
+    flag values live; this helper just stamps the command name.
+    """
+    return {
+        "command": "ohtv ask",
+        "question": question,
+        "flags": dict(flags),
+    }
+
+
+def build_rag_record(rag_answer: "RAGAnswer") -> dict:
+    """Convert a :class:`RAGAnswer` into the ``rag`` block.
+
+    Chunk text is capped at :data:`CHUNK_TEXT_CAP_BYTES`; ``cost`` and
+    ``tokens`` come straight off the dataclass. Token split (prompt /
+    completion) is approximated from the available fields:
+    ``context_tokens`` ≈ prompt, ``total_tokens - context_tokens`` ≈
+    completion. That's not exact but it's the best the existing
+    ``RAGAnswer`` shape exposes without widening it for this issue.
+    """
+    chunks: list[dict] = []
+    for chunk in rag_answer.context_chunks:
+        text = chunk.source_text or ""
+        text_trunc, size, truncated = _truncate_bytes(text, CHUNK_TEXT_CAP_BYTES)
+        chunks.append(
+            {
+                "conversation_id": chunk.conversation_id,
+                "root_conversation_id": chunk.root_conversation_id,
+                "chunk_type": chunk.embed_type,
+                "score": float(chunk.score),
+                "chunk_text": text_trunc,
+                "chunk_text_size_bytes": size,
+                "chunk_text_truncated": truncated,
+            }
+        )
+
+    date_range: list[str | None] | None = None
+    if rag_answer.date_range is not None:
+        start, end = rag_answer.date_range
+        date_range = [
+            start.isoformat() if start is not None else None,
+            end.isoformat() if end is not None else None,
+        ]
+
+    context_tokens = int(rag_answer.context_tokens or 0)
+    total_tokens = int(rag_answer.total_tokens or 0)
+    completion = max(0, total_tokens - context_tokens)
+
+    elapsed = float(rag_answer.search_time_seconds or 0.0) + float(
+        rag_answer.generation_time_seconds or 0.0
+    )
+
+    return {
+        "elapsed_seconds": elapsed,
+        "search_seconds": float(rag_answer.search_time_seconds or 0.0),
+        "generation_seconds": float(rag_answer.generation_time_seconds or 0.0),
+        "temporal_filter_applied": bool(rag_answer.temporal_filter_applied),
+        "date_range": date_range,
+        "retrieved_chunks": chunks,
+        "initial_answer": rag_answer.answer,
+        "source_conversation_ids": sorted(rag_answer.source_conversation_ids),
+        "model": rag_answer.model,
+        "tokens": {"prompt": context_tokens, "completion": completion},
+        "cost": float(rag_answer.cost or 0.0),
+    }
+
+
+def build_agent_record(result: "InvestigationResult", steps: list[dict]) -> dict:
+    """Shape the ``agent`` block from an :class:`InvestigationResult`.
+
+    ``steps`` is the list accumulated by the recorder during the loop;
+    the caller passes it explicitly so this helper stays a pure
+    serializer.
+    """
+    return {
+        "mode": result.mode,
+        "iterations": int(result.total_iterations),
+        "finished_normally": bool(result.finished_normally),
+        "error": result.error,
+        "elapsed_seconds": float(result.elapsed_seconds or 0.0),
+        "model": result.model,
+        "total_cost": float(result.total_cost or 0.0),
+        "total_tokens": int(result.total_tokens or 0),
+        "conversations_examined": sorted(result.conversations_examined),
+        "final_answer": result.final_answer,
+        "steps": steps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# StepRecorder — per-iteration context manager
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StepRecorder:
+    """One agent-loop iteration; used as a context manager.
+
+    Token + cost values reported via :meth:`set_metrics` are *cumulative*
+    (the SDK exposes them as ``response.metrics.accumulated_*``). The
+    step computes its delta against a baseline snapshot taken in
+    ``__enter__`` so the on-disk step record reads naturally
+    ("this step cost N, used M tokens"). Summed deltas across all
+    steps in a session reconcile to ``totals.cost`` minus ``rag.cost``
+    within float epsilon (asserted by tests).
+    """
+
+    iteration: int
+    _parent: "SessionRecorder"
+    _t0: float = 0.0
+    _cost_baseline: float = 0.0
+    _prompt_baseline: int = 0
+    _completion_baseline: int = 0
+    _tool_name: str | None = None
+    _arguments: dict[str, Any] | None = None
+    _kind: str = "tool_call"
+    _observation: str | None = None
+    _observation_size: int = 0
+    _observation_truncated: bool = False
+    _accumulated_cost: float = 0.0
+    _accumulated_prompt: int = 0
+    _accumulated_completion: int = 0
+    _metrics_seen: bool = False
+
+    def __enter__(self) -> "StepRecorder":
+        self._t0 = time.perf_counter()
+        # Baselines snapshot the recorder's running totals (so the
+        # first step's deltas equal the SDK's first read).
+        self._cost_baseline = self._parent._last_cost
+        self._prompt_baseline = self._parent._last_prompt
+        self._completion_baseline = self._parent._last_completion
+        return self
+
+    def set_tool_call(self, name: str, arguments: Any) -> None:
+        """Record the tool the LLM picked this iteration.
+
+        ``arguments`` is whatever the SDK reports — a dict for tools
+        mode, ``{"argv": [...]}``-shape for cli mode (#161). Stored
+        verbatim; the cross-mode comparison surface is the
+        ``arguments`` payload shape.
+        """
+        self._tool_name = name
+        # Normalise to a dict for JSON serialisation. The SDK
+        # sometimes hands us a string (raw JSON) when the tool call
+        # arguments failed to parse; round-trip that through json.loads
+        # so the on-disk record is always a structured value.
+        if isinstance(arguments, dict):
+            self._arguments = dict(arguments)
+        elif isinstance(arguments, str):
+            try:
+                parsed = json.loads(arguments)
+            except json.JSONDecodeError:
+                parsed = {"_raw": arguments}
+            self._arguments = parsed if isinstance(parsed, dict) else {"_raw": parsed}
+        elif arguments is None:
+            self._arguments = {}
+        else:
+            self._arguments = {"_raw": repr(arguments)}
+
+        if name == "think":
+            self._kind = "think"
+        elif name == "finish":
+            self._kind = "finish"
+        else:
+            self._kind = "tool_call"
+
+    def set_observation(
+        self, text: str, *, cap_bytes: int = OBSERVATION_CAP_BYTES
+    ) -> None:
+        """Record the tool's text observation, truncated to ``cap_bytes``."""
+        truncated, size, was_truncated = _truncate_bytes(text or "", cap_bytes)
+        self._observation = truncated
+        self._observation_size = size
+        self._observation_truncated = was_truncated
+
+    def set_metrics(
+        self,
+        accumulated_cost: float,
+        prompt_tokens: int,
+        completion_tokens: int,
+    ) -> None:
+        """Record the SDK's cumulative cost/token counters for this iteration.
+
+        Safe to call multiple times — only the last call wins. The
+        recorder turns these into deltas on ``__exit__`` and propagates
+        the running totals to the parent recorder for the next step's
+        baseline.
+        """
+        self._accumulated_cost = float(accumulated_cost or 0.0)
+        self._accumulated_prompt = int(prompt_tokens or 0)
+        self._accumulated_completion = int(completion_tokens or 0)
+        self._metrics_seen = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        elapsed = time.perf_counter() - self._t0
+
+        if self._metrics_seen:
+            cost_delta = max(0.0, self._accumulated_cost - self._cost_baseline)
+            prompt_delta = max(0, self._accumulated_prompt - self._prompt_baseline)
+            completion_delta = max(
+                0, self._accumulated_completion - self._completion_baseline
+            )
+            # Propagate so the next step's baseline reflects this step's
+            # observed cumulative totals.
+            self._parent._last_cost = self._accumulated_cost
+            self._parent._last_prompt = self._accumulated_prompt
+            self._parent._last_completion = self._accumulated_completion
+        else:
+            cost_delta = 0.0
+            prompt_delta = 0
+            completion_delta = 0
+
+        record: dict[str, Any] = {
+            "iteration": self.iteration,
+            "kind": self._kind,
+            "tool_name": self._tool_name,
+            "arguments": self._arguments if self._arguments is not None else {},
+            "elapsed_seconds": elapsed,
+            "tokens": {"prompt": prompt_delta, "completion": completion_delta},
+            "cost": cost_delta,
+        }
+        if self._observation is not None:
+            record["observation_truncated_text"] = self._observation
+            record["observation_size_bytes"] = self._observation_size
+            record["observation_truncated"] = self._observation_truncated
+
+        if exc_type is not None:
+            record["error"] = f"{exc_type.__name__}: {exc_val}"
+
+        self._parent._steps.append(record)
+        # Never suppress the underlying exception.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# SessionRecorder — one ohtv ask invocation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionRecorder:
+    """Accumulates one ``ohtv ask`` invocation's telemetry.
+
+    Constructed at the top of the ``ask`` handler via :meth:`start`,
+    handed off to the investigator (if any), and finalised in a
+    ``finally`` block. Write failures inside :meth:`finalize` raise so
+    the CLI can log + swallow them; in-memory accumulation is exception
+    free.
+    """
+
+    session_id: str
+    started_at: datetime
+    invocation: dict
+    environment: dict
+    telemetry_dir: Path
+    _rag: dict | None = None
+    _agent: dict | None = None
+    _steps: list[dict] = field(default_factory=list)
+    # Running cumulative counters used by StepRecorder baselines.
+    _last_cost: float = 0.0
+    _last_prompt: int = 0
+    _last_completion: int = 0
+    _agent_recorded: bool = False
+    _t0: float = field(default_factory=time.perf_counter)
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        invocation: dict,
+        environment: dict,
+        telemetry_dir: Path | None = None,
+    ) -> "SessionRecorder":
+        """Create a fresh recorder. Does not touch disk."""
+        from ohtv.config import get_telemetry_dir
+
+        return cls(
+            session_id=uuid.uuid4().hex,
+            started_at=_utcnow(),
+            invocation=invocation,
+            environment=environment,
+            telemetry_dir=telemetry_dir or get_telemetry_dir(),
+        )
+
+    # ------------------------------------------------------------------
+    # Mutation API
+    # ------------------------------------------------------------------
+
+    def record_rag(self, rag_answer: "RAGAnswer") -> None:
+        """Capture the initial RAG answer (best-effort, never raises)."""
+        try:
+            self._rag = build_rag_record(rag_answer)
+        except Exception:  # noqa: BLE001 - best-effort
+            log.warning("telemetry: failed to record RAG block", exc_info=True)
+            self._rag = None
+
+    def begin_step(self, iteration: int) -> StepRecorder:
+        """Context manager for a single agent-loop iteration."""
+        return StepRecorder(iteration=iteration, _parent=self)
+
+    def record_agent(self, result: "InvestigationResult | None") -> None:
+        """Capture the investigator result.
+
+        ``None`` is a legal value — for plain RAG sessions (no agent
+        flag), the ``agent`` block lands as explicit ``null`` so JSON
+        consumers see a stable key set (#162 schema lock-in: ``agent:
+        null``, not key omission).
+        """
+        self._agent_recorded = True
+        if result is None:
+            self._agent = None
+            return
+        try:
+            self._agent = build_agent_record(result, self._steps)
+        except Exception:  # noqa: BLE001 - best-effort
+            log.warning("telemetry: failed to record agent block", exc_info=True)
+            # Fall back to a minimal block so the agent_mode is still
+            # discoverable.
+            self._agent = {
+                "mode": getattr(result, "mode", None),
+                "iterations": 0,
+                "finished_normally": False,
+                "error": "telemetry: failed to serialize agent block",
+                "steps": [],
+            }
+
+    # ------------------------------------------------------------------
+    # Finalize
+    # ------------------------------------------------------------------
+
+    def finalize(self) -> Path:
+        """Write the session blob + index line to disk.
+
+        Returns the path of the session blob. Raises on I/O errors —
+        callers should catch + log without propagating, per the
+        graceful-degradation AC.
+        """
+        ended = _utcnow()
+        wall_seconds = time.perf_counter() - self._t0
+
+        rag_cost = float((self._rag or {}).get("cost", 0.0) or 0.0)
+        rag_tokens = (self._rag or {}).get("tokens") or {
+            "prompt": 0,
+            "completion": 0,
+        }
+        agent_cost = float((self._agent or {}).get("total_cost", 0.0) or 0.0) if self._agent else 0.0
+        # Per-step tokens sum reconciles to agent.total_tokens within
+        # SDK rounding; here we want the totals envelope so we use the
+        # parent's running deltas.
+        agent_prompt = int(self._last_prompt or 0)
+        agent_completion = int(self._last_completion or 0)
+
+        # If we never observed metrics (e.g. recorder ran without an
+        # agent), fall back to the agent block's totals.
+        if not agent_prompt and not agent_completion and self._agent:
+            agent_total = int(self._agent.get("total_tokens", 0) or 0)
+            # Best-effort 50/50 split — exact split is recoverable from
+            # the per-step records.
+            agent_prompt = agent_total
+            agent_completion = 0
+
+        totals = {
+            "tokens": {
+                "prompt": int(rag_tokens.get("prompt", 0)) + agent_prompt,
+                "completion": int(rag_tokens.get("completion", 0)) + agent_completion,
+            },
+            "cost": rag_cost + agent_cost,
+            "wall_seconds": wall_seconds,
+        }
+
+        blob: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "session_id": self.session_id,
+            "started_at": _format_iso8601_z(self.started_at),
+            "ended_at": _format_iso8601_z(ended),
+            "invocation": self.invocation,
+            "environment": self.environment,
+            "rag": self._rag,
+            "agent": self._agent,  # explicit ``None`` if no agent ran
+            "totals": totals,
+        }
+
+        sessions_dir = self.telemetry_dir / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = (
+            f"{_format_filename_timestamp(self.started_at)}_{self.session_id[:8]}.json"
+        )
+        target = sessions_dir / filename
+
+        # Atomic write: NamedTemporaryFile in the same directory +
+        # os.replace (POSIX-atomic + Windows-safe).
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(sessions_dir),
+            prefix=f".{self.session_id[:8]}_",
+            suffix=".json.tmp",
+            delete=False,
+        ) as tmp:
+            json.dump(blob, tmp, default=_json_default, indent=2)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+        os.replace(tmp_path, target)
+
+        # Append the index line. Single ``write()`` of <PIPE_BUF bytes
+        # is atomic under POSIX O_APPEND — no locking needed (see
+        # docs/reference/telemetry.md for the concurrency contract).
+        index_line = {
+            "session_id": self.session_id,
+            "started_at": _format_iso8601_z(self.started_at),
+            "ended_at": _format_iso8601_z(ended),
+            "question": self.invocation.get("question"),
+            "agent_mode": self.invocation.get("flags", {}).get("agent_mode"),
+            "model": self.invocation.get("flags", {}).get("model"),
+            "total_cost": totals["cost"],
+            "total_tokens": totals["tokens"]["prompt"] + totals["tokens"]["completion"],
+            "iterations": (self._agent or {}).get("iterations", 0) if self._agent else 0,
+            "finished_normally": (
+                (self._agent or {}).get("finished_normally", True)
+                if self._agent
+                else True
+            ),
+            "blob": filename,
+        }
+        index_path = self.telemetry_dir / "sessions.jsonl"
+        # ``a`` opens with O_APPEND; the single write below stays well
+        # under PIPE_BUF (4096 bytes) so concurrent writers from two
+        # processes interleave at line boundaries only.
+        with open(index_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(index_line, default=_json_default) + "\n")
+
+        return target
+
+
+# ---------------------------------------------------------------------------
+# Public helpers used by the CLI ask handler
+# ---------------------------------------------------------------------------
+
+
+def _json_default(value: Any) -> Any:
+    """JSON encoder fallback for datetime/set/Path values."""
+    if isinstance(value, datetime):
+        return _format_iso8601_z(value)
+    if isinstance(value, set):
+        return sorted(value)
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"telemetry: cannot serialise {type(value).__name__}")
+
+
+@contextlib.contextmanager
+def maybe_step(recorder: SessionRecorder | None, iteration: int):
+    """Convenience for the investigator loop bodies.
+
+    ``with maybe_step(recorder, iteration) as step:`` yields the
+    :class:`StepRecorder` when ``recorder`` is set, or ``None`` when
+    telemetry is disabled. Lets the loop be written once instead of
+    two branches per call site.
+    """
+    if recorder is None:
+        yield None
+        return
+    with recorder.begin_step(iteration) as step:
+        yield step
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "OBSERVATION_CAP_BYTES",
+    "CHUNK_TEXT_CAP_BYTES",
+    "ENV_DISABLED",
+    "ENV_DIR_OVERRIDE",
+    "SessionRecorder",
+    "StepRecorder",
+    "build_environment_record",
+    "build_invocation_record",
+    "build_rag_record",
+    "build_agent_record",
+    "is_enabled",
+    "maybe_step",
+]

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -3850,15 +3850,59 @@ def ask(
         
         # Use RAGAnswerer for context retrieval and answer generation
         answerer = RAGAnswerer(
-            embed_store, conv_store, 
-            model=model, 
+            embed_store, conv_store,
+            model=model,
             enable_temporal_filter=enable_temporal,
             link_store=link_store,
             ref_store=ref_store,
             repo_store=repo_store,
             cloud_base_url=cloud_base_url,
         )
-        
+
+        # Telemetry recorder (Issue #162). Captures the invocation +
+        # environment up-front; ``record_rag`` / ``record_agent`` /
+        # ``finalize`` are called below. ``OHTV_TELEMETRY_ENABLED=0``
+        # opts out entirely (no recorder constructed → zero overhead).
+        # The recorder is finalised in a ``finally`` block so an
+        # investigator exception still produces a session record with
+        # ``agent.finished_normally=false``.
+        recorder = None
+        try:
+            from ohtv.analysis.telemetry import (
+                SessionRecorder,
+                build_environment_record,
+                build_invocation_record,
+                is_enabled as telemetry_is_enabled,
+            )
+
+            if telemetry_is_enabled():
+                flags_record = {
+                    "context": context,
+                    "min_score": min_score,
+                    "model": model,
+                    "agent_mode": investigation_mode,  # "cli" | "tools" | None
+                    "max_steps": max_steps,
+                    "since": since,
+                    "until": until,
+                    "no_temporal": no_temporal,
+                    "explain": explain,
+                    "explain_only": explain_only,
+                    "show_context": show_context,
+                }
+                recorder = SessionRecorder.start(
+                    invocation=build_invocation_record(
+                        question=question, flags=flags_record
+                    ),
+                    environment=build_environment_record(
+                        embed_store=embed_store,
+                        conv_store=conv_store,
+                        conn=conn,
+                    ),
+                )
+        except Exception:  # noqa: BLE001 - best-effort
+            log.warning("telemetry: recorder construction failed", exc_info=True)
+            recorder = None
+
         try:
             result = answerer.answer_question(
                 question,
@@ -3870,11 +3914,18 @@ def ask(
         except ValueError as e:
             console.print(f"[yellow]{e}[/yellow]")
             console.print("[dim]Try lowering --min-score or building more embeddings.[/dim]")
+            _maybe_finalize_telemetry(recorder)
             raise SystemExit(1)
         except RuntimeError as e:
             console.print(f"[red]Error:[/red] {e}")
             console.print("[dim]Make sure LLM_API_KEY is set.[/dim]")
+            _maybe_finalize_telemetry(recorder)
             raise SystemExit(1)
+
+        # Record the RAG block as soon as the answer is in. The agent
+        # block is added below in the investigation branch.
+        if recorder is not None:
+            recorder.record_rag(result)
         
         # Show retrieval breakdown if --explain
         if explain:
@@ -3929,7 +3980,9 @@ def ask(
                         max_iterations=max_steps,
                         console=console,
                     )
-                    investigation_result = investigator.investigate(question, result)
+                    investigation_result = investigator.investigate(
+                        question, result, recorder=recorder
+                    )
                 else:
                     from ohtv.analysis.investigator import InvestigationAgent
                     investigator_tools = InvestigationAgent(
@@ -3944,7 +3997,9 @@ def ask(
                         max_iterations=max_steps,
                         console=console,
                     )
-                    investigation_result = investigator_tools.investigate(question, result)
+                    investigation_result = investigator_tools.investigate(
+                        question, result, recorder=recorder
+                    )
 
                 if investigation_result.error:
                     console.print(f"[yellow]Investigation error: {investigation_result.error}[/yellow]")
@@ -4218,6 +4273,30 @@ def ask(
         if investigation_result and not investigation_result.error:
             timing_parts.append("🔍 agent")
         console.print(f"\n[dim]{' | '.join(timing_parts)}[/dim]")
+
+        # Finalise telemetry (Issue #162). Best-effort: a failure here
+        # must NOT propagate (the user already got their answer).
+        if recorder is not None:
+            recorder.record_agent(investigation_result)
+            _maybe_finalize_telemetry(recorder)
+
+
+def _maybe_finalize_telemetry(recorder) -> None:
+    """Write the session blob + index line; swallow + log on failure.
+
+    Called from the ``ask`` handler's success path and from every
+    early-exit branch (``ValueError`` / ``RuntimeError`` after the RAG
+    answer call). Idempotent guard: a ``None`` recorder short-circuits.
+    The graceful-degradation AC requires this to never re-raise — the
+    user's answer has already been printed by the time we reach here.
+    """
+    if recorder is None:
+        return
+    try:
+        session_path = recorder.finalize()
+        log.debug("telemetry session written: %s", session_path)
+    except Exception:  # noqa: BLE001 - per #162 graceful-degradation AC
+        log.warning("telemetry write failed", exc_info=True)
 
 
 def _load_all_conversations(

--- a/src/ohtv/config.py
+++ b/src/ohtv/config.py
@@ -244,6 +244,20 @@ def get_analysis_cache_dir() -> Path:
     return get_ohtv_dir() / "cache" / "analysis"
 
 
+def get_telemetry_dir() -> Path:
+    """Get the telemetry directory (~/.ohtv/telemetry).
+
+    Per-session telemetry blobs from ``ohtv ask`` (Issue #162) live here,
+    alongside an append-only ``sessions.jsonl`` index. Override with
+    ``OHTV_TELEMETRY_DIR``. The directory is created lazily on the first
+    successful write — readers should not assume it exists.
+    """
+    env_dir = os.environ.get("OHTV_TELEMETRY_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return get_ohtv_dir() / "telemetry"
+
+
 def save_config_value(key: str, value: str) -> None:
     """Save a configuration value to the config file.
     

--- a/tests/unit/analysis/test_telemetry.py
+++ b/tests/unit/analysis/test_telemetry.py
@@ -1,0 +1,538 @@
+"""Tests for session telemetry (Issue #162).
+
+Covers:
+- Filename grammar lockdown
+- Schema serialisation (top-level keys, schema_version, agent: null for
+  plain-RAG, agent dict for both modes)
+- Truncation flag pairing (observation, chunk_text)
+- Index-line shape
+- Per-step cost/token deltas reconcile to agent totals
+- Recorder write-failure raises (the CLI swallows it elsewhere)
+- Two-process concurrent writes produce two distinct lines, no
+  interleaving (the AC concurrency invariant)
+- OHTV_TELEMETRY_DIR override is honoured
+- OHTV_TELEMETRY_ENABLED=0 disables capture
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ohtv.analysis.telemetry import (
+    CHUNK_TEXT_CAP_BYTES,
+    OBSERVATION_CAP_BYTES,
+    SCHEMA_VERSION,
+    SessionRecorder,
+    _truncate_bytes,
+    build_agent_record,
+    build_invocation_record,
+    build_rag_record,
+    is_enabled,
+)
+from ohtv.analysis.investigator import InvestigationResult
+
+
+# ---------------------------------------------------------------------------
+# Small fakes — avoid importing the real RAGAnswer (it transitively pulls
+# litellm, which adds ~2s to test collection).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeChunk:
+    conversation_id: str = "abc12345"
+    root_conversation_id: str = "abc12345"
+    title: str = "t"
+    embed_type: str = "summary"
+    source_text: str = "hello"
+    score: float = 0.5
+    chunk_index: int = 0
+    summary: str | None = None
+    cloud_url: str | None = None
+    created_at: datetime | None = None
+    conv_source: str = "local"
+    source: object | None = None
+
+
+@dataclass
+class FakeRAGAnswer:
+    answer: str = "an answer"
+    context_chunks: list = field(default_factory=list)
+    source_conversation_ids: set = field(default_factory=set)
+    search_time_seconds: float = 0.12
+    generation_time_seconds: float = 0.34
+    model: str = "openai/gpt-4o-mini"
+    temporal_filter_applied: bool = False
+    date_range: tuple | None = None
+    related_repos: list | None = None
+    related_prs: list | None = None
+    related_issues: list | None = None
+    context_tokens: int = 1234
+    total_tokens: int = 1690  # 1234 + 456
+    cost: float = 0.0023
+
+
+def _make_result(**overrides) -> InvestigationResult:
+    defaults = dict(
+        final_answer="final",
+        initial_answer="initial",
+        investigation_steps=["Called finish: ..."],
+        conversations_examined={"abc12345", "def67890"},
+        total_iterations=2,
+        total_cost=0.012,
+        total_tokens=2000,
+        model="openai/gpt-4o-mini",
+        elapsed_seconds=3.4,
+        finished_normally=True,
+        error=None,
+        mode="cli",
+    )
+    defaults.update(overrides)
+    return InvestigationResult(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Truncation helper
+# ---------------------------------------------------------------------------
+
+
+class TestTruncate:
+    def test_under_cap(self):
+        text, size, truncated = _truncate_bytes("hello", 100)
+        assert text == "hello"
+        assert size == 5
+        assert truncated is False
+
+    def test_over_cap(self):
+        big = "x" * 10_000
+        text, size, truncated = _truncate_bytes(big, 1024)
+        assert size == 10_000
+        assert truncated is True
+        assert len(text.encode("utf-8")) <= 1024
+
+    def test_multi_byte_boundary(self):
+        # Emoji is 4 bytes in UTF-8 — cap that lands mid-emoji must not
+        # produce invalid UTF-8.
+        text = "🙂" * 10  # 40 UTF-8 bytes
+        result, size, truncated = _truncate_bytes(text, 3)
+        assert truncated is True
+        assert size == 40
+        # ``ignore`` errors policy → cleanly truncates to "" since one
+        # full code point is 4 bytes; the important invariant is that
+        # the result encodes back without crashing.
+        result.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# build_* helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHelpers:
+    def test_build_invocation_record(self):
+        rec = build_invocation_record(
+            question="q?", flags={"context": 5, "agent_mode": "cli"}
+        )
+        assert rec == {
+            "command": "ohtv ask",
+            "question": "q?",
+            "flags": {"context": 5, "agent_mode": "cli"},
+        }
+        # Defensive copy: mutating the caller's dict must not bleed in.
+        flags = {"a": 1}
+        rec = build_invocation_record(question="x", flags=flags)
+        flags["a"] = 99
+        assert rec["flags"]["a"] == 1
+
+    def test_build_rag_record_chunks_truncated(self):
+        big_chunk = FakeChunk(source_text="x" * (CHUNK_TEXT_CAP_BYTES + 500))
+        small_chunk = FakeChunk(source_text="small", embed_type="content")
+        rag = FakeRAGAnswer(
+            context_chunks=[big_chunk, small_chunk],
+            source_conversation_ids={"a", "b"},
+        )
+        rec = build_rag_record(rag)  # type: ignore[arg-type]
+        assert len(rec["retrieved_chunks"]) == 2
+        big_rec, small_rec = rec["retrieved_chunks"]
+        assert big_rec["chunk_text_truncated"] is True
+        assert big_rec["chunk_text_size_bytes"] == CHUNK_TEXT_CAP_BYTES + 500
+        assert small_rec["chunk_text_truncated"] is False
+        assert small_rec["chunk_text_size_bytes"] == 5
+        # Token split derived from context_tokens / total_tokens.
+        assert rec["tokens"] == {"prompt": 1234, "completion": 456}
+        # Sorted, deterministic.
+        assert rec["source_conversation_ids"] == ["a", "b"]
+        # Elapsed is search + generation summed.
+        assert rec["elapsed_seconds"] == pytest.approx(0.46)
+
+    def test_build_rag_record_with_date_range(self):
+        rag = FakeRAGAnswer(
+            temporal_filter_applied=True,
+            date_range=(
+                datetime(2026, 5, 1, tzinfo=timezone.utc),
+                datetime(2026, 5, 8, tzinfo=timezone.utc),
+            ),
+        )
+        rec = build_rag_record(rag)  # type: ignore[arg-type]
+        assert rec["temporal_filter_applied"] is True
+        assert rec["date_range"][0].startswith("2026-05-01")
+        assert rec["date_range"][1].startswith("2026-05-08")
+
+    def test_build_agent_record_sorts_conversations(self):
+        result = _make_result(conversations_examined={"zzz", "aaa", "mmm"})
+        rec = build_agent_record(result, steps=[])
+        assert rec["conversations_examined"] == ["aaa", "mmm", "zzz"]
+        assert rec["mode"] == "cli"
+        assert rec["steps"] == []
+
+
+# ---------------------------------------------------------------------------
+# is_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestEnvToggles:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("OHTV_TELEMETRY_ENABLED", raising=False)
+        assert is_enabled() is True
+
+    def test_opt_out(self, monkeypatch):
+        monkeypatch.setenv("OHTV_TELEMETRY_ENABLED", "0")
+        assert is_enabled() is False
+
+    def test_any_other_value_still_enabled(self, monkeypatch):
+        monkeypatch.setenv("OHTV_TELEMETRY_ENABLED", "1")
+        assert is_enabled() is True
+        monkeypatch.setenv("OHTV_TELEMETRY_ENABLED", "true")
+        assert is_enabled() is True
+
+    def test_telemetry_dir_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("OHTV_TELEMETRY_DIR", str(tmp_path / "custom"))
+        from ohtv.config import get_telemetry_dir
+
+        assert get_telemetry_dir() == tmp_path / "custom"
+
+    def test_telemetry_dir_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("OHTV_TELEMETRY_DIR", raising=False)
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path))
+        from ohtv.config import get_telemetry_dir
+
+        assert get_telemetry_dir() == tmp_path / "telemetry"
+
+
+# ---------------------------------------------------------------------------
+# StepRecorder deltas
+# ---------------------------------------------------------------------------
+
+
+class TestStepDeltas:
+    def _new_recorder(self, tmp_path: Path) -> SessionRecorder:
+        return SessionRecorder.start(
+            invocation=build_invocation_record(question="q?", flags={}),
+            environment={"ohtv_version": "test"},
+            telemetry_dir=tmp_path,
+        )
+
+    def test_first_step_delta_equals_first_observation(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            step.set_metrics(0.01, 100, 50)
+            step.set_tool_call("show_conversation", {"conversation_id": "abc"})
+            step.set_observation("hi")
+        assert len(rec._steps) == 1
+        s = rec._steps[0]
+        assert s["cost"] == pytest.approx(0.01)
+        assert s["tokens"] == {"prompt": 100, "completion": 50}
+        assert s["tool_name"] == "show_conversation"
+        assert s["kind"] == "tool_call"
+        assert s["observation_truncated"] is False
+
+    def test_deltas_sum_to_total_cost(self, tmp_path):
+        """The summed per-step deltas must equal the final cumulative cost.
+
+        This is the reconciliation AC: ``sum(step.cost) ≈
+        agent.total_cost`` because the agent.total_cost is what the LLM
+        client reported as accumulated_cost after the last call.
+        """
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            step.set_metrics(0.01, 100, 50)
+        with rec.begin_step(2) as step:
+            step.set_metrics(0.025, 250, 100)  # cumulative
+        with rec.begin_step(3) as step:
+            step.set_metrics(0.04, 400, 180)  # cumulative
+
+        summed_cost = sum(s["cost"] for s in rec._steps)
+        summed_prompt = sum(s["tokens"]["prompt"] for s in rec._steps)
+        summed_completion = sum(s["tokens"]["completion"] for s in rec._steps)
+        assert summed_cost == pytest.approx(0.04)
+        assert summed_prompt == 400
+        assert summed_completion == 180
+
+    def test_step_with_no_metrics_records_zero_cost(self, tmp_path):
+        # Errors / cap hits may produce a step that never observes
+        # metrics. The delta should be 0, not negative.
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            step.set_tool_call("run_ohtv", {"argv": ["show", "x"]})
+            step.set_observation("oops")
+        assert rec._steps[0]["cost"] == 0.0
+        assert rec._steps[0]["tokens"] == {"prompt": 0, "completion": 0}
+
+    def test_observation_truncation_flag_paired(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            big = "x" * (OBSERVATION_CAP_BYTES + 100)
+            step.set_observation(big)
+        s = rec._steps[0]
+        assert s["observation_truncated"] is True
+        assert s["observation_size_bytes"] == OBSERVATION_CAP_BYTES + 100
+        assert len(s["observation_truncated_text"].encode()) <= OBSERVATION_CAP_BYTES
+
+    def test_tool_kind_inference(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            step.set_tool_call("think", {"thought": "..."})
+        with rec.begin_step(2) as step:
+            step.set_tool_call("finish", {"message": "done"})
+        with rec.begin_step(3) as step:
+            step.set_tool_call("run_ohtv", {"argv": ["show"]})
+        assert rec._steps[0]["kind"] == "think"
+        assert rec._steps[1]["kind"] == "finish"
+        assert rec._steps[2]["kind"] == "tool_call"
+
+    def test_string_arguments_normalised_to_dict(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            step.set_tool_call("run_ohtv", '{"argv": ["show", "abc"]}')
+        assert rec._steps[0]["arguments"] == {"argv": ["show", "abc"]}
+
+    def test_unparseable_string_arguments_wrapped(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        with rec.begin_step(1) as step:
+            step.set_tool_call("run_ohtv", "{bad json")
+        assert rec._steps[0]["arguments"] == {"_raw": "{bad json"}
+
+
+# ---------------------------------------------------------------------------
+# finalize → on-disk shape
+# ---------------------------------------------------------------------------
+
+
+FILENAME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z_[0-9a-f]{8}\.json$"
+)
+
+
+class TestFinalize:
+    def _new_recorder(self, tmp_path: Path) -> SessionRecorder:
+        return SessionRecorder.start(
+            invocation=build_invocation_record(
+                question="what changed?",
+                flags={
+                    "context": 5,
+                    "min_score": 0.3,
+                    "model": None,
+                    "agent_mode": "cli",
+                    "max_steps": 5,
+                    "since": None,
+                    "until": None,
+                    "no_temporal": False,
+                    "explain": False,
+                    "explain_only": False,
+                    "show_context": False,
+                },
+            ),
+            environment={"ohtv_version": "test", "corpus": {}},
+            telemetry_dir=tmp_path,
+        )
+
+    def test_filename_grammar(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(_make_result())
+        path = rec.finalize()
+        assert FILENAME_RE.match(path.name), (
+            f"Filename {path.name!r} does not match the locked grammar"
+        )
+        # Filename's 8-char prefix matches session_id[:8]
+        prefix = path.name.rsplit("_", 1)[1].split(".", 1)[0]
+        assert prefix == rec.session_id[:8]
+
+    def test_schema_keys_and_version(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(_make_result())
+        path = rec.finalize()
+        blob = json.loads(path.read_text())
+        assert blob["schema_version"] == SCHEMA_VERSION
+        assert set(blob.keys()) >= {
+            "schema_version",
+            "session_id",
+            "started_at",
+            "ended_at",
+            "invocation",
+            "environment",
+            "rag",
+            "agent",
+            "totals",
+        }
+        # session_id is 32 hex chars (UUID4 hex)
+        assert re.fullmatch(r"[0-9a-f]{32}", blob["session_id"])
+        # ISO-8601 Z (no fractional seconds)
+        assert blob["started_at"].endswith("Z")
+        assert blob["ended_at"].endswith("Z")
+        # Agent block populated.
+        assert blob["agent"]["mode"] == "cli"
+        assert blob["agent"]["finished_normally"] is True
+
+    def test_agent_null_for_plain_rag_sessions(self, tmp_path):
+        """AC: plain ohtv ask (no agent flag) → ``"agent": null`` literally.
+
+        Schema lock-in: stable key set for JSON consumers.
+        """
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(None)  # explicit None — no agent ran
+        path = rec.finalize()
+        raw = path.read_text()
+        blob = json.loads(raw)
+        assert blob["agent"] is None
+        # Make sure the key is *present* in the serialised JSON, not
+        # just None at the dict level (matters for downstream tooling
+        # that walks JSON text).
+        assert '"agent": null' in raw
+
+    def test_record_agent_not_called_still_writes_agent_null(self, tmp_path):
+        """If the ask handler never calls ``record_agent``, the blob still
+        has ``"agent": null`` — i.e. the default state is the same as
+        "explicit None". Defensive against a future refactor."""
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        path = rec.finalize()
+        blob = json.loads(path.read_text())
+        assert blob["agent"] is None
+
+    def test_index_line_shape(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(_make_result(total_iterations=4, finished_normally=True))
+        rec.finalize()
+        index_path = tmp_path / "sessions.jsonl"
+        assert index_path.exists()
+        lines = index_path.read_text().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert set(entry.keys()) >= {
+            "session_id",
+            "started_at",
+            "ended_at",
+            "question",
+            "agent_mode",
+            "model",
+            "total_cost",
+            "total_tokens",
+            "iterations",
+            "finished_normally",
+            "blob",
+        }
+        assert entry["agent_mode"] == "cli"
+        assert entry["iterations"] == 4
+        assert entry["question"] == "what changed?"
+        # blob is the filename, not a path
+        assert "/" not in entry["blob"]
+        assert FILENAME_RE.match(entry["blob"])
+
+    def test_index_line_under_pipe_buf(self, tmp_path):
+        """The concurrency contract relies on the index line fitting under
+        ``PIPE_BUF`` (4096 bytes). Locked down to catch a future shape
+        change that would silently break the no-locking promise."""
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(_make_result())
+        rec.finalize()
+        line = (tmp_path / "sessions.jsonl").read_text().splitlines()[0]
+        assert len(line.encode("utf-8")) < 4096
+
+    def test_atomic_write_no_tmp_left_behind(self, tmp_path):
+        rec = self._new_recorder(tmp_path)
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(_make_result())
+        rec.finalize()
+        # No ``.tmp`` siblings should remain after a successful write.
+        leftover = list((tmp_path / "sessions").glob("*.tmp"))
+        assert leftover == []
+
+    def test_finalize_raises_on_read_only_dir(self, tmp_path):
+        """finalize() raises; the CLI swallows with log.warning. We assert
+        the raise so the swallow contract is meaningful."""
+        rec = self._new_recorder(tmp_path / "blocked")
+        rec.record_rag(FakeRAGAnswer())  # type: ignore[arg-type]
+        rec.record_agent(_make_result())
+        sessions_dir = tmp_path / "blocked" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        # Stub mkdir so finalize tries to write into a path we can
+        # force-fail without root-only chmod tricks.
+        with patch(
+            "ohtv.analysis.telemetry.tempfile.NamedTemporaryFile",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError):
+                rec.finalize()
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — two-process append integrity (the AC)
+# ---------------------------------------------------------------------------
+
+
+def _concurrent_worker(telemetry_dir_str: str, question: str) -> None:
+    """Spawned in a child process; writes one session."""
+    telemetry_dir = Path(telemetry_dir_str)
+    rec = SessionRecorder.start(
+        invocation=build_invocation_record(question=question, flags={"agent_mode": None}),
+        environment={"ohtv_version": "test"},
+        telemetry_dir=telemetry_dir,
+    )
+    rec.record_agent(None)
+    rec.finalize()
+
+
+class TestConcurrency:
+    def test_two_processes_two_lines_no_interleave(self, tmp_path):
+        ctx = multiprocessing.get_context("spawn")
+        procs = [
+            ctx.Process(target=_concurrent_worker, args=(str(tmp_path), f"q{i}"))
+            for i in range(2)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=30)
+            assert p.exitcode == 0
+
+        index_path = tmp_path / "sessions.jsonl"
+        lines = index_path.read_text().splitlines()
+        assert len(lines) == 2
+
+        # Every line is independently valid JSON (no interleaving).
+        questions = set()
+        for line in lines:
+            entry = json.loads(line)
+            questions.add(entry["question"])
+            # session_id is a full 32-char hex
+            assert re.fullmatch(r"[0-9a-f]{32}", entry["session_id"])
+
+        assert questions == {"q0", "q1"}
+
+        # Both blobs exist on disk too.
+        blobs = list((tmp_path / "sessions").glob("*.json"))
+        assert len(blobs) == 2

--- a/tests/unit/test_cli_ask_telemetry.py
+++ b/tests/unit/test_cli_ask_telemetry.py
@@ -1,0 +1,238 @@
+"""CLI integration tests for ``ohtv ask`` telemetry (Issue #162).
+
+Drives the ``ask`` Click handler end-to-end with a real (but minimal)
+sqlite DB and a stubbed ``RAGAnswerer`` so the LLM is never called.
+Verifies that the recorder hookup lands a session blob + index line on
+disk, and that the env-var contracts (``OHTV_TELEMETRY_DIR``,
+``OHTV_TELEMETRY_ENABLED=0``) are honoured by the handler.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeChunk:
+    conversation_id: str = "abc12345"
+    root_conversation_id: str = "abc12345"
+    title: str = "t"
+    embed_type: str = "summary"
+    source_text: str = "hello"
+    score: float = 0.6
+    chunk_index: int = 0
+    summary: str | None = None
+    cloud_url: str | None = None
+    created_at = None
+    conv_source: str = "local"
+    source: object | None = None
+
+
+@dataclass
+class FakeRAGAnswer:
+    answer: str = "stub answer"
+    context_chunks: list = field(default_factory=lambda: [FakeChunk()])
+    source_conversation_ids: set = field(default_factory=lambda: {"abc12345"})
+    search_time_seconds: float = 0.01
+    generation_time_seconds: float = 0.02
+    model: str = "openai/gpt-4o-mini"
+    temporal_filter_applied: bool = False
+    date_range = None
+    related_repos = None
+    related_prs = None
+    related_issues = None
+    context_tokens: int = 100
+    total_tokens: int = 150
+    cost: float = 0.001
+
+
+class FakeRAGAnswerer:
+    """Drop-in for ``ohtv.cli.RAGAnswerer`` — never calls an LLM."""
+
+    def __init__(self, *args, **kwargs):
+        self.model = kwargs.get("model") or "openai/gpt-4o-mini"
+
+    def answer_question(self, question, **_kwargs):
+        return FakeRAGAnswer(answer=f"answer for: {question}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ohtv_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated $OHTV_DIR + $OHTV_TELEMETRY_DIR per test.
+
+    Creates a fresh DB, inserts one dummy embedding row so the
+    ``embed_store.count() == 0`` early-exit in the ``ask`` handler
+    doesn't fire, and points telemetry at ``tmp_path/telemetry``.
+    """
+    ohtv_dir = tmp_path / "ohtv"
+    ohtv_dir.mkdir()
+    telemetry_dir = tmp_path / "telemetry"
+
+    monkeypatch.setenv("OHTV_DIR", str(ohtv_dir))
+    monkeypatch.setenv("OHTV_TELEMETRY_DIR", str(telemetry_dir))
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    # Avoid hitting LiteLLM with a real model.
+    monkeypatch.delenv("LLM_BASE_URL", raising=False)
+
+    # Initialise the DB schema via the public entry point.
+    from ohtv.db import get_ready_connection
+
+    with get_ready_connection() as _conn:
+        pass  # just trigger migrations; no rows needed
+
+    # Patch ``EmbeddingStore.count`` so the ask handler's
+    # ``if embed_count == 0`` early-exit doesn't fire. Inserting a
+    # real row would violate the FK on conversations and isn't worth
+    # the bookkeeping for a telemetry-focused test.
+    from ohtv.db.stores import EmbeddingStore
+
+    monkeypatch.setattr(EmbeddingStore, "count", lambda self: 1)
+
+    return telemetry_dir
+
+
+@pytest.fixture
+def stub_rag(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``RAGAnswerer`` in ``ohtv.cli`` so no LLM is reached."""
+    import ohtv.analysis.rag as rag_mod
+
+    monkeypatch.setattr(rag_mod, "RAGAnswerer", FakeRAGAnswerer)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAskWritesTelemetry:
+    def test_plain_ask_writes_session_with_agent_null(
+        self, ohtv_env, stub_rag
+    ):
+        runner = CliRunner()
+        result = runner.invoke(main, ["ask", "what changed?"])
+        # The handler may emit extra warnings on stderr (e.g. no
+        # citations), but it must exit 0 and print our stub answer.
+        assert result.exit_code == 0, (
+            f"unexpected non-zero exit\nstdout={result.stdout}\n"
+            f"stderr={result.stderr}"
+        )
+        assert "answer for: what changed?" in result.stdout
+
+        # Session blob landed in the override dir.
+        sessions_dir = ohtv_env / "sessions"
+        index_path = ohtv_env / "sessions.jsonl"
+        assert sessions_dir.exists(), "telemetry sessions dir was not created"
+        assert index_path.exists(), "sessions.jsonl was not appended to"
+
+        blobs = list(sessions_dir.glob("*.json"))
+        assert len(blobs) == 1
+        blob = json.loads(blobs[0].read_text())
+
+        # Schema lock-ins.
+        assert blob["schema_version"] == 1
+        assert blob["agent"] is None  # plain RAG → agent: null
+        assert blob["invocation"]["question"] == "what changed?"
+        assert blob["invocation"]["flags"]["agent_mode"] is None
+        # RAG block present + populated by record_rag.
+        assert blob["rag"] is not None
+        assert blob["rag"]["initial_answer"] == "answer for: what changed?"
+
+        # Index line shape.
+        index_lines = index_path.read_text().splitlines()
+        assert len(index_lines) == 1
+        entry = json.loads(index_lines[0])
+        assert entry["question"] == "what changed?"
+        assert entry["agent_mode"] is None
+        assert entry["blob"] == blobs[0].name
+
+
+class TestEnvOptOut:
+    def test_telemetry_disabled_writes_nothing(
+        self, ohtv_env, stub_rag, monkeypatch
+    ):
+        """``OHTV_TELEMETRY_ENABLED=0`` short-circuits recorder construction."""
+        monkeypatch.setenv("OHTV_TELEMETRY_ENABLED", "0")
+        runner = CliRunner()
+        result = runner.invoke(main, ["ask", "anything"])
+        assert result.exit_code == 0
+        # No directory, no index, no blobs.
+        assert not (ohtv_env / "sessions").exists()
+        assert not (ohtv_env / "sessions.jsonl").exists()
+
+
+class TestGracefulDegradation:
+    """If finalize raises, ``ohtv ask`` MUST still succeed.
+
+    Simulated by patching ``SessionRecorder.finalize`` to raise.
+    The CLI handler catches and logs; the user's answer must still
+    print and the exit code stays 0.
+    """
+
+    def test_finalize_failure_does_not_break_ask(
+        self, ohtv_env, stub_rag, monkeypatch
+    ):
+        from ohtv.analysis import telemetry as telemetry_mod
+
+        original_finalize = telemetry_mod.SessionRecorder.finalize
+
+        def boom(self):
+            raise OSError("simulated disk-full / readonly fs")
+
+        monkeypatch.setattr(
+            telemetry_mod.SessionRecorder, "finalize", boom
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["ask", "graceful?"])
+        # Restore for the rest of the test session (monkeypatch handles
+        # this, but be defensive).
+        monkeypatch.setattr(
+            telemetry_mod.SessionRecorder, "finalize", original_finalize
+        )
+
+        assert result.exit_code == 0, (
+            f"finalize failure must NOT propagate.\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}\n"
+            f"exc={result.exception!r}"
+        )
+        assert "answer for: graceful?" in result.stdout
+        # No blob landed (because the simulated failure was inside
+        # the only path that writes one). But the answer was printed.
+        assert not list((ohtv_env / "sessions").glob("*.json"))
+
+
+class TestTelemetryDirOverride:
+    """``OHTV_TELEMETRY_DIR=/path`` must override the storage root.
+
+    Re-verified end-to-end (in addition to the unit test on
+    ``get_telemetry_dir``) so future CLI refactors can't bypass it.
+    """
+
+    def test_override_honored_by_ask(self, ohtv_env, stub_rag):
+        # The fixture already sets OHTV_TELEMETRY_DIR — assert files
+        # land there and not in $OHTV_DIR/telemetry.
+        runner = CliRunner()
+        result = runner.invoke(main, ["ask", "where am I?"])
+        assert result.exit_code == 0
+        assert (ohtv_env / "sessions.jsonl").exists()
+        # The default location must NOT have been created.
+        from ohtv.config import get_ohtv_dir
+
+        default_telemetry = get_ohtv_dir() / "telemetry"
+        assert not default_telemetry.exists() or default_telemetry == ohtv_env

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #162.

## Summary

Captures every `ohtv ask` invocation as a self-contained, replay-friendly JSON blob under `~/.ohtv/telemetry/sessions/`, with an append-only `sessions.jsonl` index alongside. The schema is designed so a future replay tool can re-run the same question against today's corpus (full replay), re-run only the agent loop against a captured RAG result (agent-loop replay), or flip the agent mode and rerun to compare `--agent` vs `--agent-tools` head-to-head (cross-mode replay).

This is the comparison instrument for the #161 dual-mode split. Without it, the eventual "which agent wins" decision is opinion; with it, the decision is data.

No telemetry leaves the machine — ohtv has no remote storage path. No PII redaction.

## What's in the change

- **New** `src/ohtv/analysis/telemetry.py` — `SessionRecorder` + `StepRecorder` (context manager), plus `build_invocation_record` / `build_environment_record` / `build_rag_record` / `build_agent_record` helpers.
- **New** `get_telemetry_dir()` in `src/ohtv/config.py` — mirrors `get_analysis_cache_dir()`. Honours `OHTV_TELEMETRY_DIR`; defaults to `$OHTV_DIR/telemetry/`.
- `InvestigationAgent.investigate(..., recorder=None)` and `InvestigationAgentCli.investigate(..., recorder=None)` — pass-through, zero behaviour change when `None`. Loops wrap each iteration in `maybe_step(recorder, iteration)`.
- `cli.py` `ask` handler — builds invocation + environment up-front, wires the recorder into both investigators, and finalises in a `try/finally` that swallows `finalize()` exceptions with `log.warning` per the graceful-degradation AC.
- **Docs** — `docs/reference/telemetry.md` (schema v1, on-disk layout, replay contract, env-var matrix, concurrency notes).
- **AGENTS.md item #34** — telemetry schema invariants alongside the #161 dual-mode item.

## Schema lock-ins (locked down by tests)

- `agent: null` (not key omission) for plain `ohtv ask` (no agent flag).
- `flags.agent_mode` mirrors `InvestigationResult.mode` (#161): `"cli"` / `"tools"` / `null`.
- Filename grammar: `{ISO8601-Z-with-hyphens}_{8-hex-uuid-prefix}.json` (hyphens because `:` is reserved on Windows / breaks Dropbox-OneDrive sync).
- Per-step `cost` and `tokens.{prompt,completion}` are deltas — `StepRecorder.__enter__` snapshots the parent's running totals; `__exit__` computes deltas and propagates. Summed deltas reconcile to the agent's accumulated cost.
- `chunk_text` capped at 2 KB; `observation_truncated_text` capped at 8 KB. Each carries a paired `_truncated` flag + `_size_bytes` counter.
- `OHTV_TELEMETRY_ENABLED=0` → recorder is never constructed (zero overhead).

## Concurrency

- `sessions.jsonl` writes are single `write()` per session (~200 bytes, well under POSIX `PIPE_BUF=4096`). `O_APPEND` semantics give us atomic line writes across concurrent `ohtv ask` invocations. **No file locking.**
- Per-session blobs are atomic via `tempfile.NamedTemporaryFile(dir=sessions_dir)` + `os.replace()` (POSIX-atomic, Windows-safe).
- Regression-tested by `multiprocessing.Process(2)` workers writing two sessions concurrently — assertion checks both lines are present, each parses as JSON independently, and both questions land.

## Acceptance criteria mapping (Issue #162)

- [x] Every `ohtv ask` invocation writes one session blob + one index line. _(CLI integration test `test_plain_ask_writes_session_with_agent_null`.)_
- [x] Both `--agent` and `--agent-tools` modes share the same top-level schema; only `agent.steps[].tool_name` / `arguments` differ. _(Both investigators take the same `recorder=` kwarg; cli mode reports `mode="cli"`, tools mode reports `mode="tools"`.)_
- [x] Plain `ohtv ask` (no agent) writes a session with `agent: null` (explicit, not omission). _(Locked down by `test_agent_null_for_plain_rag_sessions`.)_
- [x] Schema documented in `docs/reference/telemetry.md` with field-level semantics + replay-readiness contract.
- [x] All replay-critical input fields captured: question, model, agent_mode, max_steps, context, min_score, since, until, no_temporal, explain, explain_only, show_context.
- [x] Truncation is explicit: paired `_truncated` flag + `_size_bytes` counter. _(Locked down by `test_observation_truncation_flag_paired`, `test_build_rag_record_chunks_truncated`.)_
- [x] Telemetry write failures degrade gracefully — `ohtv ask` still completes and prints its answer. _(CLI test `test_finalize_failure_does_not_break_ask`.)_
- [x] `OHTV_TELEMETRY_ENABLED=0` disables capture. _(CLI test `test_telemetry_disabled_writes_nothing`.)_
- [x] `OHTV_TELEMETRY_DIR=/path` overrides the storage root. _(CLI test `test_override_honored_by_ask` + unit test `test_telemetry_dir_override`.)_
- [x] Unit tests cover: schema serialization, truncation, missing-agent block, recorder write-failure path, index-line shape. _(28 unit tests in `tests/unit/analysis/test_telemetry.py`.)_
- [x] Concurrency: two concurrent `multiprocessing.Process` writers produce two distinct JSONL lines with no interleaving.

## Tests

`uv run pytest -q` — **2592 passed**, 2 skipped, 3 xfailed (pre-existing markers; unrelated to this change).

New tests:
- `tests/unit/analysis/test_telemetry.py` — 28 unit tests covering recorder lifecycle, filename grammar, schema serialisation, truncation flag pairing, env-var contracts, delta reconciliation, and the `multiprocessing.Process(2)` concurrency assertion.
- `tests/unit/test_cli_ask_telemetry.py` — 4 CLI integration tests driving the `ask` Click handler with a stubbed `RAGAnswerer` (no LLM calls), asserting blob + index landing, the `OHTV_TELEMETRY_DIR` override, the `OHTV_TELEMETRY_ENABLED=0` opt-out, and the graceful-degradation path.

## Out of scope (per #162 Non-Goals)

- No `ohtv telemetry list / show / replay / compare / prune` subcommands (separate follow-up).
- No remote storage / upload path.
- No PII scrubbing — telemetry stays local.
- No vector capture in `retrieved_chunks` — `environment.embedding_model` + `embedding_dim` + `corpus.newest_conversation_at` are sufficient.
- `ConversationStore.update_metadata` is untouched. No cloud-sync writes affected.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2a8db4ae-29ce-4180-a11e-8399f6489dd6)