### PR TITLE
feat(cli): add ohtv messages command to list user messages across conversations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,8 @@ uv run ohtv show <id> -s -d -o         # Actions with details + outputs
 uv run ohtv refs <id>                  # Git references (rich display)
 uv run ohtv refs -D --prs-only -1      # Today's PRs, one per line
 uv run ohtv refs -W --format json      # This week's refs as JSON
+uv run ohtv messages -W                # User messages from this week
+uv run ohtv messages -D 7 -1           # Last 7 days, one tab-sep line per msg (pipe)
 uv run ohtv errors <id>                # Agent/LLM error summary
 uv run ohtv list --errors-only         # List conversations with errors
 uv run ohtv db status                  # Database statistics

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Created: 2026-05-22 10:15 UTC | Events: 47
 [2026-05-22 10:15:03] Can you help me implement OAuth2 authentication...
 
 ─────────────────────────────────────────────────────────────────
-Showing 2 of 15 conversations (6 messages) | Next: --offset 2
+Showing 2 of 15 candidate conversations (6 messages) | Next: --offset 2
 ```
 
 `-F json` emits a single object: `{total_conversations, total_messages,
@@ -245,9 +245,11 @@ full message text — the 500-char truncation only applies to `text` mode.
 
 - Like `--event-dates` and the `--engaged` family, the date filter runs against
   `conversation_engagement.first_event_ts` / `last_event_ts`. Conversations
-  without an engagement row are silently excluded (INNER JOIN). On an empty
-  result set the command prints a hint pointing at `ohtv db process engagement`
-  (or `ohtv sync`).
+  without an engagement row are silently excluded (INNER JOIN). When the
+  candidate pool is empty the command prints a hint pointing at
+  `ohtv db process engagement` (or `ohtv sync`); when candidates exist but
+  the current page is empty (e.g. paged past the message-bearing pool with
+  `--offset`) it prints an offset-aware hint instead.
 - The footer's `total_messages` counts only the *displayed* conversations —
   pagination is by conversation, so the full-history message count across all
   candidates is intentionally not computed (would defeat the per-invocation

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A 5-minute end-to-end walkthrough lives at
 | **Classify** | `classify` | [classification](docs/guides/classification.md) |
 | **Analyze (LLM)** | `gen objs / titles / run`, `prompts` | [analysis](docs/guides/analysis.md), [customizing-prompts](docs/guides/customizing-prompts.md) |
 | **Report** | `report velocity / weekly-counts`, `fetch-loc` | [reporting](docs/guides/reporting.md) |
-| **Search & ask** | `search`, `ask` | [search-and-ask](docs/guides/search-and-ask.md) |
+| **Search & ask** | `search`, `ask`, `messages` | [search-and-ask](docs/guides/search-and-ask.md) |
 
 A flag-by-flag command index is at [docs/reference/cli.md](docs/reference/cli.md).
 For terminology (change_ref, partial_loc, manifest, sandbox, …) see
@@ -170,6 +170,88 @@ ohtv gen objs --event-dates --since 1m
 
 Full per-command flag table:
 [exploration](docs/guides/exploration.md#filtering-by-event-timestamps---event-dates).
+
+## Listing user messages
+
+`ohtv messages` ([#181](https://github.com/jpshackelford/ohtv/issues/181))
+is the third way to find a conversation by what *you* said — the time-shaped
+sibling of `ohtv ask` (semantic RAG over embeddings) and `ohtv search` (FTS5
+keyword). When you only remember roughly *when* you typed something, this
+command lists every user message in a date range, grouped by conversation,
+ordered by most-recent activity first. Pagination is **by conversation**:
+within a displayed conversation, every matching user message renders.
+
+Date filtering uses **engagement event timestamps**, not
+`conversations.created_at` — a conversation started months ago that received a
+user message yesterday surfaces under `-D` or `-D 7`. This is the same
+column-swap mechanism [`--event-dates`](#event-date-filtering) introduces for
+`list` / `search` / `ask`, but for `messages` it is the only mode (no
+`--event-dates` flag, no opt-out — per issue scope). The same engagement-row
+prerequisite applies (run `ohtv db process engagement` or `ohtv sync`).
+
+```bash
+# Default: 10 most recently engaged conversations (no date cap),
+# 500-char truncation per message in text mode.
+ohtv messages
+
+# Time windows — same shortcuts as `ohtv list` and `ohtv refs`
+ohtv messages -D                       # Today
+ohtv messages -D 7                     # Last 7 days
+ohtv messages -W                       # This week
+ohtv messages -W 2                     # Last 2 weeks
+ohtv messages --since 2026-05-01 --until 2026-05-31
+
+# Pagination is by conversation; within a shown conversation
+# ALL in-range user messages render.
+ohtv messages -D 30 -n 25              # First 25 conversations
+ohtv messages -D 30 -n 25 -k 25        # Next page (offset 25)
+ohtv messages -D 30 -A                 # No cap
+
+# Output formats
+ohtv messages -W -F json               # Machine-readable
+ohtv messages -D 7 -1                  # `--format raw` shortcut: one
+                                       # tab-separated <conv>\t<ts>\t<msg>
+                                       # line per message, pipe-friendly
+ohtv messages -D 7 -1 | grep -i auth   # Find auth mentions this week
+ohtv messages -W --full                # Disable the 500-char truncation
+
+# Conversation-level filters compose
+ohtv messages -W --source cloud
+ohtv messages -W --repo jpshackelford/ohtv
+ohtv messages -W -L status=active
+ohtv messages -W --include-sub-conversations  # opt in to delegated subs
+```
+
+**Default text output** — one rule line + header per conversation, indented
+`[timestamp] message` rows under each, then a pagination footer:
+
+```text
+─────────────────────────────────────────────────────────────────
+Conversation: a1b2c3d4 — "Implement Authentication Flow"
+Created: 2026-05-22 10:15 UTC | Events: 47
+
+[2026-05-22 10:15:03] Can you help me implement OAuth2 authentication...
+
+─────────────────────────────────────────────────────────────────
+Showing 2 of 15 conversations (6 messages) | Next: --offset 2
+```
+
+`-F json` emits a single object: `{total_conversations, total_messages,
+offset, limit, conversations: [{id, title, created_at, source, event_count,
+messages: [{timestamp, text}, …]}]}`. JSON and raw modes always carry the
+full message text — the 500-char truncation only applies to `text` mode.
+
+**Gotchas:**
+
+- Like `--event-dates` and the `--engaged` family, the date filter runs against
+  `conversation_engagement.first_event_ts` / `last_event_ts`. Conversations
+  without an engagement row are silently excluded (INNER JOIN). On an empty
+  result set the command prints a hint pointing at `ohtv db process engagement`
+  (or `ohtv sync`).
+- The footer's `total_messages` counts only the *displayed* conversations —
+  pagination is by conversation, so the full-history message count across all
+  candidates is intentionally not computed (would defeat the per-invocation
+  cost ceiling).
 
 ## Configuration
 

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -6376,12 +6376,31 @@ def _render_messages_text(
     console.print(f"[dim]{rule}[/dim]")
 
     # Footer — only the text renderer carries it.
+    #
+    # Two-pool semantics (Issue #181 review round 1): the renderer sees
+    # the messages-bearing *displayed* window (``groups``), while
+    # ``total_conversations`` is the engagement-joined *candidate* pool
+    # (#180's ``list_by_event_date_range`` predicate, after
+    # ``--source`` / ``--repo`` / ``--label`` filtering). The full
+    # messages-bearing pool count would require Pass 2 over every
+    # candidate, which defeats the cost ceiling documented at the top
+    # of :mod:`ohtv.messages`. We therefore:
+    #
+    # 1. Say "candidate conversations" in the denominator so users see
+    #    that the number includes engagement-bearing convs that may
+    #    have had zero in-range user messages (and were dropped from
+    #    the displayed window).
+    # 2. Compute the "Next" guard from ``offset + limit`` (the
+    #    candidate cursor advance), NOT ``offset + shown`` (the
+    #    messages-bearing display count) — otherwise a page where some
+    #    candidates filter out leaks a Next link past the end of the
+    #    candidate pool.
     shown = len(groups)
     parts = [
-        f"Showing {shown} of {total_conversations} conversations",
+        f"Showing {shown} of {total_conversations} candidate conversations",
         f"({total_messages} messages)",
     ]
-    if limit is not None and (offset + shown) < total_conversations:
+    if limit is not None and (offset + limit) < total_conversations:
         parts.append(f"Next: --offset {offset + limit}")
     console.print("[dim]" + " | ".join(parts) + "[/dim]")
 
@@ -6558,17 +6577,46 @@ def messages_cmd(
         offset=offset,
     )
 
-    # Empty-result hint per AC. Mention the engagement-stage caveat
-    # (the engagement-table INNER JOIN in ``list_by_event_date_range``
-    # silently drops convs that haven't been processed yet).
+    # Empty-result hint per AC, split into the two pool-aware cases
+    # (Issue #181 review round 1):
+    #
+    # * ``total_convs == 0`` — genuinely no candidates in the engagement
+    #   table for this range / filter combo. The historical engagement-
+    #   stage hint is the right one here: the user may have forgotten
+    #   to run ``ohtv db process engagement``.
+    #
+    # * ``total_convs > 0`` but ``not groups`` — candidates exist but
+    #   the paginated window of them had zero in-range user messages.
+    #   Either the user walked past the messages-bearing pool with
+    #   ``--offset`` (Repro 1 in the testing report), or filters
+    #   matched a slice of agent-only conversations. The engagement
+    #   hint MISFIRES here; surface an offset hint instead.
     if not groups:
         if fmt == "text":
-            console.print("No user messages in range.")
-            console.print(
-                "[dim]Hint: if you recently synced, run "
-                "'ohtv db process engagement' (or 'ohtv sync') to "
-                "populate event timestamps.[/dim]"
-            )
+            if total_convs == 0:
+                console.print("No user messages in range.")
+                console.print(
+                    "[dim]Hint: if you recently synced, run "
+                    "'ohtv db process engagement' (or 'ohtv sync') to "
+                    "populate event timestamps.[/dim]"
+                )
+            else:
+                console.print(
+                    f"No user messages on this page "
+                    f"({total_convs} candidate conversations in range)."
+                )
+                if offset > 0:
+                    console.print(
+                        "[dim]Hint: try --offset 0 (or drop --offset / "
+                        "--max) to widen the window — some candidates "
+                        "had no in-range user messages.[/dim]"
+                    )
+                else:
+                    console.print(
+                        "[dim]Hint: the candidates in range had no "
+                        "in-range user messages (agent-only "
+                        "conversations or post-filter dropouts).[/dim]"
+                    )
         elif fmt == "json":
             print(_render_messages_json(
                 [],

--- a/src/ohtv/cli.py
+++ b/src/ohtv/cli.py
@@ -28,6 +28,7 @@ from ohtv.db.utils import generate_unique_source_names
 from ohtv.locks import SyncLockTimeout, sync_lock
 
 if TYPE_CHECKING:
+    from ohtv.messages import ConversationMessages
     from ohtv.prompts import DisplaySchema
 
 log = logging.getLogger("ohtv")
@@ -6296,6 +6297,309 @@ def _print_error_detail(err) -> None:
         if len(msg) > 200:
             msg = msg[:200] + "..."
         console.print(f"       Detail: {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Issue #181: ``ohtv messages`` — browse-what-you-said command.
+# ---------------------------------------------------------------------------
+
+
+def _format_messages_short_id(conv_id: str) -> str:
+    """Render the first 8 hex chars of a conversation id for headers."""
+    return conv_id.replace("-", "")[:8]
+
+
+def _format_messages_iso(dt: datetime | None) -> str | None:
+    """Render a datetime as a stable, dashless ISO 8601 ``Z`` string.
+
+    JSON / raw modes need a machine-readable, timezone-stable form.
+    Naive datetimes are assumed UTC (consistent with how events are
+    stored on disk — see :func:`_parse_event_datetime`).
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _render_messages_text(
+    groups: list["ConversationMessages"],
+    *,
+    total_conversations: int,
+    total_messages: int,
+    offset: int,
+    limit: int | None,
+    full: bool,
+) -> None:
+    """Render messages in the human-readable ``text`` format.
+
+    Uses rich styling (dim rule lines, cyan conversation ids) to match
+    the rest of the CLI. Each conversation gets a header + an indented
+    list of timestamped messages, with the 500-char truncation applied
+    when ``full`` is False.
+    """
+    from ohtv.messages import TEXT_TRUNCATION_CHARS, truncate_text
+
+    rule = "─" * 65
+
+    for group in groups:
+        console.print(f"[dim]{rule}[/dim]")
+        short_id = _format_messages_short_id(group.conv.id)
+        title = group.conv.title or "(untitled)"
+        # Truncate long titles so the header stays on one line.
+        if len(title) > 60:
+            title = title[:57] + "..."
+        console.print(
+            f'[bold]Conversation:[/bold] [cyan]{short_id}[/cyan] — "{title}"'
+        )
+
+        created = (
+            group.conv.created_at.strftime("%Y-%m-%d %H:%M UTC")
+            if group.conv.created_at
+            else "(unknown)"
+        )
+        ev_count = group.conv.event_count if group.conv.event_count is not None else 0
+        console.print(
+            f"[dim]Created: {created} | Events: {ev_count}[/dim]"
+        )
+        console.print()
+
+        for msg in group.messages:
+            ts_str = msg.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+            text = msg.text if full else truncate_text(
+                msg.text, TEXT_TRUNCATION_CHARS
+            )
+            console.print(f"[dim]\\[{ts_str}][/dim] {text}")
+            console.print()
+
+    console.print(f"[dim]{rule}[/dim]")
+
+    # Footer — only the text renderer carries it.
+    shown = len(groups)
+    parts = [
+        f"Showing {shown} of {total_conversations} conversations",
+        f"({total_messages} messages)",
+    ]
+    if limit is not None and (offset + shown) < total_conversations:
+        parts.append(f"Next: --offset {offset + limit}")
+    console.print("[dim]" + " | ".join(parts) + "[/dim]")
+
+
+def _render_messages_json(
+    groups: list["ConversationMessages"],
+    *,
+    total_conversations: int,
+    total_messages: int,
+    offset: int,
+    limit: int | None,
+) -> str:
+    """Render messages as a single JSON object matching the AC shape.
+
+    Top-level keys: ``total_conversations``, ``total_messages``,
+    ``offset``, ``limit``, ``conversations``. Per-conversation keys:
+    ``id`` (dashless), ``title``, ``created_at`` (ISO Z),
+    ``source``, ``event_count``, ``messages`` (list of
+    ``{timestamp, text}``). Always carries the full message text
+    (truncation is text-mode-only per AC).
+    """
+    out = {
+        "total_conversations": total_conversations,
+        "total_messages": total_messages,
+        "offset": offset,
+        "limit": limit,
+        "conversations": [
+            {
+                "id": group.conv.id.replace("-", ""),
+                "title": group.conv.title,
+                "created_at": _format_messages_iso(group.conv.created_at),
+                "source": group.conv.source,
+                "event_count": group.conv.event_count,
+                "messages": [
+                    {
+                        "timestamp": _format_messages_iso(m.timestamp),
+                        "text": m.text,
+                    }
+                    for m in group.messages
+                ],
+            }
+            for group in groups
+        ],
+    }
+    return json.dumps(out, indent=2)
+
+
+def _render_messages_raw(groups: list["ConversationMessages"]) -> str:
+    """Render messages in the ``raw`` (``-1``) line-per-message format.
+
+    One tab-separated line per message::
+
+        <conv_id_short>\\t<ISO_timestamp>\\t<single_line_message>
+
+    Newlines in the message body collapse to ``⏎``; literal tabs
+    collapse to four spaces — both via
+    :func:`ohtv.messages.collapse_to_single_line` — so downstream
+    ``grep`` / ``awk`` pipelines see uniform columns.
+    """
+    from ohtv.messages import collapse_to_single_line
+
+    lines = []
+    for group in groups:
+        short_id = _format_messages_short_id(group.conv.id)
+        for msg in group.messages:
+            ts = _format_messages_iso(msg.timestamp)
+            text = collapse_to_single_line(msg.text)
+            lines.append(f"{short_id}\t{ts}\t{text}")
+    return "\n".join(lines)
+
+
+@main.command("messages")
+@click.option("--since", "-S", "since_date",
+              help="Show messages with event timestamp >= DATE")
+@click.option("--until", "-U", "until_date",
+              help="Show messages with event timestamp < DATE")
+@click.option("--day", "-D", "day_date", is_flag=False, flag_value="today",
+              default=None,
+              help="Filter by day: -D (today), -D DATE, or -D N (last N days)")
+@click.option("--week", "-W", "week_date", is_flag=False, flag_value="today",
+              default=None,
+              help="Filter by week: -W (this week), -W DATE, or -W N (last N weeks)")
+@click.option("--max", "-n", "limit", type=int, default=10,
+              help="Limit to N conversations (default: 10)")
+@click.option("--all", "-A", "show_all", is_flag=True,
+              help="Show all matching conversations (no cap)")
+@click.option("--offset", "-k", type=int, default=0,
+              help="Skip first N conversations (matches `list` semantics)")
+@click.option("--format", "-F", "fmt",
+              type=click.Choice(["text", "json", "raw"]),
+              default="text",
+              help="Output format (default: text)")
+@click.option("-1", "one_per_line", is_flag=True,
+              help="Shorthand for --format raw (one message per line)")
+@click.option("--full", "full_messages", is_flag=True,
+              help="Disable 500-char truncation in text mode")
+@click.option("--source", "source_filter",
+              type=click.Choice(["local", "cloud"]), default=None,
+              help="Filter by source: local or cloud")
+@click.option("--repo", "repo_filter", default=None,
+              help="Filter to conversations linked to a repository")
+@click.option("--label", "-L", "label_filter", default=None,
+              help="Filter by label (key=value)")
+@click.option("--include-sub-conversations", "include_subs",
+              is_flag=True, default=False,
+              help=(
+                  "Include agent-delegated sub-conversation messages "
+                  "(default off, matches #127)"
+              ))
+@logging_options
+def messages_cmd(
+    since_date: str | None,
+    until_date: str | None,
+    day_date: str | None,
+    week_date: str | None,
+    limit: int,
+    show_all: bool,
+    offset: int,
+    fmt: str,
+    one_per_line: bool,
+    full_messages: bool,
+    source_filter: str | None,
+    repo_filter: str | None,
+    label_filter: str | None,
+    include_subs: bool,
+) -> None:
+    """List user messages across conversations, grouped by conversation.
+
+    \b
+    The "what did I say last week?" browse surface — complements
+    ``ohtv ask`` (semantic RAG) and ``ohtv search`` (FTS5) when you
+    only remember roughly *when* you said something.
+
+    \b
+    Date filtering uses **event timestamps**, not ``conversations.created_at``
+    — a conversation created two months ago that received a user
+    message yesterday surfaces under ``--since yesterday``. This is
+    the same column-swap mechanism #180 introduced for ``--event-dates``,
+    but here event-time is the only mode (see #181 "Out of Scope").
+
+    \b
+    Examples:
+      ohtv messages --since 7d              # Last 7 days, default 10 convs
+      ohtv messages --day --all             # Today, no cap
+      ohtv messages --week -F json          # Scripting
+      ohtv messages -D 30 -1 | grep -i auth # One per line + grep
+    """
+    init_logging_from_cli()
+    config = Config.from_env()
+
+    # ``-1`` is the shorthand for ``--format raw`` (matches ``ohtv refs -1``).
+    if one_per_line:
+        fmt = "raw"
+
+    # Resolve date shortcuts (``-D`` / ``-W``) into (since, until).
+    since, until = _parse_date_filters(
+        since_date, until_date, day_date, week_date,
+    )
+
+    # ``--all`` disables the cap; otherwise honour ``--max``.
+    effective_limit: int | None = None if show_all else limit
+
+    from ohtv.messages import collect_messages
+
+    groups, total_convs, total_msgs = collect_messages(
+        config,
+        since=since,
+        until=until,
+        source=source_filter,
+        repo=repo_filter,
+        label=label_filter,
+        include_subs=include_subs,
+        limit=effective_limit,
+        offset=offset,
+    )
+
+    # Empty-result hint per AC. Mention the engagement-stage caveat
+    # (the engagement-table INNER JOIN in ``list_by_event_date_range``
+    # silently drops convs that haven't been processed yet).
+    if not groups:
+        if fmt == "text":
+            console.print("No user messages in range.")
+            console.print(
+                "[dim]Hint: if you recently synced, run "
+                "'ohtv db process engagement' (or 'ohtv sync') to "
+                "populate event timestamps.[/dim]"
+            )
+        elif fmt == "json":
+            print(_render_messages_json(
+                [],
+                total_conversations=total_convs,
+                total_messages=total_msgs,
+                offset=offset,
+                limit=effective_limit,
+            ))
+        # ``raw`` mode on empty result prints nothing — designed for
+        # pipelines where empty input is a non-event.
+        return
+
+    if fmt == "text":
+        _render_messages_text(
+            groups,
+            total_conversations=total_convs,
+            total_messages=total_msgs,
+            offset=offset,
+            limit=effective_limit,
+            full=full_messages,
+        )
+    elif fmt == "json":
+        print(_render_messages_json(
+            groups,
+            total_conversations=total_convs,
+            total_messages=total_msgs,
+            offset=offset,
+            limit=effective_limit,
+        ))
+    else:  # ``raw``
+        print(_render_messages_raw(groups))
 
 
 @main.command()

--- a/src/ohtv/messages.py
+++ b/src/ohtv/messages.py
@@ -1,0 +1,507 @@
+"""User-message browse surface for ``ohtv messages`` (Issue #181).
+
+This module provides the pure-Python core of the ``ohtv messages``
+command: list every user message within a date range, grouped by
+conversation, newest conversation first.
+
+It is the sibling of :mod:`ohtv.errors` / :mod:`ohtv.actions` /
+:mod:`ohtv.fetch_loc` — kept out of :mod:`ohtv.cli` so the message-
+extraction logic stays unit-testable without Click.
+
+Two pass strategy (see Issue #181 technical comment for the full
+write-up):
+
+1. **Pass 1 — DB candidates** via
+   :meth:`ohtv.db.stores.ConversationStore.list_by_event_date_range`
+   (the SINGLE owner of the engagement-overlap WHERE clause, AGENTS.md
+   item #35). Returns conversations whose
+   ``[first_event_ts, last_event_ts]`` engagement span overlaps
+   ``[since, until]`` — a strict superset of "conversations with ≥1
+   user message in range". We then pass that list through the existing
+   ``--repo`` / ``--label`` filters and through the pagination
+   (offset + limit).
+
+2. **Pass 2 — events from disk** for *displayed* conversations only.
+   We load each surviving conversation's ``events/*.json`` file once,
+   keep only ``source == "user"`` ``MessageEvent`` rows whose
+   timestamp lies in ``[since, until]``, truncate the conversation
+   from the output if zero such messages survive, and yield the rest.
+
+The cost ceiling is ``offset + limit`` JSON-loaded conversations per
+invocation. With the default ``-n 10``, a 7-day query loads ~10
+conversations × ~50 events ≈ ~500 JSON parses — far below the cost of
+a synchronous LLM call.
+
+Output rendering (text / json / raw) lives in :mod:`ohtv.cli` so it can
+reuse the existing ``console`` Rich glue; this module only produces
+the structured :class:`ConversationMessages` records that the CLI
+formats.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ohtv.config import Config
+    from ohtv.sources.base import ConversationInfo
+
+
+# Default truncation cutoff for text-mode rendering. Matches the AC in
+# Issue #181. ``json`` and ``raw`` always carry the full text.
+TEXT_TRUNCATION_CHARS = 500
+
+
+@dataclass
+class UserMessage:
+    """A single user message extracted from a conversation's event log.
+
+    Fields are denormalized (conversation context is carried alongside
+    the message) so the JSON / raw renderers don't need to look back at
+    the parent conversation. The text-mode renderer groups by
+    ``conv_id`` and prints the conversation header once per group via
+    :class:`ConversationMessages`.
+    """
+
+    conv_id: str
+    """Conversation id (normalized — dashless, 32-char hex).
+
+    Stored dashless so it matches the directory name on disk and the
+    DB primary key. The CLI renders ``conv_id[:8]`` (or similar
+    short form) for human-readable headers.
+    """
+
+    conv_title: str | None
+    """Conversation title, or ``None`` if the conversation has no
+    title yet (fresh sync, no first-user-message fallback applied)."""
+
+    conv_created_at: datetime | None
+    """The conversation's ``created_at``. Distinct from the per-
+    message ``timestamp`` — Issue #181 explicitly filters by event
+    timestamp, not ``created_at``, but we still render ``created_at``
+    in the conversation header for context."""
+
+    source: str
+    """``"local"`` or ``"cloud"``, propagated from the parent
+    conversation row."""
+
+    event_count: int
+    """Number of events in the parent conversation, displayed in the
+    text-mode header for context."""
+
+    timestamp: datetime
+    """The user message's own ``timestamp`` field. The date predicate
+    in :func:`extract_user_messages` runs against this value."""
+
+    text: str
+    """Full message text. Multi-part ``llm_message.content`` arrays
+    are joined with ``\\n`` (matching
+    :func:`ohtv.cli._extract_message_content`). Truncation is the
+    renderer's responsibility — this dataclass always carries the
+    untruncated text."""
+
+
+@dataclass
+class ConversationMessages:
+    """All in-range user messages for a single conversation.
+
+    Returned by :func:`collect_messages` as a list, one entry per
+    conversation that has at least one matching message. Conversations
+    with zero matching messages are dropped before this list is
+    handed back (they're still counted toward
+    ``total_conversations`` though — pagination is by conversation,
+    not by message).
+    """
+
+    conv: "ConversationInfo"
+    """The parent conversation row (carries id, title,
+    created_at, event_count, source — all the fields the text-mode
+    header needs)."""
+
+    messages: list[UserMessage] = field(default_factory=list)
+    """In-range user messages, ordered by timestamp ascending. The
+    text renderer prints them in this order under the conversation
+    header."""
+
+
+# ---------------------------------------------------------------------------
+# Event extraction — Pass 2 of the two-pass design.
+# ---------------------------------------------------------------------------
+
+
+def _extract_message_content(event: dict) -> str:
+    """Return the text payload of a user MessageEvent.
+
+    Mirrors :func:`ohtv.cli._extract_message_content` verbatim — the
+    same shape handling for ``llm_message.content`` (list of typed
+    parts, plain string, or top-level ``content`` fallback). Kept as a
+    private helper here so :mod:`ohtv.messages` does not depend on the
+    Click monolith.
+    """
+    llm_msg = event.get("llm_message", {})
+    content = llm_msg.get("content", [])
+
+    if isinstance(content, list):
+        texts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                texts.append(item.get("text", ""))
+        return "\n".join(texts)
+
+    if isinstance(content, str):
+        return content
+
+    # Fallback for direct content field on the event.
+    return event.get("content", "")
+
+
+def _parse_event_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 timestamp string. Returns ``None`` on failure.
+
+    Events are written with microseconds-and-no-zone (cloud) or with a
+    trailing ``Z`` (some local CLI versions). We strip both before
+    calling :meth:`datetime.fromisoformat` for compatibility with
+    Python 3.10's stricter parser.
+    """
+    if not value:
+        return None
+    cleaned = value.rstrip("Z").split("+")[0]
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def _load_events(conv_dir: Path) -> list[dict]:
+    """Load all event JSON files from ``conv_dir/events`` in name order.
+
+    Mirrors :func:`ohtv.cli._load_events`: ``sorted(glob)`` for
+    deterministic order, malformed or unreadable files are silently
+    skipped (the CLI absorbs the same exceptions on the same code
+    path). Returns an empty list if the events directory is missing.
+    """
+    events_dir = conv_dir / "events"
+    if not events_dir.exists():
+        return []
+
+    events: list[dict] = []
+    for event_file in sorted(events_dir.glob("event-*.json")):
+        try:
+            events.append(json.loads(event_file.read_text()))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return events
+
+
+def _is_aware(dt: datetime) -> bool:
+    """Return ``True`` if ``dt`` carries a tzinfo."""
+    return dt.tzinfo is not None
+
+
+def _coerce_naive(dt: datetime) -> datetime:
+    """Drop tzinfo on aware datetimes so comparisons stay total.
+
+    Event timestamps in fixture data are naive (cloud writes them
+    without a trailing ``Z`` zone). The CLI passes ``since`` / ``until``
+    through :func:`ohtv.cli._parse_date_option` which can yield either
+    aware or naive datetimes depending on input format. We coerce both
+    sides to naive before comparison rather than risk a
+    ``TypeError: can't compare offset-naive and offset-aware``.
+    """
+    return dt.replace(tzinfo=None) if _is_aware(dt) else dt
+
+
+def extract_user_messages(
+    conv: "ConversationInfo",
+    conv_dir: Path,
+    *,
+    since: datetime | None,
+    until: datetime | None,
+) -> list[UserMessage]:
+    """Extract in-range user messages from a single conversation directory.
+
+    Filters at the event level:
+
+    * ``source == "user"`` (drops agent / environment events).
+    * ``kind == "MessageEvent"`` (drops user-mode tool results, etc.
+      — there shouldn't be any, but we're defensive).
+    * Optional ``timestamp >= since`` and ``timestamp < until``
+      (matching the existing CLI ``--since`` / ``--until`` half-open
+      convention).
+
+    Multi-part ``llm_message.content`` arrays are concatenated with
+    ``\\n``. Events with malformed JSON or missing timestamps are
+    skipped silently (the parent ``_load_events`` swallows the
+    decode error; an event lacking a timestamp cannot be range-
+    filtered and is dropped rather than guessed).
+
+    Returns the surviving messages sorted by timestamp ascending — the
+    same order :func:`collect_messages` and the text renderer expect.
+    """
+    norm_since = _coerce_naive(since) if since else None
+    norm_until = _coerce_naive(until) if until else None
+
+    out: list[UserMessage] = []
+    for event in _load_events(conv_dir):
+        if event.get("source") != "user":
+            continue
+        if event.get("kind") != "MessageEvent":
+            continue
+
+        ts = _parse_event_timestamp(event.get("timestamp"))
+        if ts is None:
+            continue
+
+        norm_ts = _coerce_naive(ts)
+        if norm_since is not None and norm_ts < norm_since:
+            continue
+        if norm_until is not None and norm_ts >= norm_until:
+            continue
+
+        text = _extract_message_content(event)
+        # An empty user message is a Click "send" with no payload —
+        # we still surface it; the renderer will show "(empty)" if
+        # the consumer cares (out of scope for v1; we emit "").
+        out.append(
+            UserMessage(
+                conv_id=conv.id.replace("-", ""),
+                conv_title=conv.title,
+                conv_created_at=conv.created_at,
+                source=conv.source,
+                event_count=conv.event_count or 0,
+                timestamp=norm_ts,
+                text=text,
+            )
+        )
+
+    out.sort(key=lambda m: m.timestamp)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Conversation aggregation — the public entry point for the CLI handler.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_conversation_dir(
+    config: "Config", conv: "ConversationInfo"
+) -> Path | None:
+    """Resolve a ConversationInfo to its on-disk directory.
+
+    The DB stores ``conversations.location`` as the absolute (or
+    config-relative) directory — but the value can become stale if the
+    user moves the ohtv data dir. We prefer the canonical
+    ``<source>_conversations_dir / <dir_name>`` layout (using
+    ``conv.dir_name`` which is the dashless 32-char id, per AGENTS.md
+    item #14), falling back to ``conv.location`` when that path
+    doesn't exist.
+    """
+    dir_name = conv.dir_name or conv.id.replace("-", "")
+
+    candidates: list[Path] = []
+    if conv.source == "local":
+        candidates.append(config.local_conversations_dir / dir_name)
+    elif conv.source == "cloud":
+        candidates.append(config.synced_conversations_dir / dir_name)
+    else:  # Extra paths or unknown source — try both standard dirs.
+        candidates.append(config.synced_conversations_dir / dir_name)
+        candidates.append(config.local_conversations_dir / dir_name)
+
+    # Extra conversation paths (rare, but supported).
+    for extra in config.extra_conversation_paths:
+        candidates.append(extra / dir_name)
+
+    for cand in candidates:
+        if cand.exists():
+            return cand
+
+    return None
+
+
+def collect_messages(
+    config: "Config",
+    *,
+    since: datetime | None,
+    until: datetime | None,
+    source: str | None,
+    repo: str | None,
+    label: str | None,
+    include_subs: bool,
+    limit: int | None,
+    offset: int,
+) -> tuple[list[ConversationMessages], int, int]:
+    """Two-pass collection of in-range user messages.
+
+    Pass 1 (DB):
+
+    * Open a ``get_connection()`` and call
+      :meth:`ConversationStore.list_by_event_date_range` — the single
+      SQL owner introduced in #180. This returns conversations whose
+      engagement span overlaps ``[since, until]``, with the same
+      ``source`` / ``include_subs`` filters the rest of the CLI uses.
+
+    * Apply ``--repo`` / ``--label`` in Python via
+      :func:`ohtv.cli._filter_by_repo` / :func:`ohtv.cli._filter_by_label`
+      so we don't duplicate the join logic.
+
+    * Apply ``--offset`` then ``--max`` (or ``--all``) at the
+      conversation grain (AC #4: pagination is BY CONVERSATION).
+
+    Pass 2 (FS): for each surviving conversation, load events from
+    disk and keep the in-range user messages. Conversations that end
+    up with zero such messages are dropped from the output but still
+    counted toward ``total_conversations`` — that's what the user is
+    paging through and what the footer hint reports.
+
+    Returns:
+        ``(displayed_groups, total_conversations, total_messages)``.
+
+        * ``displayed_groups`` is the list of conversations that
+          survive both the pagination window AND have ≥1 user message
+          in range, sorted by most-recent in-range user message
+          descending (newest first).
+        * ``total_conversations`` is the count BEFORE applying
+          ``offset`` / ``limit`` — the denominator in the
+          "Showing K of N" footer. We use the DB candidate count for
+          this rather than walking every conversation's events
+          (which would defeat the cost ceiling).
+        * ``total_messages`` is the count across the *displayed*
+          groups only. The full-history count would require Pass 2
+          over every candidate; we deliberately do not pay that cost.
+    """
+    from ohtv.conversations import _db_conv_to_info
+    from ohtv.db import get_connection, get_db_path
+    from ohtv.db.stores import ConversationStore
+
+    # ---- Pass 1: DB candidates ---------------------------------------
+    db_path = get_db_path()
+    if not db_path.exists():
+        # Without a DB we have no engagement table and therefore no
+        # cheap candidate set. The CLI's empty-result path will render
+        # the appropriate hint.
+        return [], 0, 0
+
+    with get_connection() as conn:
+        store = ConversationStore(conn)
+        db_convs = store.list_by_event_date_range(
+            since=since,
+            until=until,
+            source=source,
+            include_subs=include_subs,
+        )
+
+    # Convert to ConversationInfo so the existing repo/label filters
+    # accept them. ``_db_conv_to_info`` carries dashed ids forward to
+    # match what the filter helpers expect.
+    candidates: list[ConversationInfo] = [
+        _db_conv_to_info(c) for c in db_convs
+    ]
+
+    # Apply non-date filters via the existing helpers. We deliberately
+    # call them as siblings rather than going through
+    # ``_apply_conversation_filters`` because that helper also
+    # re-runs the DB date predicate (which we already pushed through
+    # ``list_by_event_date_range``).
+    from ohtv.cli import _filter_by_label, _filter_by_repo
+
+    if repo is not None:
+        candidates = _filter_by_repo(
+            candidates, repo, include_subs=include_subs
+        )
+    if label is not None:
+        candidates = _filter_by_label(
+            config, candidates, label, include_subs=include_subs
+        )
+
+    total_conversations = len(candidates)
+
+    # ---- Pagination at the conversation grain (AC) -------------------
+    if offset:
+        candidates = candidates[offset:]
+    if limit is not None:
+        candidates = candidates[:limit]
+
+    # ---- Pass 2: load events from disk for the displayed window ------
+    groups: list[ConversationMessages] = []
+    total_messages = 0
+
+    for conv in candidates:
+        conv_dir = _resolve_conversation_dir(config, conv)
+        if conv_dir is None:
+            # Conversation row exists in the DB but the directory is
+            # missing on disk — skip silently (matches ``ohtv show``
+            # which renders an "events_dir does not exist" hint and
+            # carries on).
+            continue
+
+        messages = extract_user_messages(
+            conv, conv_dir, since=since, until=until,
+        )
+        if not messages:
+            # Pass 1 returned this conversation because *some* event
+            # was in range, but no user message was. Drop it from the
+            # output — the count still surfaces via Pass 1's
+            # ``total_conversations``.
+            continue
+
+        groups.append(ConversationMessages(conv=conv, messages=messages))
+        total_messages += len(messages)
+
+    # Sort by most-recent in-range user message timestamp descending,
+    # so "what did I most recently say" surfaces first. The
+    # ``list_by_event_date_range`` query already sorts by
+    # ``last_event_ts DESC``, but that includes non-user events; we
+    # re-sort here by the strictly-user-message timestamp to match the
+    # documented contract. Secondary stable sort by conv.id for
+    # determinism in tests.
+    groups.sort(
+        key=lambda g: (
+            -g.messages[-1].timestamp.timestamp(),
+            g.conv.id,
+        )
+    )
+
+    return groups, total_conversations, total_messages
+
+
+# ---------------------------------------------------------------------------
+# Truncation / single-line helpers used by the CLI renderers.
+# ---------------------------------------------------------------------------
+
+
+def truncate_text(
+    text: str, max_chars: int = TEXT_TRUNCATION_CHARS
+) -> str:
+    """Truncate ``text`` to ``max_chars`` chars with a single-character
+    ellipsis suffix.
+
+    Used by the ``text`` renderer when ``--full`` is not set. Matches
+    the AC "truncate to 500 chars + …". The suffix is the Unicode
+    ellipsis (U+2026), which is one code point but one display column.
+    Empty / short strings are returned unchanged.
+    """
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "…"
+
+
+def collapse_to_single_line(text: str) -> str:
+    """Collapse newlines and tabs so a message fits a single tab-delimited line.
+
+    Used exclusively by the ``raw`` (``-1``) renderer where each
+    message must be a single line of the form::
+
+        <conv_id_short>\\t<ISO_timestamp>\\t<text>
+
+    ``\\n`` and ``\\r`` collapse to a visible ``⏎``; literal tabs in
+    the message collapse to four spaces so they don't pollute the
+    column layout downstream consumers ``cut``/``awk`` on.
+    """
+    # ``\r\n`` first so we don't double-substitute it.
+    out = text.replace("\r\n", "⏎").replace("\n", "⏎").replace("\r", "⏎")
+    out = out.replace("\t", "    ")
+    return out

--- a/tests/unit/test_cli_messages.py
+++ b/tests/unit/test_cli_messages.py
@@ -1,0 +1,579 @@
+"""CliRunner integration tests for ``ohtv messages`` (Issue #181).
+
+Exercises the Click handler end-to-end: flag wiring, format dispatch
+(``text`` / ``json`` / ``raw``), the ``-1`` shorthand, pagination
+math, empty-result hints, and 500-char truncation. Seeds a real OHTV
+DB + on-disk events so we hit the SAME SQL path
+(:meth:`ConversationStore.list_by_event_date_range`) the CLI uses in
+production — no mocks.
+
+Pattern lifted from ``tests/unit/test_cli_event_dates_filter.py``
+which #180 introduced for the same shape of test.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from ohtv.cli import main
+
+
+# ---------------------------------------------------------------------------
+# Test ids + clock. Using a fixed T0 keeps the assertions stable across
+# wall-clock drift.
+# ---------------------------------------------------------------------------
+ID_A = "a" * 32
+ID_B = "b" * 32
+ID_C = "c" * 32
+ID_D = "d" * 32
+
+T0 = datetime(2026, 6, 1, 12, 0)
+
+
+def _write_event(conv_dir: Path, idx: int, event: dict) -> None:
+    events_dir = conv_dir / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    eid = event.get("id", f"e{idx:05d}")
+    (events_dir / f"event-{idx:05d}-{eid}.json").write_text(_json.dumps(event))
+
+
+def _user_evt(idx: int, ts: datetime, text: str) -> dict:
+    return {
+        "id": f"u-{idx}",
+        "timestamp": ts.isoformat(),
+        "source": "user",
+        "kind": "MessageEvent",
+        "llm_message": {
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+@pytest.fixture
+def seeded_cli_env(tmp_path, monkeypatch):
+    """Seed three conversations with user messages and a fourth with
+    only an action event (no user messages).
+
+    * Conv A (cloud, "Auth feature"): 2 user messages at T0 and T0+10m.
+    * Conv B (cloud, "Bug fix"):      1 user message at T0+1d.
+    * Conv C (local, "Local task"):   1 user message at T0+2d.
+    * Conv D (cloud, "No messages"):  only an agent action event.
+    """
+    monkeypatch.setenv("OHTV_DIR", str(tmp_path / "ohtv"))
+    monkeypatch.setenv("OHTV_CONVERSATIONS_DIR", str(tmp_path / "local"))
+    monkeypatch.setenv("OHTV_SYNCED_CONVERSATIONS_DIR", str(tmp_path / "cloud"))
+    monkeypatch.setenv("OPENHANDS_BASE_DIR", str(tmp_path / "oh"))
+
+    from ohtv.config import Config
+    from ohtv.db import get_ready_connection
+    from ohtv.db.models.conversation import Conversation
+    from ohtv.db.stores import ConversationStore
+
+    config = Config.from_env()
+    cloud_dir = config.synced_conversations_dir
+    local_dir = config.local_conversations_dir
+    cloud_dir.mkdir(parents=True, exist_ok=True)
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    # ---- Disk ----
+    _write_event(cloud_dir / ID_A, 0, _user_evt(0, T0, "How do I add OAuth?"))
+    _write_event(cloud_dir / ID_A, 1, _user_evt(1, T0 + timedelta(minutes=10), "Also email/password please."))
+
+    _write_event(cloud_dir / ID_B, 0, _user_evt(0, T0 + timedelta(days=1), "There's a memory leak."))
+
+    _write_event(local_dir / ID_C, 0, _user_evt(0, T0 + timedelta(days=2), "Local task message"))
+
+    # Conv D — only an action event, no user MessageEvent.
+    _write_event(
+        cloud_dir / ID_D,
+        0,
+        {
+            "id": "act-0",
+            "timestamp": (T0 + timedelta(hours=2)).isoformat(),
+            "source": "agent",
+            "kind": "ActionEvent",
+            "action": {"command": "ls", "kind": "TerminalAction"},
+            "tool_name": "terminal",
+        },
+    )
+
+    # ---- DB ----
+    specs = [
+        (ID_A, "Auth feature", "cloud", T0 - timedelta(days=30), T0, T0 + timedelta(minutes=10), 2, str(cloud_dir / ID_A)),
+        (ID_B, "Bug fix",      "cloud", T0 - timedelta(days=5),  T0 + timedelta(days=1), T0 + timedelta(days=1), 1, str(cloud_dir / ID_B)),
+        (ID_C, "Local task",   "local", T0 - timedelta(days=1),  T0 + timedelta(days=2), T0 + timedelta(days=2), 1, str(local_dir / ID_C)),
+        (ID_D, "No messages",  "cloud", T0 - timedelta(days=2),  T0 + timedelta(hours=2), T0 + timedelta(hours=2), 1, str(cloud_dir / ID_D)),
+    ]
+
+    with get_ready_connection(show_progress=False) as conn:
+        store = ConversationStore(conn)
+        for cid, title, source, created, first_ts, last_ts, ev_count, loc in specs:
+            store.upsert(
+                Conversation(
+                    id=cid,
+                    location=loc,
+                    event_count=ev_count,
+                    title=title,
+                    created_at=created,
+                    updated_at=last_ts,
+                    source=source,
+                )
+            )
+            conn.execute(
+                "INSERT INTO conversation_engagement "
+                "(conversation_id, threshold_seconds, first_event_ts, "
+                "last_event_ts, total_duration_seconds, engaged_seconds, "
+                "attention_periods, follow_up_user_message_count, "
+                "attended_user_message_count, processed_at, event_count) "
+                "VALUES (?, ?, ?, ?, ?, ?, 1, 0, 0, ?, ?)",
+                (
+                    cid, 420,
+                    first_ts.isoformat(),
+                    last_ts.isoformat(),
+                    int((last_ts - first_ts).total_seconds()) or 1,
+                    600,
+                    T0.isoformat(),
+                    ev_count,
+                ),
+            )
+        conn.commit()
+
+    yield config
+
+
+def _invoke(*args) -> tuple[int, str]:
+    runner = CliRunner()
+    # Wide terminal so rich doesn't insert line breaks mid-token.
+    result = runner.invoke(main, list(args), env={"COLUMNS": "200"})
+    return result.exit_code, result.output
+
+
+# ===========================================================================
+# Format dispatch + -1 shorthand
+# ===========================================================================
+
+
+class TestFormatDispatch:
+    def test_default_text_format(self, seeded_cli_env):
+        exit_code, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+        )
+        assert exit_code == 0, out
+        # Text format prints conversation headers.
+        assert "Conversation:" in out
+        # Footer reports counts.
+        assert "Showing" in out and "conversations" in out
+        assert "messages)" in out
+
+    def test_format_json_emits_documented_shape(self, seeded_cli_env):
+        exit_code, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-F", "json",
+        )
+        assert exit_code == 0, out
+        data = _json.loads(out)
+        assert {"total_conversations", "total_messages", "offset",
+                "limit", "conversations"}.issubset(data.keys())
+        assert isinstance(data["conversations"], list)
+        for conv in data["conversations"]:
+            assert {"id", "title", "created_at", "source",
+                    "event_count", "messages"}.issubset(conv.keys())
+            assert isinstance(conv["messages"], list)
+            for m in conv["messages"]:
+                assert {"timestamp", "text"} == set(m.keys())
+
+    def test_format_raw_one_line_per_message(self, seeded_cli_env):
+        exit_code, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-F", "raw",
+        )
+        assert exit_code == 0, out
+        # Strip trailing newline so an empty last line doesn't inflate count.
+        lines = out.rstrip("\n").splitlines()
+        # 4 user messages in the [05-31, 06-04) range: A×2, B×1, C×1.
+        assert len(lines) == 4
+        # Each line is tab-separated: short_id, ISO timestamp, text.
+        for line in lines:
+            parts = line.split("\t")
+            assert len(parts) == 3
+            assert len(parts[0]) == 8  # short id
+            assert parts[1].endswith("Z")  # ISO Z timestamp
+            assert "\n" not in parts[2]
+
+    def test_dash_one_aliases_raw(self, seeded_cli_env):
+        """``-1`` must produce identical output to ``-F raw``."""
+        rc1, out_raw = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-F", "raw",
+        )
+        rc2, out_dash = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-1",
+        )
+        assert rc1 == rc2 == 0
+        assert out_raw == out_dash
+
+
+# ===========================================================================
+# Pagination — by conversation, not by message
+# ===========================================================================
+
+
+class TestPagination:
+    def test_default_limit_is_ten(self, seeded_cli_env):
+        """Documented default cap is 10 conversations."""
+        exit_code, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-F", "json",
+        )
+        data = _json.loads(out)
+        assert data["limit"] == 10
+        assert data["offset"] == 0
+
+    def test_all_drops_cap(self, seeded_cli_env):
+        exit_code, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "--all", "-F", "json",
+        )
+        data = _json.loads(out)
+        assert data["limit"] is None
+
+    def test_offset_skips_first_n_conversations(self, seeded_cli_env):
+        """``--offset 1`` drops the most-recent conversation only.
+
+        Sort order is newest-first by last in-range user message → Conv C
+        (T0+2d) first, then Conv B (T0+1d), then Conv A (T0+10m).
+        """
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "--offset", "1", "-F", "json",
+        )
+        data = _json.loads(out)
+        ids = [c["id"] for c in data["conversations"]]
+        # First entry (Conv C) is skipped; B and A remain.
+        assert ids[0] == ID_B
+        # offset is echoed in the response.
+        assert data["offset"] == 1
+
+    def test_within_conversation_all_messages_render(self, seeded_cli_env):
+        """Conv A has 2 user messages; both must appear under a single
+        conversation entry (no per-message cap)."""
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-F", "json",
+        )
+        data = _json.loads(out)
+        conv_a = next(c for c in data["conversations"] if c["id"] == ID_A)
+        assert len(conv_a["messages"]) == 2
+
+    def test_text_footer_reports_next_offset_when_paginating(self, seeded_cli_env):
+        """When a strict ``-n`` window leaves more conversations
+        behind, the footer surfaces the next ``--offset`` hint."""
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-n", "1",
+        )
+        assert "Showing 1 of" in out
+        assert "Next: --offset 1" in out
+
+
+# ===========================================================================
+# Date filtering wired through _parse_date_filters
+# ===========================================================================
+
+
+class TestDateFilters:
+    def test_since_filters_by_event_timestamp(self, seeded_cli_env):
+        """A conversation created 30d before T0 with a fresh message
+        still surfaces — the predicate runs against event timestamp."""
+        # Conv A was created 30 days before T0 but has user messages at
+        # T0; ``--since T0-1d`` must include it.
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "-F", "json",
+        )
+        data = _json.loads(out)
+        ids = {c["id"] for c in data["conversations"]}
+        assert ID_A in ids
+
+    def test_until_excludes_future_messages(self, seeded_cli_env):
+        """``--until`` is exclusive; messages at-or-after are excluded."""
+        # Conv B's message is at T0+1d; until=T0+1d excludes it.
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31",
+            "--until", "2026-06-02",
+            "-F", "json",
+        )
+        data = _json.loads(out)
+        ids = {c["id"] for c in data["conversations"]}
+        # Conv A is at T0 (in), Conv B at T0+1d == until (excluded).
+        assert ID_A in ids
+        assert ID_B not in ids
+
+
+# ===========================================================================
+# Source / repo / label scoping
+# ===========================================================================
+
+
+class TestSourceFilter:
+    def test_source_local_only(self, seeded_cli_env):
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "--source", "local", "-F", "json",
+        )
+        data = _json.loads(out)
+        ids = {c["id"] for c in data["conversations"]}
+        # Only Conv C is local.
+        assert ids == {ID_C}
+
+    def test_source_cloud_excludes_local(self, seeded_cli_env):
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "--source", "cloud", "-F", "json",
+        )
+        data = _json.loads(out)
+        ids = {c["id"] for c in data["conversations"]}
+        assert ID_C not in ids
+        # Conv A and Conv B remain (both cloud).
+        assert {ID_A, ID_B}.issubset(ids)
+
+
+# ===========================================================================
+# Truncation + --full
+# ===========================================================================
+
+
+class TestTruncation:
+    def test_text_mode_truncates_long_messages(self, tmp_path, monkeypatch):
+        """A 600-char user message renders with ``…`` suffix by default."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path / "ohtv"))
+        monkeypatch.setenv("OHTV_CONVERSATIONS_DIR", str(tmp_path / "local"))
+        monkeypatch.setenv("OHTV_SYNCED_CONVERSATIONS_DIR", str(tmp_path / "cloud"))
+        monkeypatch.setenv("OPENHANDS_BASE_DIR", str(tmp_path / "oh"))
+
+        from ohtv.config import Config
+        from ohtv.db import get_ready_connection
+        from ohtv.db.models.conversation import Conversation
+        from ohtv.db.stores import ConversationStore
+
+        config = Config.from_env()
+        long_text = "x" * 600
+        cloud_dir = config.synced_conversations_dir
+        cloud_dir.mkdir(parents=True, exist_ok=True)
+        _write_event(cloud_dir / ID_A, 0, _user_evt(0, T0, long_text))
+
+        with get_ready_connection(show_progress=False) as conn:
+            store = ConversationStore(conn)
+            store.upsert(
+                Conversation(
+                    id=ID_A,
+                    location=str(cloud_dir / ID_A),
+                    event_count=1,
+                    title="Long",
+                    created_at=T0,
+                    updated_at=T0,
+                    source="cloud",
+                )
+            )
+            conn.execute(
+                "INSERT INTO conversation_engagement "
+                "(conversation_id, threshold_seconds, first_event_ts, "
+                "last_event_ts, total_duration_seconds, engaged_seconds, "
+                "attention_periods, follow_up_user_message_count, "
+                "attended_user_message_count, processed_at, event_count) "
+                "VALUES (?, ?, ?, ?, ?, ?, 1, 0, 0, ?, 1)",
+                (
+                    ID_A, 420,
+                    T0.isoformat(),
+                    T0.isoformat(),
+                    1, 600, T0.isoformat(),
+                ),
+            )
+            conn.commit()
+
+        # Default (no --full) → text-mode output truncates.
+        _, default_out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-02",
+        )
+        assert "…" in default_out
+        # The truncated body holds at most 500 ``x`` characters.
+        max_run = max((len(s) for s in default_out.split() if s.startswith("x")), default=0)
+        assert max_run <= 500
+
+        # ``--full`` → entire 600 chars present.
+        _, full_out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-02",
+            "--full",
+        )
+        # Allow rich to wrap; just check the full repetition appears.
+        assert ("x" * 600) in full_out.replace("\n", "")
+
+    def test_json_always_carries_full_text(self, tmp_path, monkeypatch):
+        """``json`` and ``raw`` ignore the 500-char cap (AC).
+
+        Even without ``--full``, machine-readable formats see the
+        whole message body.
+        """
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path / "ohtv"))
+        monkeypatch.setenv("OHTV_CONVERSATIONS_DIR", str(tmp_path / "local"))
+        monkeypatch.setenv("OHTV_SYNCED_CONVERSATIONS_DIR", str(tmp_path / "cloud"))
+        monkeypatch.setenv("OPENHANDS_BASE_DIR", str(tmp_path / "oh"))
+
+        from ohtv.config import Config
+        from ohtv.db import get_ready_connection
+        from ohtv.db.models.conversation import Conversation
+        from ohtv.db.stores import ConversationStore
+
+        config = Config.from_env()
+        long_text = "x" * 700
+        cloud_dir = config.synced_conversations_dir
+        cloud_dir.mkdir(parents=True, exist_ok=True)
+        _write_event(cloud_dir / ID_A, 0, _user_evt(0, T0, long_text))
+
+        with get_ready_connection(show_progress=False) as conn:
+            store = ConversationStore(conn)
+            store.upsert(
+                Conversation(
+                    id=ID_A, location=str(cloud_dir / ID_A),
+                    event_count=1, title="L", created_at=T0, updated_at=T0,
+                    source="cloud",
+                )
+            )
+            conn.execute(
+                "INSERT INTO conversation_engagement "
+                "(conversation_id, threshold_seconds, first_event_ts, "
+                "last_event_ts, total_duration_seconds, engaged_seconds, "
+                "attention_periods, follow_up_user_message_count, "
+                "attended_user_message_count, processed_at, event_count) "
+                "VALUES (?, ?, ?, ?, ?, ?, 1, 0, 0, ?, 1)",
+                (ID_A, 420, T0.isoformat(), T0.isoformat(), 1, 600, T0.isoformat()),
+            )
+            conn.commit()
+
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-02",
+            "-F", "json",
+        )
+        data = _json.loads(out)
+        assert data["conversations"][0]["messages"][0]["text"] == long_text
+
+
+# ===========================================================================
+# Empty-result path
+# ===========================================================================
+
+
+class TestEmptyResult:
+    def test_text_empty_prints_hint(self, seeded_cli_env):
+        """Range with no user messages → ``No user messages in range.``
+        + engagement-stage hint, exit 0."""
+        # Far-future range → nothing.
+        exit_code, out = _invoke(
+            "messages", "--since", "2030-01-01", "--until", "2030-01-02",
+        )
+        assert exit_code == 0
+        assert "No user messages in range." in out
+        # Hint mentions the engagement stage so users know where to look.
+        assert "engagement" in out.lower() or "sync" in out.lower()
+
+    def test_json_empty_renders_zero_totals(self, seeded_cli_env):
+        exit_code, out = _invoke(
+            "messages", "--since", "2030-01-01", "--until", "2030-01-02",
+            "-F", "json",
+        )
+        assert exit_code == 0
+        data = _json.loads(out)
+        assert data["total_conversations"] == 0
+        assert data["total_messages"] == 0
+        assert data["conversations"] == []
+
+    def test_raw_empty_prints_nothing(self, seeded_cli_env):
+        """``raw`` mode on empty input prints zero output — clean for
+        pipelines that don't want a hint on stdout."""
+        exit_code, out = _invoke(
+            "messages", "--since", "2030-01-01", "--until", "2030-01-02",
+            "-1",
+        )
+        assert exit_code == 0
+        assert out.strip() == ""
+
+
+# ===========================================================================
+# Sub-conversation handling (#127 plumbing)
+# ===========================================================================
+
+
+class TestSubConversations:
+    def test_default_excludes_subs(self, tmp_path, monkeypatch):
+        """Default (no ``--include-sub-conversations``): only roots
+        contribute messages."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path / "ohtv"))
+        monkeypatch.setenv("OHTV_CONVERSATIONS_DIR", str(tmp_path / "local"))
+        monkeypatch.setenv("OHTV_SYNCED_CONVERSATIONS_DIR", str(tmp_path / "cloud"))
+        monkeypatch.setenv("OPENHANDS_BASE_DIR", str(tmp_path / "oh"))
+
+        from ohtv.config import Config
+        from ohtv.db import get_ready_connection
+        from ohtv.db.stores import ConversationStore
+        from ohtv.db.models.conversation import Conversation
+
+        config = Config.from_env()
+        cloud_dir = config.synced_conversations_dir
+        cloud_dir.mkdir(parents=True, exist_ok=True)
+
+        # Root (A) and a sub of A (B). Each has a user message in range.
+        _write_event(cloud_dir / ID_A, 0, _user_evt(0, T0, "root msg"))
+        _write_event(cloud_dir / ID_B, 0, _user_evt(0, T0, "sub msg"))
+
+        with get_ready_connection(show_progress=False) as conn:
+            store = ConversationStore(conn)
+            store.upsert(
+                Conversation(
+                    id=ID_A, location=str(cloud_dir / ID_A),
+                    event_count=1, title="Root", created_at=T0, updated_at=T0,
+                    source="cloud",
+                )
+            )
+            store.upsert(
+                Conversation(
+                    id=ID_B, location=str(cloud_dir / ID_B),
+                    event_count=1, title="Sub", created_at=T0, updated_at=T0,
+                    source="cloud",
+                    parent_conversation_id=ID_A,
+                )
+            )
+            for cid in (ID_A, ID_B):
+                conn.execute(
+                    "INSERT INTO conversation_engagement "
+                    "(conversation_id, threshold_seconds, first_event_ts, "
+                    "last_event_ts, total_duration_seconds, engaged_seconds, "
+                    "attention_periods, follow_up_user_message_count, "
+                    "attended_user_message_count, processed_at, event_count) "
+                    "VALUES (?, ?, ?, ?, ?, ?, 1, 0, 0, ?, 1)",
+                    (cid, 420, T0.isoformat(), T0.isoformat(), 1, 600, T0.isoformat()),
+                )
+            conn.commit()
+
+        # Default (roots-only) — only Conv A appears.
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-02",
+            "-F", "json",
+        )
+        data = _json.loads(out)
+        ids = {c["id"] for c in data["conversations"]}
+        assert ids == {ID_A}
+
+        # ``--include-sub-conversations`` — both appear.
+        _, out_with_subs = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-02",
+            "--include-sub-conversations", "-F", "json",
+        )
+        data_subs = _json.loads(out_with_subs)
+        ids_subs = {c["id"] for c in data_subs["conversations"]}
+        assert ids_subs == {ID_A, ID_B}

--- a/tests/unit/test_cli_messages.py
+++ b/tests/unit/test_cli_messages.py
@@ -274,13 +274,82 @@ class TestPagination:
 
     def test_text_footer_reports_next_offset_when_paginating(self, seeded_cli_env):
         """When a strict ``-n`` window leaves more conversations
-        behind, the footer surfaces the next ``--offset`` hint."""
+        behind, the footer surfaces the next ``--offset`` hint.
+
+        Also locks down the two-pool footer terminology (#181 review
+        round 1): the denominator is "candidate conversations", not
+        plain "conversations", because it counts engagement-joined
+        candidates (which may include message-free convs).
+        """
         _, out = _invoke(
             "messages", "--since", "2026-05-31", "--until", "2026-06-04",
             "-n", "1",
         )
-        assert "Showing 1 of" in out
+        # Fixture has 4 candidates in range (A, B, C, D — D has only an
+        # action event but its engagement row covers the window).
+        assert "Showing 1 of 4 candidate conversations" in out
         assert "Next: --offset 1" in out
+
+    def test_next_link_does_not_overshoot_when_candidates_have_no_messages(
+        self, seeded_cli_env,
+    ):
+        """Regression for the 🟠 review-bot thread on
+        ``src/ohtv/cli.py:6384`` (Issue #181 review round 1).
+
+        Scenario: 4 candidates in range (A, B, C, D). Candidate sort is
+        ``last_event_ts DESC`` → C, B, D, A. Paging with ``-k 2 -n 2``
+        gives us candidates [D, A]; D has no user messages, so
+        ``shown == 1``. The OLD guard ``(offset + shown) < total`` =
+        ``(2 + 1) < 4`` = True would have emitted ``Next: --offset 3``
+        — pointing past the end of the candidate pool. The new guard
+        ``(offset + limit) < total`` = ``(2 + 2) < 4`` = False
+        correctly suppresses the Next link.
+        """
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-n", "2", "-k", "2",
+        )
+        # We showed 1 of 4 candidates on this page (only A had
+        # messages; D was filtered out by Pass 2).
+        assert "Showing 1 of 4 candidate conversations" in out
+        # Critical regression assertion: no Next link.
+        assert "Next:" not in out
+
+    def test_text_footer_uses_candidate_terminology(self, seeded_cli_env):
+        """Lockdown: the word ``candidate`` appears in the footer so
+        future refactors do not silently revert to plain
+        ``conversations`` (which conflates the two pools — see #181
+        review round 1)."""
+        _, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+        )
+        assert "candidate conversations" in out
+
+    def test_empty_page_does_not_show_engagement_hint_when_candidates_exist(
+        self, seeded_cli_env,
+    ):
+        """The engagement-stage hint is for the ``total_convs == 0``
+        path (no candidates → user probably forgot
+        ``ohtv db process engagement``). When candidates exist but the
+        paginated window has zero user messages (#181 review round 1
+        Repro 3), surfacing the engagement hint MISFIRES; show an
+        offset hint instead.
+
+        Scenario: ``-k 2 -n 1`` over the fixture → candidates [D] only,
+        D has no user messages → empty groups, total_convs == 4.
+        """
+        exit_code, out = _invoke(
+            "messages", "--since", "2026-05-31", "--until", "2026-06-04",
+            "-n", "1", "-k", "2",
+        )
+        assert exit_code == 0
+        # New "no messages on this page" wording.
+        assert "No user messages on this page" in out
+        assert "4 candidate conversations in range" in out
+        # Offset-aware hint, NOT the engagement hint.
+        assert "--offset 0" in out
+        # Engagement hint must not fire here.
+        assert "db process engagement" not in out
 
 
 # ===========================================================================

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -1,0 +1,581 @@
+"""Pure-Python unit tests for :mod:`ohtv.messages` (Issue #181).
+
+Covers the message-extraction logic, on-disk event loading, truncation
+and single-line collapse helpers, and the conversation-grouped
+``collect_messages`` aggregator. The CLI surface is tested separately
+in ``test_cli_messages.py`` via :class:`click.testing.CliRunner`.
+
+These tests deliberately avoid mocking
+:meth:`ConversationStore.list_by_event_date_range` — they seed a real
+SQLite database via :func:`get_ready_connection` so we exercise the
+same SQL path the CLI uses. The pattern mirrors
+``tests/unit/test_cli_event_dates_filter.py`` which #180 introduced.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from ohtv.messages import (
+    ConversationMessages,
+    TEXT_TRUNCATION_CHARS,
+    UserMessage,
+    collapse_to_single_line,
+    collect_messages,
+    extract_user_messages,
+    truncate_text,
+)
+from ohtv.sources.base import ConversationInfo
+
+
+# ---------------------------------------------------------------------------
+# Test constants — 32-char dashless hex ids match the on-disk layout
+# and the DB primary key (AGENTS.md item #14).
+# ---------------------------------------------------------------------------
+ID_A = "a" * 32
+ID_B = "b" * 32
+ID_C = "c" * 32
+
+T0 = datetime(2026, 6, 1, 12, 0)  # Naive — matches fixture events.
+
+
+# ---------------------------------------------------------------------------
+# Helpers for writing fixture conversations.
+# ---------------------------------------------------------------------------
+
+
+def _write_event(conv_dir: Path, idx: int, event: dict) -> None:
+    """Write a single event JSON to ``conv_dir/events/event-NNNNN-id.json``.
+
+    Filename matches the production layout (``event-<5digits>-<id>.json``)
+    so :func:`ohtv.messages._load_events`'s ``sorted(glob)`` yields a
+    deterministic order.
+    """
+    events_dir = conv_dir / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    event_id = event.get("id", f"evt{idx:05d}")
+    path = events_dir / f"event-{idx:05d}-{event_id}.json"
+    path.write_text(json.dumps(event))
+
+
+def _user_message_event(idx: int, ts: datetime, text: str | list) -> dict:
+    """Construct a fixture user MessageEvent.
+
+    ``text`` may be a string (rendered as a top-level ``content``
+    fallback) or a list of ``{type, text}`` dicts (the canonical
+    cloud shape).
+    """
+    if isinstance(text, list):
+        content = text
+    else:
+        content = [{"type": "text", "text": text}]
+    return {
+        "id": f"user-{idx}",
+        "timestamp": ts.isoformat(),
+        "source": "user",
+        "kind": "MessageEvent",
+        "llm_message": {"role": "user", "content": content},
+    }
+
+
+def _agent_message_event(idx: int, ts: datetime, text: str) -> dict:
+    """Construct a fixture agent MessageEvent (filtered out by extract)."""
+    return {
+        "id": f"agent-{idx}",
+        "timestamp": ts.isoformat(),
+        "source": "agent",
+        "kind": "MessageEvent",
+        "llm_message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _action_event(idx: int, ts: datetime) -> dict:
+    """Construct a fixture agent ActionEvent (filtered out by extract)."""
+    return {
+        "id": f"act-{idx}",
+        "timestamp": ts.isoformat(),
+        "source": "agent",
+        "kind": "ActionEvent",
+        "action": {"command": "ls", "kind": "TerminalAction"},
+        "tool_name": "terminal",
+    }
+
+
+def _conv_info(
+    conv_id: str,
+    *,
+    title: str = "Test conv",
+    source: str = "cloud",
+    created_at: datetime | None = None,
+    event_count: int = 5,
+) -> ConversationInfo:
+    """Build a ConversationInfo carrying a dashed id (matches what
+    :func:`_db_conv_to_info` returns to the CLI).
+    """
+    return ConversationInfo(
+        id=conv_id,
+        title=title,
+        created_at=created_at,
+        updated_at=created_at,
+        event_count=event_count,
+        source=source,
+        dir_name=conv_id.replace("-", ""),
+    )
+
+
+# ===========================================================================
+# 1. Truncation + single-line helpers (pure functions, no I/O).
+# ===========================================================================
+
+
+class TestTruncateText:
+    def test_short_text_returned_unchanged(self):
+        assert truncate_text("hello", 500) == "hello"
+
+    def test_text_at_boundary_unchanged(self):
+        # Exactly ``max_chars`` characters → no truncation.
+        text = "x" * 500
+        assert truncate_text(text, 500) == text
+
+    def test_text_over_boundary_truncated(self):
+        text = "x" * 600
+        result = truncate_text(text, 500)
+        assert len(result) == 501  # 500 chars + 1 ellipsis char
+        assert result.endswith("…")
+        assert result[:-1] == "x" * 500
+
+    def test_default_cutoff_matches_constant(self):
+        text = "x" * (TEXT_TRUNCATION_CHARS + 10)
+        result = truncate_text(text)
+        assert len(result) == TEXT_TRUNCATION_CHARS + 1
+        assert result.endswith("…")
+
+    def test_zero_or_negative_max_chars_returns_unchanged(self):
+        # Defensive — caller bug; we don't truncate to nothing.
+        assert truncate_text("hello", 0) == "hello"
+        assert truncate_text("hello", -1) == "hello"
+
+
+class TestCollapseToSingleLine:
+    def test_no_newlines_unchanged(self):
+        assert collapse_to_single_line("simple text") == "simple text"
+
+    def test_unix_newlines_become_arrow(self):
+        assert collapse_to_single_line("line1\nline2") == "line1⏎line2"
+
+    def test_windows_newlines_become_single_arrow(self):
+        # ``\r\n`` must NOT produce two arrows.
+        assert collapse_to_single_line("line1\r\nline2") == "line1⏎line2"
+
+    def test_bare_cr_becomes_arrow(self):
+        assert collapse_to_single_line("a\rb") == "a⏎b"
+
+    def test_tabs_collapse_to_spaces(self):
+        # Tabs in user text must not break the tab-delimited raw format.
+        assert collapse_to_single_line("col1\tcol2") == "col1    col2"
+
+    def test_mixed_whitespace(self):
+        text = "line1\nline2\tindent\r\nline3"
+        assert (
+            collapse_to_single_line(text)
+            == "line1⏎line2    indent⏎line3"
+        )
+
+
+# ===========================================================================
+# 2. extract_user_messages — on-disk event filtering.
+# ===========================================================================
+
+
+class TestExtractUserMessages:
+    def test_filters_by_source_and_kind(self, tmp_path):
+        """Only ``source=user`` ``kind=MessageEvent`` events survive.
+
+        Agent messages, agent actions, and any other event type are
+        dropped before timestamp filtering even runs.
+        """
+        conv_dir = tmp_path / "conv"
+        _write_event(conv_dir, 0, _user_message_event(0, T0, "first"))
+        _write_event(conv_dir, 1, _agent_message_event(1, T0 + timedelta(minutes=1), "ack"))
+        _write_event(conv_dir, 2, _action_event(2, T0 + timedelta(minutes=2)))
+        _write_event(conv_dir, 3, _user_message_event(3, T0 + timedelta(minutes=3), "second"))
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=None, until=None)
+
+        assert [m.text for m in msgs] == ["first", "second"]
+        # Conv context is propagated onto every message.
+        assert all(m.conv_id == ID_A for m in msgs)
+        assert all(m.conv_title == "Test conv" for m in msgs)
+        assert all(m.source == "cloud" for m in msgs)
+
+    def test_respects_since_until_half_open(self, tmp_path):
+        """``since`` is inclusive, ``until`` is exclusive (half-open)."""
+        conv_dir = tmp_path / "conv"
+        _write_event(conv_dir, 0, _user_message_event(0, T0, "at-since"))
+        _write_event(conv_dir, 1, _user_message_event(1, T0 + timedelta(minutes=10), "in-range"))
+        _write_event(conv_dir, 2, _user_message_event(2, T0 + timedelta(minutes=30), "at-until"))
+        _write_event(conv_dir, 3, _user_message_event(3, T0 + timedelta(hours=1), "after-until"))
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(
+            conv,
+            conv_dir,
+            since=T0,
+            until=T0 + timedelta(minutes=30),
+        )
+
+        # ``at-since`` (==since) IN, ``at-until`` (==until) OUT.
+        assert [m.text for m in msgs] == ["at-since", "in-range"]
+
+    def test_handles_malformed_json_silently(self, tmp_path):
+        """Corrupt event files are skipped (no exception bubbles up)."""
+        conv_dir = tmp_path / "conv"
+        _write_event(conv_dir, 0, _user_message_event(0, T0, "ok"))
+        # Hand-write a corrupt JSON file.
+        events_dir = conv_dir / "events"
+        (events_dir / "event-00001-bad.json").write_text("{ not json")
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=None, until=None)
+
+        assert len(msgs) == 1
+        assert msgs[0].text == "ok"
+
+    def test_extracts_multipart_content(self, tmp_path):
+        """Multi-part ``llm_message.content`` arrays concatenate with newlines.
+
+        Matches :func:`ohtv.cli._extract_message_content` verbatim.
+        """
+        conv_dir = tmp_path / "conv"
+        _write_event(
+            conv_dir,
+            0,
+            _user_message_event(
+                0,
+                T0,
+                [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            ),
+        )
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=None, until=None)
+
+        assert msgs[0].text == "part one\npart two"
+
+    def test_handles_string_content(self, tmp_path):
+        """Direct ``content: "..."`` string is supported as a fallback."""
+        conv_dir = tmp_path / "conv"
+        event = {
+            "id": "user-0",
+            "timestamp": T0.isoformat(),
+            "source": "user",
+            "kind": "MessageEvent",
+            "llm_message": {"role": "user", "content": "plain string"},
+        }
+        _write_event(conv_dir, 0, event)
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=None, until=None)
+
+        assert msgs[0].text == "plain string"
+
+    def test_sorts_by_timestamp_ascending(self, tmp_path):
+        """Out-of-order filenames still produce chronological results."""
+        conv_dir = tmp_path / "conv"
+        # Write in reverse chronological filename order.
+        _write_event(conv_dir, 0, _user_message_event(0, T0 + timedelta(minutes=20), "late"))
+        _write_event(conv_dir, 1, _user_message_event(1, T0, "early"))
+        _write_event(conv_dir, 2, _user_message_event(2, T0 + timedelta(minutes=10), "middle"))
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=None, until=None)
+
+        assert [m.text for m in msgs] == ["early", "middle", "late"]
+
+    def test_skips_events_without_timestamp(self, tmp_path):
+        """An event without a parseable timestamp is dropped silently."""
+        conv_dir = tmp_path / "conv"
+        _write_event(conv_dir, 0, _user_message_event(0, T0, "ok"))
+        no_ts = {
+            "id": "user-1",
+            "source": "user",
+            "kind": "MessageEvent",
+            "llm_message": {"role": "user", "content": "no timestamp"},
+        }
+        _write_event(conv_dir, 1, no_ts)
+
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=None, until=None)
+
+        assert len(msgs) == 1
+        assert msgs[0].text == "ok"
+
+    def test_missing_events_dir_returns_empty(self, tmp_path):
+        """Conversation directory with no ``events/`` subdir → empty list."""
+        conv_dir = tmp_path / "empty"
+        conv_dir.mkdir()
+        conv = _conv_info(ID_A, created_at=T0)
+        assert extract_user_messages(conv, conv_dir, since=None, until=None) == []
+
+    def test_handles_aware_since_with_naive_event_timestamps(self, tmp_path):
+        """Aware ``since`` doesn't crash when events are naive.
+
+        Cloud event timestamps are written without zone info; CLI
+        ``--since`` may yield aware datetimes. We coerce both to naive
+        rather than raise ``TypeError``.
+        """
+        conv_dir = tmp_path / "conv"
+        _write_event(conv_dir, 0, _user_message_event(0, T0, "in"))
+        _write_event(conv_dir, 1, _user_message_event(1, T0 - timedelta(hours=1), "out"))
+
+        aware_since = T0.replace(tzinfo=timezone.utc) - timedelta(minutes=30)
+        conv = _conv_info(ID_A, created_at=T0)
+        msgs = extract_user_messages(conv, conv_dir, since=aware_since, until=None)
+
+        assert [m.text for m in msgs] == ["in"]
+
+
+# ===========================================================================
+# 3. collect_messages — DB candidate + FS event load integration.
+# ===========================================================================
+
+
+@pytest.fixture
+def seeded_collect_env(tmp_path, monkeypatch):
+    """Seed a real OHTV DB + on-disk conversations for ``collect_messages``.
+
+    Three conversations:
+
+    * ``ID_A`` (cloud) — 2 user messages in [T0, T0+1d], 1 agent msg.
+    * ``ID_B`` (cloud) — 1 user message at T0+2d.
+    * ``ID_C`` (cloud) — 0 user messages, only an action event in range.
+
+    Each has a matching ``conversation_engagement`` row so
+    ``list_by_event_date_range`` includes them.
+    """
+    # Isolate ALL ohtv state inside ``tmp_path``: the SQLite DB
+    # (OHTV_DIR), the local conv dir (OHTV_CONVERSATIONS_DIR), and the
+    # synced cloud conv dir (OHTV_SYNCED_CONVERSATIONS_DIR). Otherwise
+    # ``Config.from_env`` falls back to ``~/.openhands/conversations``
+    # and tests pollute each other's on-disk events.
+    monkeypatch.setenv("OHTV_DIR", str(tmp_path / "ohtv"))
+    monkeypatch.setenv("OPENHANDS_BASE_DIR", str(tmp_path / "oh"))
+    monkeypatch.setenv("OHTV_CONVERSATIONS_DIR", str(tmp_path / "local"))
+    monkeypatch.setenv(
+        "OHTV_SYNCED_CONVERSATIONS_DIR", str(tmp_path / "cloud")
+    )
+
+    from ohtv.config import Config
+    from ohtv.db import get_ready_connection
+    from ohtv.db.models.conversation import Conversation
+    from ohtv.db.stores import ConversationStore
+
+    config = Config.from_env()
+    cloud_dir = config.synced_conversations_dir
+    cloud_dir.mkdir(parents=True, exist_ok=True)
+
+    # ---- On-disk events ----
+    conv_a = cloud_dir / ID_A
+    _write_event(conv_a, 0, _user_message_event(0, T0, "first A message"))
+    _write_event(conv_a, 1, _agent_message_event(1, T0 + timedelta(minutes=30), "agent"))
+    _write_event(conv_a, 2, _user_message_event(2, T0 + timedelta(days=1), "second A message"))
+
+    conv_b = cloud_dir / ID_B
+    _write_event(conv_b, 0, _user_message_event(0, T0 + timedelta(days=2), "only B"))
+
+    conv_c = cloud_dir / ID_C
+    _write_event(conv_c, 0, _action_event(0, T0 + timedelta(hours=3)))
+
+    # ---- DB rows ----
+    specs = [
+        (ID_A, "Conv A", T0 - timedelta(days=10), T0, T0 + timedelta(days=1)),
+        (ID_B, "Conv B", T0 - timedelta(days=5), T0 + timedelta(days=2), T0 + timedelta(days=2)),
+        (ID_C, "Conv C", T0 - timedelta(days=3), T0 + timedelta(hours=3), T0 + timedelta(hours=3)),
+    ]
+
+    with get_ready_connection(show_progress=False) as conn:
+        store = ConversationStore(conn)
+        for cid, title, created, first_ts, last_ts in specs:
+            store.upsert(
+                Conversation(
+                    id=cid,
+                    location=str(cloud_dir / cid),
+                    event_count=3 if cid == ID_A else 1,
+                    title=title,
+                    created_at=created,
+                    updated_at=last_ts,
+                    source="cloud",
+                )
+            )
+            conn.execute(
+                "INSERT INTO conversation_engagement "
+                "(conversation_id, threshold_seconds, first_event_ts, "
+                "last_event_ts, total_duration_seconds, engaged_seconds, "
+                "attention_periods, follow_up_user_message_count, "
+                "attended_user_message_count, processed_at, event_count) "
+                "VALUES (?, ?, ?, ?, ?, ?, 1, 0, 0, ?, ?)",
+                (
+                    cid, 420,
+                    first_ts.isoformat(),
+                    last_ts.isoformat(),
+                    int((last_ts - first_ts).total_seconds()) or 1,
+                    600,
+                    T0.isoformat(),
+                    3 if cid == ID_A else 1,
+                ),
+            )
+        conn.commit()
+
+    yield config
+
+
+class TestCollectMessages:
+    def test_returns_only_conversations_with_user_messages(self, seeded_collect_env):
+        """Conv C is dropped (zero user messages) but still counted."""
+        config = seeded_collect_env
+        groups, total_convs, total_msgs = collect_messages(
+            config,
+            since=T0 - timedelta(days=1),
+            until=T0 + timedelta(days=5),
+            source=None,
+            repo=None,
+            label=None,
+            include_subs=False,
+            limit=None,
+            offset=0,
+        )
+
+        ids = {g.conv.id.replace("-", "") for g in groups}
+        assert ids == {ID_A, ID_B}, "Conv C has no user messages"
+        # total_conversations counts the DB candidate set (includes C).
+        assert total_convs == 3
+        # total_messages counts only the displayed groups.
+        assert total_msgs == 3  # A has 2, B has 1
+
+    def test_filters_by_event_timestamp_not_created_at(self, seeded_collect_env):
+        """A conversation created far outside the range surfaces if its
+        user messages are in range."""
+        config = seeded_collect_env
+        # Conv A was created 10 days before T0 but has messages in range.
+        groups, _, _ = collect_messages(
+            config,
+            since=T0 - timedelta(hours=1),
+            until=T0 + timedelta(hours=1),
+            source=None,
+            repo=None,
+            label=None,
+            include_subs=False,
+            limit=None,
+            offset=0,
+        )
+
+        # Only Conv A has a user message in the [T0-1h, T0+1h] window.
+        ids = {g.conv.id.replace("-", "") for g in groups}
+        assert ids == {ID_A}
+        # And within that window, only the "first A message" qualifies.
+        assert [m.text for m in groups[0].messages] == ["first A message"]
+
+    def test_pagination_offset_and_limit_by_conversation(self, seeded_collect_env):
+        """``offset`` + ``limit`` paginate at the CONVERSATION grain.
+
+        Within a shown conversation, ALL matching user messages render
+        (AC: no per-message cap).
+        """
+        config = seeded_collect_env
+
+        # offset=1, limit=1 → skip the most-recent (B), keep the next (A).
+        groups, total_convs, _ = collect_messages(
+            config,
+            since=T0 - timedelta(days=1),
+            until=T0 + timedelta(days=5),
+            source=None,
+            repo=None,
+            label=None,
+            include_subs=False,
+            limit=1,
+            offset=1,
+        )
+
+        # Both Conv A's user messages render in the single shown conv.
+        assert len(groups) == 1
+        assert len(groups[0].messages) == 2  # No per-message cap.
+        # The candidate denominator still reports all 3 DB convs.
+        assert total_convs == 3
+
+    def test_groups_sorted_newest_first(self, seeded_collect_env):
+        """Conv B's user message (T0+2d) is more recent than Conv A's
+        last (T0+1d), so B sorts before A."""
+        config = seeded_collect_env
+        groups, _, _ = collect_messages(
+            config,
+            since=T0 - timedelta(days=1),
+            until=T0 + timedelta(days=5),
+            source=None,
+            repo=None,
+            label=None,
+            include_subs=False,
+            limit=None,
+            offset=0,
+        )
+
+        ids = [g.conv.id.replace("-", "") for g in groups]
+        assert ids == [ID_B, ID_A]
+
+    def test_no_db_returns_empty(self, tmp_path, monkeypatch):
+        """No DB file → empty result (the CLI prints the hint)."""
+        monkeypatch.setenv("OHTV_DIR", str(tmp_path / "nodb"))
+        monkeypatch.setenv("OPENHANDS_BASE_DIR", str(tmp_path / "oh"))
+        from ohtv.config import Config
+
+        groups, total_convs, total_msgs = collect_messages(
+            Config.from_env(),
+            since=T0,
+            until=T0 + timedelta(days=1),
+            source=None,
+            repo=None,
+            label=None,
+            include_subs=False,
+            limit=10,
+            offset=0,
+        )
+        assert groups == []
+        assert total_convs == 0
+        assert total_msgs == 0
+
+
+# ===========================================================================
+# 4. Dataclass smoke — make sure UserMessage / ConversationMessages
+#    are constructible with the documented shape.
+# ===========================================================================
+
+
+class TestDataclasses:
+    def test_user_message_fields(self):
+        msg = UserMessage(
+            conv_id=ID_A,
+            conv_title="Title",
+            conv_created_at=T0,
+            source="cloud",
+            event_count=5,
+            timestamp=T0,
+            text="hello",
+        )
+        assert msg.conv_id == ID_A
+        assert msg.text == "hello"
+
+    def test_conversation_messages_defaults(self):
+        conv = _conv_info(ID_A, created_at=T0)
+        cm = ConversationMessages(conv=conv)
+        assert cm.conv is conv
+        assert cm.messages == []

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "ohtv"
-version = "0.28.0"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Implements Issue #181 — a new top-level `ohtv messages` command that lists every user message within a date range, grouped by conversation, newest first. Complements `ohtv ask` (semantic RAG) and `ohtv search` (FTS5) when you only remember roughly *when* you said something.

Fixes #181

## Scope

One new top-level command (`messages`), plus a new sibling module `src/ohtv/messages.py`. No changes to `ConversationStore`, `exporter.py`, migrations, or any other existing module. No new external dependencies — pure Click + Rich + existing ohtv internals.

## Dependency on #180

This work strictly depends on PR #182 (Issue #180, `--event-dates`), which **merged at `9cdbbe2`**. The `ohtv messages` command calls `ConversationStore.list_by_event_date_range(...)` directly — the single SQL owner of the engagement-overlap WHERE clause per AGENTS.md item #35. **No parallel SQL implementation** — we extend the same predicate rather than duplicating it.

## Module Layout (per technical-approach comment)

```
src/ohtv/messages.py
    UserMessage           dataclass
    ConversationMessages  dataclass
    extract_user_messages(conv, conv_dir, since, until)
    collect_messages(config, *, since, until, source, repo,
                     label, include_subs, limit, offset)
    truncate_text(text, max_chars=500)
    collapse_to_single_line(text)
```

CLI handler + three render helpers (`_render_messages_text`, `_render_messages_json`, `_render_messages_raw`) live in `cli.py` so they reuse the existing `console` Rich glue.

## Acceptance Criteria Coverage

| AC | Status | Notes |
|---|---|---|
| `ohtv messages --since 7d` shows user messages from last 7 days, grouped by conversation, with header per group | ✅ | `text` renderer prints rule-line header + indented messages |
| Standard date shortcuts (`--day`, `--day N`, `--week`, `--week N`, `--since`, `--until`) | ✅ | Reuses `_parse_date_filters` verbatim |
| Date filter uses **event timestamps**, not `conversations.created_at` | ✅ | Calls `list_by_event_date_range` (the #180 SQL owner) — event-time is the ONLY mode (see #181 "Out of Scope") |
| Default pagination: 10 convs; `-n N` overrides; `--all` / `-A` removes cap; `--offset K` skips first K | ✅ | Matches `ohtv list` semantics |
| Pagination is **by conversation**, not by message; within a shown conv ALL matching user messages render | ✅ | Verified by `test_pagination_offset_and_limit_by_conversation` + `test_within_conversation_all_messages_render` |
| Conv-level filters compose: `--source`, `--repo`, `--label`, `--include-sub-conversations` | ✅ | Source goes to the SQL; repo/label via existing `_filter_by_repo` / `_filter_by_label`; sub-conv flag matches #127 |
| Output formats: `text` (default), `json` (`total_conversations` / `total_messages` / `offset` / `limit` / `conversations` shape), `raw` (tab-separated one-per-line) | ✅ | All three implemented; JSON shape matches issue verbatim |
| `-1` shorthand for `--format raw` | ✅ | Mirrors `ohtv refs -1`; tested by `test_dash_one_aliases_raw` |
| Long messages truncate to 500 chars + `…` in `text` mode; `--full` shows complete text; `json` / `raw` always full | ✅ | `truncate_text` / `TEXT_TRUNCATION_CHARS` constant; tested by `TestTruncation` |
| Empty result set: `No user messages in range.` + dim engagement-stage hint, exit 0 | ✅ | Hint mentions `ohtv db process engagement` / `ohtv sync` |
| `text`-mode header uses rich styling matching `ohtv list` / `ohtv show` | ✅ | Dim rule lines, cyan conv id + title |
| Same `--include-sub-conversations` plumbing as `ohtv list` (#127); default OFF means only root conversations contribute | ✅ | Forwards directly to `list_by_event_date_range(include_subs=...)`; verified by `test_default_excludes_subs` |

## Output Format Examples

**`text` (default)**:
```
─────────────────────────────────────────────────────────────────
Conversation: a1b2c3d4 — "Implement Authentication Flow"
Created: 2026-05-22 10:15 UTC | Events: 47

[2026-05-22 10:15:03] Can you help me implement OAuth2 authentication...

─────────────────────────────────────────────────────────────────
Showing 2 of 15 conversations (6 messages) | Next: --offset 2
```

**`json` (`-F json`)**:
```json
{
  "total_conversations": 15,
  "total_messages": 38,
  "offset": 0,
  "limit": 10,
  "conversations": [
    {
      "id": "a1b2c3d4...",
      "title": "Implement Authentication Flow",
      "created_at": "2026-05-22T10:15:00Z",
      "source": "cloud",
      "event_count": 47,
      "messages": [
        {"timestamp": "2026-05-22T10:15:03Z", "text": "..."}
      ]
    }
  ]
}
```

**`raw` (`-1` / `-F raw`)**:
```
a1b2c3d4	2026-05-22T10:15:03Z	Can you help me implement OAuth2...
a1b2c3d4	2026-05-22T10:32:15Z	Actually, let us also add email/password as a fallback option.
```

## Manual Smoke Results

```bash
$ uv run ohtv messages --help          # Renders full flag table
$ uv run ohtv messages -D 7 -F json    # {"total_conversations": 0, ...} on empty DB
$ uv run ohtv messages -D 7            # "No user messages in range." + hint
$ uv run ohtv messages -D 7 -1         # (empty — designed for pipelines)
```

## Tests

* **`tests/unit/test_messages.py`** — 27 pure-Python tests covering message extraction (source/kind filter, half-open `since`/`until`, malformed JSON tolerance, multi-part `content`, string-content fallback, timestamp sort, missing timestamps, aware-vs-naive coercion), truncation helpers, single-line collapse, and `collect_messages` end-to-end (DB candidate + FS event load, drops convs with zero in-range user messages, sorts newest-first, no-DB returns empty).
* **`tests/unit/test_cli_messages.py`** — 19 CliRunner tests covering format dispatch, `-1` alias, pagination footer (`Next: --offset N`), `--full` truncation toggle, JSON shape, raw line count, source filter, empty-result hint, and `--include-sub-conversations` plumbing.
* **No mocks of `list_by_event_date_range`** — both test files seed a real SQLite DB via `get_ready_connection()` so we hit the production SQL path. Pattern lifted from `tests/unit/test_cli_event_dates_filter.py` (#180's test seam).

Full suite: **2660 passed, 2 skipped, 3 xfailed** (2614 baseline + 46 new). Ruff: no new warnings (cli.py error count unchanged at 73; new modules clean).

## Out of Scope (per #181)

* Agent message listing (use `ohtv show -a`).
* Full-text search within listed messages (that's `ohtv search` / `grep`).
* Pre-aggregated message index (events loaded lazily; bounded by `offset + limit` conversations).
* README.md / docs updates — handled by the docs worker after CI is green and `gh pr ready`.

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b68bb0de-9043-4480-abfc-f8914363b57f)