### PR TITLE
refactor: extract _process_engagement_rows helper from _load_engagement_for_ids

### DIFF
--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -13,7 +13,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, Iterable, NamedTuple
 
 import click
 from click import Context, HelpFormatter
@@ -4420,6 +4420,47 @@ def _load_refs_for_conversations(
     return refs_map
 
 
+def _process_engagement_rows(
+    rows: Iterable[Any],
+    normalized_to_original: dict[str, str],
+    engagement_map: dict[str, dict],
+) -> None:
+    """Merge one chunk of ``conversation_engagement`` rows into ``engagement_map``.
+
+    Each row is coerced to a plain ``dict`` (handling both ``sqlite3.Row``
+    and bare tuples), its ``conversation_id`` is back-translated through
+    ``normalized_to_original`` to the caller's original (possibly dashed)
+    id form, and the row dict is written into ``engagement_map`` keyed on
+    that original id. Rows whose ``conversation_id`` is not in the
+    translation map are silently dropped — they would only appear if the
+    DB returned a row the caller did not ask for, which the batched
+    ``WHERE conversation_id IN (...)`` clause makes impossible in
+    practice.
+
+    This is a pure mutator: ``engagement_map`` is modified in place; the
+    function returns ``None``. The DB-error suppression contract
+    (Issues #167 / #168: never raise) stays at the outer ``try/except``
+    in :func:`_load_engagement_for_ids`.
+    """
+    for row in rows:
+        # sqlite3.Row supports keys(); fall back to indexing for plain
+        # tuples just in case.
+        if hasattr(row, "keys"):
+            row_dict = {k: row[k] for k in row.keys()}
+        else:
+            row_dict = {
+                "conversation_id": row[0],
+                "engaged_seconds": row[1],
+                "attention_periods": row[2],
+                "threshold_seconds": row[3],
+                "total_duration_seconds": row[4],
+            }
+        norm_id = row_dict.get("conversation_id")
+        original = normalized_to_original.get(norm_id)
+        if original is not None:
+            engagement_map[original] = row_dict
+
+
 def _load_engagement_for_ids(
     conversation_ids: list[str],
 ) -> dict[str, dict]:
@@ -4477,23 +4518,7 @@ def _load_engagement_for_ids(
                     f"WHERE conversation_id IN ({placeholders})",
                     batch,
                 )
-                for row in cur.fetchall():
-                    # sqlite3.Row supports keys(); fall back to indexing
-                    # for plain tuples just in case.
-                    if hasattr(row, "keys"):
-                        row_dict = {k: row[k] for k in row.keys()}
-                    else:
-                        row_dict = {
-                            "conversation_id": row[0],
-                            "engaged_seconds": row[1],
-                            "attention_periods": row[2],
-                            "threshold_seconds": row[3],
-                            "total_duration_seconds": row[4],
-                        }
-                    norm_id = row_dict.get("conversation_id")
-                    original = normalized_to_original.get(norm_id)
-                    if original is not None:
-                        engagement_map[original] = row_dict
+                _process_engagement_rows(cur.fetchall(), normalized_to_original, engagement_map)
     except Exception:  # pragma: no cover - defensive only
         return engagement_map
 


### PR DESCRIPTION
Closes #173.

## Summary

Pure depth-reduction refactor of `_load_engagement_for_ids` in `src/ohtv/cli.py` per the technical-approach comment on #173. The inner row-coercion + back-translation block is lifted into a new private helper `_process_engagement_rows`, dropping the chunk loop body to four lines (build `batch`, build `placeholders`, `cur = conn.execute(...)`, helper call) and reducing nested-block depth from 5 to 3.

## What changed

- **New helper** `_process_engagement_rows(rows, normalized_to_original, engagement_map) -> None` defined immediately above `_load_engagement_for_ids`. In-place mutator (chosen per the design comment's rationale: `engagement_map` is already the accumulator across chunks).
- **`_load_engagement_for_ids`** chunk loop body replaced with a single call to the new helper.
- **`typing.Any` + `typing.Iterable`** added to the existing `from typing import ...` line for the helper signature.

## Behavioral invariants preserved (no behavior change)

- Same single batched `WHERE conversation_id IN (...)` SELECT per `BATCH_SIZE = 900` ids — **load-bearing test `test_chunk_query_count` verifies the 1100-id → 2 SELECTs guarantee across the chunk boundary** and stays green.
- Same dashless ↔ dashed id back-translation via `normalized_to_original` (AGENTS.md item #14).
- Same never-raise contract (Issues #167 / #168) — the outer `try` / `except Exception: return engagement_map` guard around the `with get_ready_connection(...)` block is untouched.
- Same `engagement_map[original] = row_dict` mutation semantics (no `setdefault`, no merge, later chunk wins on collision — exactly as before).
- The SQL string, the `placeholders` builder, the early-empty guard, and the defensive `get_db_path()` / `db_path.exists()` checks are all untouched.

## Out of scope (deliberately)

- `_load_engagement_for_conversations` (the `ConversationInfo` delegator) — untouched.
- JSON schema / CLI flag surface / stage dependencies — none changed.
- Migrations, `conversation_engagement` schema — not in scope.
- Documentation — no user-visible behavior change (per the AGENTS.md `orchestrate` skill carve-out: internal refactoring does not require a docs update).

## Test coverage

- **86 targeted engagement tests** green:
  `uv run pytest -q tests/unit/test_cli_gen_objs_engagement.py tests/unit/test_cli_list_engagement.py tests/unit/test_cli_engagement_display.py` → **86 passed**.
  Includes the load-bearing `test_chunk_query_count` regression: 1100 ids ⇒ exactly two SELECTs (the helper only consumes `cur.fetchall()`, so the proxy-class connection wrapper still observes the same `execute(...)` call count).
- **Full suite** green:
  `uv run pytest -q` → **2592 passed, 2 skipped, 3 xfailed**.
- **Lint clean**: `uv run ruff check src/ohtv/cli.py` → no new errors.
- **Manual blackbox testing**: 12/12 tests PASS (see the [Manual Test Results comment](https://github.com/jpshackelford/ohtv/pull/179#issuecomment) — covers chunk-boundary invariants on a real seeded DB, dashed/dashless id round-trips, and never-raise behaviour on synthetic DB-error injection).

## Acceptance criteria (from issue + comment)

- [x] `_load_engagement_for_ids` body reads top-to-bottom as the issue's 4-step list (build map → open conn → chunk-SELECT → return).
- [x] No nested-block depth > 3 inside `_load_engagement_for_ids` (outer `try` → `with` → `for chunk`).
- [x] `tests/unit/test_cli_gen_objs_engagement.py` green.
- [x] `tests/unit/test_cli_list_engagement.py` + `tests/unit/test_cli_engagement_display.py` green.
- [x] Ruff clean (no regression).
- [x] PR title is a `refactor:` conventional-commit subject → release workflow skips this PR (no version bump, no CHANGELOG entry).

Diff is +43 / -18 in `src/ohtv/cli.py` only.

---

This PR was opened by an AI agent (OpenHands) on behalf of @jpshackelford.
